### PR TITLE
Storage:  Upload an asset!

### DIFF
--- a/server/db/api/Asset.ts
+++ b/server/db/api/Asset.ts
@@ -11,7 +11,7 @@ export class Asset extends DBC.DBObject<AssetBase> implements AssetBase, SystemO
     idAssetGroup!: number | null;
     idVAssetType!: number;
     idSystemObject!: number | null;
-    StorageKey!: string;
+    StorageKey!: string | null;
 
     private idAssetGroupOrig!: number | null;
     private idSystemObjectOrig!: number | null;

--- a/server/db/prisma/schema.prisma
+++ b/server/db/prisma/schema.prisma
@@ -92,7 +92,7 @@ model Asset {
   idAssetGroup                                    Int?
   idVAssetType                                    Int
   idSystemObject                                  Int?
-  StorageKey                                      String              @unique
+  StorageKey                                      String?             @unique
   AssetGroup                                      AssetGroup?         @relation(fields: [idAssetGroup], references: [idAssetGroup])
   SystemObject_Asset_idSystemObjectToSystemObject SystemObject?       @relation("Asset_idSystemObjectToSystemObject", fields: [idSystemObject], references: [idSystemObject])
   Vocabulary                                      Vocabulary          @relation(fields: [idVAssetType], references: [idVocabulary])

--- a/server/db/sql/scripts/Packrat.SCHEMA.sql
+++ b/server/db/sql/scripts/Packrat.SCHEMA.sql
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS `Asset` (
   `idAssetGroup` int(11) DEFAULT NULL,
   `idVAssetType` int(11) NOT NULL,
   `idSystemObject` int(11) DEFAULT NULL,
-  `StorageKey` varchar(512) NOT NULL UNIQUE,
+  `StorageKey` varchar(512) NULL UNIQUE,
   PRIMARY KEY (`idAsset`),
   KEY `Asset_idAssetGroup` (`idAssetGroup`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -49,7 +49,7 @@ type Asset {
   FilePath: String!
   idAssetGroup: Int
   idSystemObject: Int
-  StorageKey: String!
+  StorageKey: String
   AssetGroup: AssetGroup
   SystemObjectSource: SystemObject
   AssetVersion: [AssetVersion]

--- a/server/graphql/schema/asset/resolvers/mutations/uploadAsset.ts
+++ b/server/graphql/schema/asset/resolvers/mutations/uploadAsset.ts
@@ -1,7 +1,10 @@
-import { MutationUploadAssetArgs, UploadAssetResult, UploadStatus } from '../../../../../types/graphql';
+import { ReadStream } from 'fs';
+import { MutationUploadAssetArgs, UploadAssetResult, UploadStatus /*, AssetType */ } from '../../../../../types/graphql';
 import { Parent } from '../../../../../types/resolvers';
-import { ReadStream, createWriteStream, existsSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import * as STORE from '../../../../../storage/interface';
+import * as LOG from '../../../../../utils/logger';
+import * as CACHE from '../../../../../cache';
+import * as DBAPI from '../../../../../db';
 
 interface ApolloFile {
     filename: string;
@@ -11,34 +14,65 @@ interface ApolloFile {
 }
 
 export default async function uploadAsset(_: Parent, args: MutationUploadAssetArgs): Promise<UploadAssetResult | void> {
-    const { filename, createReadStream }: ApolloFile = await args.file;
-
-    const fileStream = createReadStream();
-
-    const path = join('uploads/');
-
-    if (!existsSync(path)) {
-        mkdirSync(path, { recursive: true });
+    const storage: STORE.IStorage | null = await STORE.StorageFactory.getInstance(); /* istanbul ignore next */
+    if (!storage) {
+        LOG.logger.error('uploadAsset unable to retrieve Storage Implementation from StorageFactory.getInstance()');
+        return { status: UploadStatus.Failed };
     }
 
-    const stream = fileStream.pipe(createWriteStream(`${path}/${filename}`));
+    const WSResult: STORE.WriteStreamResult = await storage.writeStream();
+    if (WSResult.error || !WSResult.writeStream || !WSResult.storageKey) {
+        LOG.logger.error(`uploadAsset unable to retrieve IStorage.writeStream(): ${WSResult.error}`);
+        return { status: UploadStatus.Failed };
+    }
+    const { writeStream, storageKey } = WSResult;
+    // const type: AssetType = args.type; // TODO: this AssetType needs to be a Vocabulary.idVocabulary, or something that can be transformed into such an ID
+    const vocabulary: DBAPI.Vocabulary | undefined = await CACHE.VocabularyCache.vocabularyByEnum(CACHE.eVocabularyID.eAssetAssetTypeOther);
+    if (!vocabulary) {
+        LOG.logger.error('uploadAsset unable to retrieve asset type vocabulary');
+        return { status: UploadStatus.Failed };
+    }
 
-    return new Promise(resolve => {
-        fileStream.on('error', () => {
-            stream.emit('error');
-        });
+    try {
+        const { filename, createReadStream }: ApolloFile = await args.file;
+        const fileStream = createReadStream();
+        const stream = fileStream.pipe(writeStream);
 
-        stream.on('finish', () => {
-            resolve({ status: UploadStatus.Complete });
-        });
+        return new Promise(resolve => {
+            fileStream.on('error', () => {
+                stream.emit('error');
+            });
 
-        stream.on('error', () => {
-            resolve({ status: UploadStatus.Failed });
-        });
+            stream.on('finish', async () => {
+                const ASCNAI: STORE.AssetStorageCommitNewAssetInput = {
+                    storageKey,
+                    storageHash: null,
+                    FileName: filename,
+                    FilePath: '',
+                    idAssetGroup: 0,
+                    idVAssetType: vocabulary.idVocabulary, // TODO: replace with VocabularyID for this assettype, per above TODO item
+                    idUserCreator: 1, // TODO: replace with user ID
+                    DateCreated: new Date()
+                };
 
-        stream.on('close', () => {
-            stream.close();
-            // TODO: create asset + asset version
+                const commitResult: STORE.AssetStorageResult = await STORE.AssetStorageAdapter.commitNewAsset(ASCNAI);
+                if (!commitResult.success) {
+                    LOG.logger.error(`uploadAsset AssetStorageAdapter.commitNewAsset() failed: ${commitResult.error}`);
+                    resolve({ status: UploadStatus.Failed });
+                }
+                // commitResult.asset; commitResult.assetVersion; <-- These have been created
+                resolve({ status: UploadStatus.Complete });
+            });
+
+            stream.on('error', async () => {
+                await storage.discardWriteStream({ storageKey });
+                resolve({ status: UploadStatus.Failed });
+            });
+
+            // stream.on('close', async () => { });
         });
-    });
+    } catch (error) {
+        LOG.logger.error('uploadAsset', error);
+        return { status: UploadStatus.Failed };
+    }
 }

--- a/server/graphql/schema/asset/types.graphql
+++ b/server/graphql/schema/asset/types.graphql
@@ -6,7 +6,7 @@ type Asset {
     FilePath: String!
     idAssetGroup: Int
     idSystemObject: Int
-    StorageKey: String!
+    StorageKey: String
     AssetGroup: AssetGroup
     SystemObjectSource: SystemObject
     AssetVersion: [AssetVersion]

--- a/server/storage/impl/LocalStorage/LocalStorage.ts
+++ b/server/storage/impl/LocalStorage/LocalStorage.ts
@@ -114,6 +114,11 @@ export class LocalStorage implements STORE.IStorage {
             error: ''
         };
 
+        if (CommitWriteStreamInput.storageKey.includes('..') || CommitWriteStreamInput.storageKey.includes(':')) {
+            retValue.error = 'Invalid storagekey';
+            return retValue;
+        }
+
         // Compute hash
         const filePath: string = path.join(this.ocflRoot.computeLocationStagingRoot(), CommitWriteStreamInput.storageKey);
         const hashResults: H.HashResults = await H.Helpers.computeHashFromFile(filePath, ST.OCFLDigestAlgorithm);
@@ -143,6 +148,13 @@ export class LocalStorage implements STORE.IStorage {
         retValue.storageHash = hashResults.hash;
         retValue.storageSize = statResults.stat.size;
         return retValue;
+    }
+
+    async discardWriteStream(DiscardWriteStreamInput: STORE.DiscardWriteStreamInput): Promise<STORE.DiscardWriteStreamResult> {
+        if (DiscardWriteStreamInput.storageKey.includes('..') || DiscardWriteStreamInput.storageKey.includes(':'))
+            return { success: false, error: 'Invalid storagekey' };
+        const filePath: string = path.join(this.ocflRoot.computeLocationStagingRoot(), DiscardWriteStreamInput.storageKey);
+        return H.Helpers.removeFile(filePath);
     }
 
     async promoteStagedAsset(promoteStagedAssetInput: STORE.PromoteStagedAssetInput): Promise<STORE.PromoteStagedAssetResult> {

--- a/server/storage/interface/IStorage.ts
+++ b/server/storage/interface/IStorage.ts
@@ -39,6 +39,15 @@ export type CommitWriteStreamResult = {
     error: string
 };
 
+export type DiscardWriteStreamInput = {
+    storageKey: string,
+};
+
+export type DiscardWriteStreamResult = {
+    success: boolean,
+    error: string
+};
+
 export type PromoteStagedAssetInput = {
     storageKeyStaged: string,
     storageKeyFinal: string,
@@ -133,6 +142,13 @@ export interface IStorage {
      * maintained by closeWriteStream(), and updated by promoteStagedAsset().
      */
     commitWriteStream(commitWriteStreamInput: CommitWriteStreamInput): Promise<CommitWriteStreamResult>;
+
+    /**
+     * Informs the storage system that the client is discarding the streamed input, and the storage system should clean it up.
+     * @param discardWriteStreamInput Includes storage key, the opaque storage identifier created by writeStream(),
+     * maintained by closeWriteStream(), and updated by promoteStagedAsset().
+     */
+    discardWriteStream(discardWriteStreamInput: DiscardWriteStreamInput): Promise<DiscardWriteStreamResult>;
 
     /**
      * Promotes a staged file into the repository.  This should be called after commitWriteStream(),

--- a/server/tests/db/dbcreation.test.ts
+++ b/server/tests/db/dbcreation.test.ts
@@ -1671,7 +1671,7 @@ describe('DB Fetch By ID Test Suite', () => {
 
     test('DB Fetch Asset: Asset.fetchByStorageKey', async () => {
         let assetFetch: DBAPI.Asset | null = null;
-        if (assetThumbnail) {
+        if (assetThumbnail && assetThumbnail.StorageKey) {
             assetFetch = await DBAPI.Asset.fetchByStorageKey(assetThumbnail.StorageKey);
             if (assetFetch)
                 expect(assetFetch).toEqual(assetThumbnail);

--- a/server/tests/storage/impl/LocalStorage/OCFL.test.ts
+++ b/server/tests/storage/impl/LocalStorage/OCFL.test.ts
@@ -263,7 +263,7 @@ describe('OCFL Object', () => {
     });
 });
 
-describe('OCFL Teardown', async () => {
+describe('OCFL Teardown', () => {
     // Destructive test -- leave until end!
     test('OCFL OCFLRoot.validate', async () => {
         let results: H.IOResults;

--- a/server/tests/storage/interface/AssetStorageAdapter.test.ts
+++ b/server/tests/storage/interface/AssetStorageAdapter.test.ts
@@ -161,19 +161,25 @@ async function testCommitNewAsset(TestCase: AssetStorageAdapterTestCase | null, 
     expect(storageHash).toBeTruthy();
 
     // Use STORE.AssetStorageAdapter.commitNewAsset();
-    const CWSI: STORE.CommitWriteStreamInput = {
+    const ASCNAI: STORE.AssetStorageCommitNewAssetInput = {
         storageKey: TestCase.assetVersion.StorageKeyStaging,
-        storageHash
+        storageHash,
+        FileName: TestCase.asset.FileName,
+        FilePath: TestCase.asset.FilePath,
+        idAssetGroup: TestCase.asset.idAssetGroup,
+        idVAssetType: TestCase.asset.idVAssetType,
+        idUserCreator: TestCase.assetVersion.idUserCreator,
+        DateCreated: TestCase.assetVersion.DateCreated
     };
 
     let ASR: STORE.AssetStorageResult;
     if (newAsset) {
         LOG.logger.info(`AssetStorageAdaterTest AssetStorageAdapter.commitNewAsset ${TestCase.asset.FileName}`);
-        ASR = await STORE.AssetStorageAdapter.commitNewAsset(CWSI, TestCase.asset.FileName, TestCase.asset.FilePath,
-            TestCase.asset.idAssetGroup, TestCase.asset.idVAssetType, TestCase.assetVersion.idUserCreator, TestCase.assetVersion.DateCreated);
+        ASR = await STORE.AssetStorageAdapter.commitNewAsset(ASCNAI);
     } else {
         LOG.logger.info(`AssetStorageAdaterTest AssetStorageAdapter.commitNewAssetVersion ${TestCase.asset.FileName}`);
-        ASR = await STORE.AssetStorageAdapter.commitNewAssetVersion(CWSI, TestCase.asset, TestCase.assetVersion.idUserCreator, TestCase.assetVersion.DateCreated);
+        ASR = await STORE.AssetStorageAdapter.commitNewAssetVersion({ storageKey: TestCase.assetVersion.StorageKeyStaging, storageHash },
+            TestCase.asset, TestCase.assetVersion.idUserCreator, TestCase.assetVersion.DateCreated);
     }
     expect(ASR.success).toBeTruthy();
     if (!ASR.success) {
@@ -332,14 +338,19 @@ async function testReinstateAsset(TestCase: AssetStorageAdapterTestCase, version
 }
 
 async function testCommitNewAssetFailure(TestCase: AssetStorageAdapterTestCase): Promise<boolean> {
-    const CWSI: STORE.CommitWriteStreamInput = {
+    const ASCNAI: STORE.AssetStorageCommitNewAssetInput = {
         storageKey: H.Helpers.randomSlug(),
-        storageHash: H.Helpers.randomSlug()
+        storageHash: H.Helpers.randomSlug(),
+        FileName: TestCase.asset.FileName,
+        FilePath: TestCase.asset.FilePath,
+        idAssetGroup: TestCase.asset.idAssetGroup,
+        idVAssetType: TestCase.asset.idVAssetType,
+        idUserCreator: TestCase.assetVersion.idUserCreator,
+        DateCreated: TestCase.assetVersion.DateCreated,
     };
 
     LOG.logger.info('AssetStorageAdaterTest AssetStorageAdapter.commitNewAsset Failure Expected');
-    const ASR: STORE.AssetStorageResult = await STORE.AssetStorageAdapter.commitNewAsset(CWSI, TestCase.asset.FileName, TestCase.asset.FilePath,
-        TestCase.asset.idAssetGroup, TestCase.asset.idVAssetType, TestCase.assetVersion.idUserCreator, TestCase.assetVersion.DateCreated);
+    const ASR: STORE.AssetStorageResult = await STORE.AssetStorageAdapter.commitNewAsset(ASCNAI);
     expect(ASR.success).toBeFalsy();
     return !ASR.success;
 }

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -67,7 +67,7 @@ export type Asset = {
     FilePath: Scalars['String'];
     idAssetGroup?: Maybe<Scalars['Int']>;
     idSystemObject?: Maybe<Scalars['Int']>;
-    StorageKey: Scalars['String'];
+    StorageKey?: Maybe<Scalars['String']>;
     AssetGroup?: Maybe<AssetGroup>;
     SystemObjectSource?: Maybe<SystemObject>;
     AssetVersion?: Maybe<Array<Maybe<AssetVersion>>>;


### PR DESCRIPTION
* Hooked IStorage and AssetStorageAdapter into graphQL mutation uploadAsset()
* Added IStorage.discardWriteStream() and LocalStorage.discardWriteStream(), to handle upload errors and the need to clean up partially streamed files
* Modified Asset schema to allow for null StorageKey's -- this will occur for uploaded but not ingested assets
* Added guards against maliciously modified staging storage keys

TODOs added:
1. Need to get the asset type for the upload; need this in a format that can be transformed into a DBAPI.Vocabulary.idVocabulary
2. Need to get and use the DBAPI.User.idUser for the logged in user that is performing the upload

You'll need to drop and recreate your DB to consume this change.