### PR TITLE
Pre-demo bug fixes:

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,8 @@ events {
 }
 
 http {
+  client_max_body_size 10240m;
+    
   upstream server {
     server packrat-server:4000;
   }

--- a/server/utils/parser/bulkIngestReader.ts
+++ b/server/utils/parser/bulkIngestReader.ts
@@ -118,7 +118,7 @@ export class BulkIngestReader {
             return null;
         const projectList1: DBAPI.Project[] | null = await DBAPI.Project.fetchDerivedFromSubjectsUnits([ingestMetadata.idSubject]) || /* istanbul ignore next */ [];
         const projectList2: DBAPI.Project[] | null = await DBAPI.Project.fetchMasterFromSubjects([ingestMetadata.idSubject]) || /* istanbul ignore next */ [];
-        return projectList1.concat(projectList2);
+        return [...new Set([...projectList1, ...projectList2])]; // removes duplicates
     }
 
     private async computeCaptureDataPhotos(fileStream: NodeJS.ReadableStream): Promise<H.IOResults> {


### PR DESCRIPTION
1. Set nginx max client body to 10GB, to allow for very large uploads through the proxy
2. Modified ingestion handling of unit data.  Lookup units from both Packrat units and edan units.  This allows "NMNH" to match, which isn't actually present in EDAN units.
3. Mark bulk ingest assets as ingested when ingested, to remove them from the to-be-ingested list.
4. Change the whay projects are computed to avoid adding projects twice ... though this doesn't fix the UI issue of displaying projects multiple times.
5. Prepare to override the asset name used when creating the intermediate assets after upload of a bulk ingestion zip ... but this isn't quite ready yet (causing test failures)