### PR TITLE
modified overflow to be hidden so that there is no scrolling behavior

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,7 +3,7 @@ module.exports = {
     printWidth: 180,
     tabWidth: 4,
     trailingComma: 'none',
-    jsxBracketSameLine: true,
+    jsxBracketSameLine: false,
     jsxSingleQuote: true,
     arrowParens: 'avoid'
 };

--- a/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-max-props-per-line */
+
 /**
  * RepositoryFilterView
  *


### PR DESCRIPTION
A concern about turning off scrolling behavior is what happens when there are so many filter options that the UI isn't able to render all the chips?
I was thinking maybe let the chip container be dynamic in shape but let's discuss that more in person :)