### PR TITLE
revise filter behavior when searching in repository view

### DIFF
--- a/client/src/components/shared/Header.tsx
+++ b/client/src/components/shared/Header.tsx
@@ -92,12 +92,13 @@ function Header(): React.ReactElement {
     const history = useHistory();
     const { pathname } = useLocation();
     const { user, logout } = useUserStore();
-    const [search, updateSearch, getFilterState, initializeTree, resetRepositoryFilter] = useRepositoryStore(state => [
+    const [search, updateSearch, getFilterState, initializeTree, resetRepositoryFilter, updateRepositoryFilter] = useRepositoryStore(state => [
         state.search,
         state.updateSearch,
         state.getFilterState,
         state.initializeTree,
-        state.resetRepositoryFilter
+        state.resetRepositoryFilter,
+        state.updateRepositoryFilter
     ]);
 
     const onLogout = async (): Promise<void> => {
@@ -120,7 +121,10 @@ function Header(): React.ReactElement {
     // Specific to search while in repository view
     const updateRepositorySearch = () => {
         const filterState = getFilterState();
-        const repositoryURL = generateRepositoryUrl(filterState);
+        filterState.repositoryRootType = [];
+        updateRepositoryFilter(filterState);
+        const updatedFilterState = getFilterState();
+        const repositoryURL = generateRepositoryUrl(updatedFilterState);
         const route: string = resolveRoute(HOME_ROUTES.REPOSITORY);
         history.push(route + repositoryURL);
         initializeTree();

--- a/client/src/store/repository.ts
+++ b/client/src/store/repository.ts
@@ -152,7 +152,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
     },
     resetRepositoryFilter: (): void => {
         const stateValues = {
-            repositoryRootType: [eSystemObjectType.eUnit],
+            repositoryRootType: [],
             objectsToDisplay: [],
             metadataToDisplay: [eMetadata.eHierarchyUnit, eMetadata.eHierarchySubject, eMetadata.eHierarchyItem],
             units: [],


### PR DESCRIPTION
This new change makes it so that:
1) keyword searches done in repository view will now deselect all Repository Root Type
2) have no filter values selected for Repository Root Type by default