### PR TITLE
Fix for DPO3DPKRT-373:  only load units with attached subjects into Solr

### DIFF
--- a/server/db/api/Unit.ts
+++ b/server/db/api/Unit.ts
@@ -85,6 +85,19 @@ export class Unit extends DBC.DBObject<UnitBase> implements UnitBase, SystemObje
         }
     }
 
+    static async fetchAllWithSubjects(): Promise<Unit[] | null> {
+        try {
+            return DBC.CopyArray<UnitBase, Unit>(
+                await DBC.DBConnection.prisma.$queryRaw<Unit[]>`
+                SELECT DISTINCT U.*
+                FROM Unit AS U
+                JOIN Subject AS S ON (U.idUnit = S.idUnit)`, Unit);
+        } catch (error) /* istanbul ignore next */ {
+            LOG.logger.error('DBAPI.Unit.fetchAllWithSubjects', error);
+            return null;
+        }
+    }
+
     /**
      * Computes the array of units that are connected to any of the specified projects.
      * Units  are connected to system objects; we examine those system objects which are in a *master* relationship

--- a/server/db/api/composite/ObjectGraphDatabase.ts
+++ b/server/db/api/composite/ObjectGraphDatabase.ts
@@ -95,7 +95,7 @@ export class ObjectGraphDatabase {
     private async computeGraphDataFromUnits(): Promise<boolean> {
         LOG.logger.info('ObjectGraphDatabase.computeGraphDataFromUnits');
         // iterate across all Units; for each, compute ObjectGraph; extract ObjectGraph data into a "database"
-        const units: Unit[] | null = await Unit.fetchAll(); /* istanbul ignore if */
+        const units: Unit[] | null = await Unit.fetchAllWithSubjects(); /* istanbul ignore if */
         if (!units)
             return false;
         for (const unit of units) {

--- a/server/tests/db/dbcreation.test.ts
+++ b/server/tests/db/dbcreation.test.ts
@@ -4482,6 +4482,16 @@ describe('DB Fetch Special Test Suite', () => {
         }
     });
 
+    test('DB Fetch Special: Unit.fetchAllWithSubjects', async () => {
+        const unitFetch: DBAPI.Unit[] | null = await DBAPI.Unit.fetchAllWithSubjects();
+        expect(unitFetch).toBeTruthy();
+        if (unitFetch) {
+            expect(unitFetch.length).toBeGreaterThan(0);
+            if (unit && unit2)
+                expect(unitFetch).toEqual(expect.arrayContaining([unit, unit2]));
+        }
+    });
+
     test('DB Fetch Special: UnitEdan.fetchFromUnit', async () => {
         let unitEdanFetch: DBAPI.UnitEdan[] | null = null;
         if (unit) {


### PR DESCRIPTION
DBAPI:
* Added Unit.fetchAllWithSubjects()

Solr:
* Use Unit.fetchAllWithSubjects() to populate Solr index