### PR TITLE
SystemObjectXref.deleteIfAllowed() and Identifier.delete()

### DIFF
--- a/server/db/api/Identifier.ts
+++ b/server/db/api/Identifier.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { Identifier as IdentifierBase } from '@prisma/client';
+import { Subject } from './Subject';
 import * as DBC from '../connection';
 import * as LOG from '../../utils/logger';
 
@@ -49,6 +50,25 @@ export class Identifier extends DBC.DBObject<IdentifierBase> implements Identifi
             return retValue;
         } catch (error) /* istanbul ignore next */ {
             LOG.error('DBAPI.Identifier.update', LOG.LS.eDB, error);
+            return false;
+        }
+    }
+
+    /** Don't call this directly; instead, let DBObject.delete() call this.
+     * Code needing to delete a record should call this.delete(); */
+    protected async deleteWorker(): Promise<boolean> {
+        try {
+            // LOG.info(`Identifier.deleteWorker ${JSON.stringify(this)}`, LOG.LS.eDB);
+            // First, remove this identifier from subject.idIdentifierPreferred, for any such subjects that reference it
+            const { idIdentifier } = this; /* istanbul ignore next */
+            if (!await Subject.clearPreferredIdentifier(idIdentifier))
+                return false;
+
+            return await DBC.DBConnection.prisma.identifier.delete({
+                where: { idIdentifier, },
+            }) ? true : /* istanbul ignore next */ false;
+        } catch (error) /* istanbul ignore next */ {
+            LOG.error('DBAPI.Identifier.delete', LOG.LS.eDB, error);
             return false;
         }
     }

--- a/server/db/api/SystemObjectXref.ts
+++ b/server/db/api/SystemObjectXref.ts
@@ -54,11 +54,10 @@ export class SystemObjectXref extends DBC.DBObject<SystemObjectXrefBase> impleme
      * Code needing to delete a record should call this.delete(); */
     protected async deleteWorker(): Promise<boolean> {
         try {
-            //LOG.info(`SystemObjectXref.deleteWorker ${JSON.stringify(this)}`, LOG.LS.eDB);
+            // LOG.info(`SystemObjectXref.deleteWorker ${JSON.stringify(this)}`, LOG.LS.eDB);
             const { idSystemObjectXref } = this;
             return await DBC.DBConnection.prisma.systemObjectXref.delete({
                 where: { idSystemObjectXref, },
-                // select: { idSystemObjectXref: true, },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
             LOG.error('DBAPI.SystemObjectXref.delete', LOG.LS.eDB, error);


### PR DESCRIPTION
DBAPI:
* Implemented SystemObjectXref.deleteWorker() and deleteIfAllowed(). For the latter, Xref records can be removed as long as the record in question is not the final subject for an item (in a master-derived relationship)
* Implemented Subject.clearPreferredIdentifiers, which computes the subjects using the specified identifier, and then updates them one-by-one (in order for auditing of changes).
* Implemented Identifier.deleteWorker() so that identifiers can be deleted. This method calls Subject.clearPreferredIdentifiers().  Use Identifier.delete() to delete a record.