### PR TITLE
OPS: Map container storage root to mounted storage; enable cross-volume "moves"

### DIFF
--- a/conf/docker/docker-compose.deploy.yml
+++ b/conf/docker/docker-compose.deploy.yml
@@ -57,6 +57,8 @@ services:
             - PACKRAT_LDAP_CN=$PACKRAT_LDAP_CN
             - PACKRAT_LDAP_OU=$PACKRAT_LDAP_OU
             - PACKRAT_LDAP_DC=$PACKRAT_LDAP_DC
+        volumes:
+            - $PACKRAT_OCFL_STORAGE_ROOT:$PACKRAT_OCFL_STORAGE_ROOT
 
     packrat-server-prod:
         container_name: packrat-server-prod

--- a/server/storage/impl/LocalStorage/OCFLObject.ts
+++ b/server/storage/impl/LocalStorage/OCFLObject.ts
@@ -19,7 +19,15 @@ export type OCFLPathAndHash = {
     hash: string;
 };
 
+enum eMoveFileType {
+    eUnknown,
+    eMove,
+    eCopyThenDelete,
+}
+
 export class OCFLObject {
+    private static _eMoveFileType: eMoveFileType = eMoveFileType.eUnknown;
+
     private _storageKey: string = '';
     private _createIfMissing: boolean = false;
 
@@ -115,8 +123,8 @@ export class OCFLObject {
                 if (!hashResults.success)
                     return hashResults;     // if we fail to compute the hash, don't move the file below!
 
-                // Move file to new version folder
-                results = await H.Helpers.moveFile(pathOnDisk, destName);
+                // Move file to new version folder.
+                results = await this.safeMoveFile(pathOnDisk, destName);
             } else if (inputStream) {
                 // We need to both compute the hash and stream bytes to the right location
                 const hashResultsPromise = H.Helpers.computeHashFromStream(inputStream, ST.OCFLDigestAlgorithm);
@@ -159,6 +167,34 @@ export class OCFLObject {
         if (!results.success)
             return results;
 
+        return results;
+    }
+
+    private async safeMoveFile(pathOnDisk: string, destName: string): Promise<H.IOResults> {
+        let results: H.IOResults;
+        if (OCFLObject._eMoveFileType == eMoveFileType.eUnknown ||
+            OCFLObject._eMoveFileType == eMoveFileType.eMove) {
+            results = await H.Helpers.moveFile(pathOnDisk, destName);
+            if (results.success) {
+                OCFLObject._eMoveFileType = eMoveFileType.eMove;
+                return results;
+            } else
+                OCFLObject._eMoveFileType = eMoveFileType.eCopyThenDelete; // then continue below
+        }
+
+        // eMoveFileType.eCopyThenDelete:
+        // Avoid using "H.Helpers.moveFile" because this does not work across volumes.
+        results = await H.Helpers.copyFile(pathOnDisk, destName);
+        if (!results.success) {
+            LOG.error(`OCFLObject.safeMoveFile copy not copy ${pathOnDisk} to ${destName}: ${results.error}`, LOG.LS.eSTR);
+            return results;
+        }
+
+        results = await H.Helpers.removeFile(pathOnDisk);
+        if (!results.success) {
+            LOG.error(`OCFLObject.safeMoveFile unable to delete ${pathOnDisk}: ${results.error}`, LOG.LS.eSTR);
+            return results;
+        }
         return results;
     }
 


### PR DESCRIPTION
* For Staging, map storage root in server docker container, so that container writes are propagated to the host OS, and it's notion of shared storage

Storage:
* Add smarts to logic used to move files. Detect if a move fails, and then fall back to a copy followed by a delete.  Record this preferred way of "moving", and just do that for future moves.

We need this to enable cross-volume "moves" from staging storage to repository storage