### PR TITLE
Attempted staging reliability fix

### DIFF
--- a/server/auth/impl/LDAPAuth.ts
+++ b/server/auth/impl/LDAPAuth.ts
@@ -20,7 +20,7 @@ class LDAPAuth implements IAuth {
         });
 
         // this is needed to avoid nodejs crash of server when the LDAP connection is unavailable
-        client.on('error', error=> { LOG.error('LDAPAuth.verifyUser', error, LOG.LS.eAUTH); });
+        client.on('error', error => { LOG.error('LDAPAuth.verifyUser', LOG.LS.eAUTH, error); });
 
         // Step 2: Bind Packrat Service Account
         const res: VerifyUserResult = await this.bindService(client, ldapConfig);

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -31,7 +31,7 @@ export function info(message: string, eLogSection: LS): void {
 }
 
 export function error(message: string, eLogSection: LS, obj: any | null = null): void {
-    if (obj) {
+    if (obj && typeof obj === 'object' && obj !== null) {
         obj.eLS = eLogSection;
         logger.error(message, obj);
     } else


### PR DESCRIPTION
System:
* Handle error logging performed with invalid input to the logger.  Detect if the item supplied is to error() an object, and if so, append our log section detail.  If not, fall back to default logger that ignores the object.

We need to circle back here with:
* Better handling for non-object inputs
* More robust type definitions for the logger section so that the typescript transpiler can enforce proper use of LOG.error
* A global error handler that prevents Node from crashing

LDAP:
* Log errors correctly.  This appears to have revealed the logging bug, above.