### PR TITLE
Service-side Rollback GraphQL mutation

### DIFF
--- a/server/graphql/schema/systemobject/resolvers/mutations/rollbackSystemObjectVersion.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/rollbackSystemObjectVersion.ts
@@ -1,14 +1,25 @@
 import { RollbackSystemObjectVersionResult, MutationRollbackSystemObjectVersionArgs } from '../../../../../types/graphql';
 import { Parent } from '../../../../../types/resolvers';
-// import * as DBAPI from '../../../../../db';
-// import * as LOG from '../../../../../utils/logger';
+import * as DBAPI from '../../../../../db';
+import * as LOG from '../../../../../utils/logger';
 
 export default async function rollbackSystemObjectVersion(_: Parent, args: MutationRollbackSystemObjectVersionArgs): Promise<RollbackSystemObjectVersionResult> {
-    const { input: { idSystemObjectVersion } } = args;
-    const result = { success: false, message: 'Unable to identify idSystemObjectVersion' };
-    console.log('idSystemObjectVersion', idSystemObjectVersion); // use variable to prevent compilation error
+    const { input } = args;
+    const { idSystemObjectVersion } = input;
 
-    // TODO: JON Insert DBAPI code here
+    const SOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetch(idSystemObjectVersion);
+    if (!SOV) {
+        const message: string = `rollbackSystemObjectVersion Unable to load SystemObjectVersion for ${idSystemObjectVersion}`;
+        LOG.error(message, LOG.LS.eGQL);
+        return { success: false, message };
+    }
 
-    return result;
+    const SOVRollback: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.cloneObjectAndXrefs(SOV.idSystemObject, SOV.idSystemObjectVersion);
+    if (!SOVRollback) {
+        const message: string = 'rollbackSystemObjectVersion SystemObjectVersion.cloneObjectAndXrefs failed';
+        LOG.error(message, LOG.LS.eGQL);
+        return { success: false, message };
+    }
+
+    return { success: true, message: '' };
 }


### PR DESCRIPTION
GraphQL:
* Implemented rollbackSystemObjectVersion().  Can't be tested in Packrat until AddVersion() is fully online...