### PR TITLE
Prevent duplicate entries from appearing in Ingestion Subject grid

### DIFF
--- a/server/graphql/schema/unit/resolvers/queries/searchIngestionSubjects.ts
+++ b/server/graphql/schema/unit/resolvers/queries/searchIngestionSubjects.ts
@@ -2,20 +2,37 @@ import { QuerySearchIngestionSubjectsArgs, SearchIngestionSubjectsResult } from 
 import { Parent } from '../../../../../types/resolvers';
 import * as COL from '../../../../../collections/interface/';
 import * as DBAPI from '../../../../../db';
+// import * as LOG from '../../../../../utils/logger';
 
 export default async function searchIngestionSubjects(_: Parent, args: QuerySearchIngestionSubjectsArgs): Promise<SearchIngestionSubjectsResult> {
     const { input } = args;
     const { query, EdanOnly } = input;
 
     const ICollection: COL.ICollection = COL.CollectionFactory.getInstance();
-    let resultsDB: DBAPI.SubjectUnitIdentifier[] | null = EdanOnly ? [] : await DBAPI.SubjectUnitIdentifier.fetch(query, 10);
+    const resultsDB: DBAPI.SubjectUnitIdentifier[] | null = EdanOnly ? [] : await DBAPI.SubjectUnitIdentifier.fetch(query, 10);
     const resultsCOL: COL.CollectionQueryResults | null = await ICollection.queryCollection(query, 10, 0, null);
 
-    if (!resultsDB) resultsDB = [];
+    const results: DBAPI.SubjectUnitIdentifier[] = [];
+    const resultSet: Set<string> = new Set<string>();
+
+    if (resultsDB) {
+        for (const resultDB of resultsDB) {
+            if (resultSet.has(resultDB.IdentifierPublic))
+                continue;
+            // LOG.info(`searchIngestionSubjects ${JSON.stringify(resultDB)}`, LOG.LS.eGQL);
+            resultSet.add(resultDB.IdentifierPublic);
+            results.push(resultDB);
+        }
+    }
 
     if (resultsCOL && resultsCOL.records) {
         for (const record of resultsCOL.records) {
-            resultsDB.push({
+            if (resultSet.has(record.identifierPublic))
+                continue;
+
+            // LOG.info(`searchIngestionSubjects ${JSON.stringify(record)}`, LOG.LS.eGQL);
+            resultSet.add(record.identifierPublic);
+            results.push({
                 idSubject: 0,
                 idSystemObject: 0,
                 SubjectName: record.name,
@@ -25,7 +42,7 @@ export default async function searchIngestionSubjects(_: Parent, args: QuerySear
             });
         }
 
-        return { SubjectUnitIdentifier: resultsDB };
+        return { SubjectUnitIdentifier: results };
     }
 
     return { SubjectUnitIdentifier: [] };


### PR DESCRIPTION
GraphQL:
* Prevent duplicate entries from appearing in the Ingestion subject grid by excluding repeats of public identifiers across DB and EDAN results.