### PR TITLE
applied changes so that models and datasets can have 1 - many item pa…

### DIFF
--- a/client/src/pages/Ingestion/components/Metadata/Model/RelatedObjectsList.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/RelatedObjectsList.tsx
@@ -18,6 +18,7 @@ import { ViewableProps } from '../../../../../types/repository';
 import { getDetailsUrlForObject, getTermForSystemObjectType } from '../../../../../utils/repository';
 import { sharedButtonProps, sharedLabelProps } from '../../../../../utils/shared';
 import { toast } from 'react-toastify';
+import { eSystemObjectType } from '../../../../../types/server';
 
 const useStyles = makeStyles(({ palette }) => ({
     container: {
@@ -59,7 +60,7 @@ interface RelatedObjectsListProps extends ViewableProps {
     onAdd: () => void;
     onRemove?: (id: number) => void;
     currentObject?: number;
-    onRemoveConnection?: (idSystemObjectMaster: number, idSystemObjectDerived: number, type: string, systemObjectType: number) => any;
+    onRemoveConnection?: (idSystemObjectMaster: number, objectTypeMaster: eSystemObjectType, idSystemObjectDerived: number, objectTypeDerived: eSystemObjectType) => any;
     objectType?: number;
     relationshipLanguage?: string;
 }
@@ -128,7 +129,7 @@ interface ItemProps {
     onRemove?: (id: number) => void;
     viewMode?: boolean;
     currentObject?: number;
-    onRemoveConnection?: (idSystemObjectMaster: number, idSystemObjectDerived: number, type: string, systemObjectType: number) => any;
+    onRemoveConnection?: (idSystemObjectMaster: number, objectTypeMaster: eSystemObjectType, idSystemObjectDerived: number, objectTypeDerived: eSystemObjectType) => any;
     type?: RelatedObjectType;
     systemObjectType?: number;
 }
@@ -148,8 +149,8 @@ function Item(props: ItemProps): React.ReactElement {
                 }
             } =
                 type.toString() === 'Source'
-                    ? await onRemoveConnection(idSystemObject, currentObject, type.toString(), systemObjectType)
-                    : await onRemoveConnection(currentObject, idSystemObject, type.toString(), systemObjectType);
+                    ? await onRemoveConnection(idSystemObject, objectType, currentObject, systemObjectType)
+                    : await onRemoveConnection(currentObject, systemObjectType, idSystemObject, objectType);
             if (success) {
                 toast.success(details);
             } else {

--- a/client/src/pages/Repository/hooks/useDetailsView.ts
+++ b/client/src/pages/Repository/hooks/useDetailsView.ts
@@ -113,7 +113,8 @@ export function updateSourceObjects(idSystemObject: number, objectType: number, 
                 PreviouslySelected
             }
         },
-        refetchQueries: ['getSystemObjectDetails', 'getDetailsTabDataForObject']
+        refetchQueries: ['getSystemObjectDetails', 'getDetailsTabDataForObject'],
+        awaitRefetchQueries: true
     });
 }
 
@@ -128,38 +129,23 @@ export function updateDerivedObjects(idSystemObject: number, objectType: number,
                 PreviouslySelected
             }
         },
-        refetchQueries: ['getSystemObjectDetails', 'getDetailsTabDataForObject']
+        refetchQueries: ['getSystemObjectDetails', 'getDetailsTabDataForObject'],
+        awaitRefetchQueries: true
     });
 }
 
-export async function deleteObjectConnection(idSystemObjectMaster: number, idSystemObjectDerived: number, type: string, systemObjectType: number) {
+export async function deleteObjectConnection(idSystemObjectMaster: number, objectTypeMaster: eSystemObjectType, idSystemObjectDerived: number, objectTypeDerived: eSystemObjectType) {
     return await apolloClient.mutate({
         mutation: DeleteObjectConnectionDocument,
         variables: {
             input: {
                 idSystemObjectMaster,
-                idSystemObjectDerived
+                objectTypeMaster,
+                idSystemObjectDerived,
+                objectTypeDerived
             }
         },
-        refetchQueries: [
-            {
-                query: GetSystemObjectDetailsDocument,
-                variables: {
-                    input: {
-                        idSystemObject: type === 'Source' ? idSystemObjectDerived : idSystemObjectMaster
-                    }
-                }
-            },
-            {
-                query: GetDetailsTabDataForObjectDocument,
-                variables: {
-                    input: {
-                        idSystemObject: type === 'Source' ? idSystemObjectDerived : idSystemObjectMaster,
-                        objectType: systemObjectType
-                    }
-                }
-            }
-        ],
+        refetchQueries: ['getSystemObjectDetails', 'getDetailsTabDataForObject'],
         awaitRefetchQueries: true
     });
 }

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -1574,7 +1574,9 @@ export type DeleteObjectConnectionResult = {
 
 export type DeleteObjectConnectionInput = {
   idSystemObjectMaster: Scalars['Int'];
+  objectTypeMaster: Scalars['Int'];
   idSystemObjectDerived: Scalars['Int'];
+  objectTypeDerived: Scalars['Int'];
 };
 
 export type DeleteIdentifierResult = {

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -332,8 +332,8 @@ export function isValidParentChildRelationship(
         -skip on stakeholders for now
         xitem child to only 1 parent project parent
         xitem child to multiple subject parent
-        xCD child to only 1 item parent
-        xmodel child only 1 parent Item
+        xCD child to 1 - many item parent
+        xmodel child to 1 - many parent Item
         xscene child to 1 or more item parent
         xmodel child to 0 - many CD parent
         xCD child to 0 - many CD parent
@@ -364,25 +364,11 @@ export function isValidParentChildRelationship(
             break;
         }
         case eSystemObjectType.eCaptureData: {
-            if (parent === eSystemObjectType.eItem) {
-                if (isAddingSource) {
-                    result = maximumConnections(existingAndNewRelationships, eSystemObjectType.eItem, 1);
-                } else {
-                    result = maximumConnections(existingAndNewRelationships, eSystemObjectType.eItem, 1);
-                }
-            }
 
-            if (parent === eSystemObjectType.eCaptureData) result = true;
+            if (parent === eSystemObjectType.eCaptureData || parent === eSystemObjectType.eItem) result = true;
             break;
         }
         case eSystemObjectType.eModel: {
-            if (parent === eSystemObjectType.eItem) {
-                if (isAddingSource) {
-                    result = maximumConnections(existingAndNewRelationships, eSystemObjectType.eItem, 1);
-                } else {
-                    result = maximumConnections(existingAndNewRelationships, eSystemObjectType.eItem, 1);
-                }
-            }
 
             if (parent === eSystemObjectType.eScene) {
                 if (isAddingSource) {
@@ -392,7 +378,7 @@ export function isValidParentChildRelationship(
                 }
             }
 
-            if (parent === eSystemObjectType.eCaptureData || parent === eSystemObjectType.eModel) result = true;
+            if (parent === eSystemObjectType.eCaptureData || parent === eSystemObjectType.eModel || parent === eSystemObjectType.eItem) result = true;
             break;
         }
         case eSystemObjectType.eScene: {

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -1142,7 +1142,9 @@ type DeleteObjectConnectionResult {
 
 input DeleteObjectConnectionInput {
   idSystemObjectMaster: Int!
+  objectTypeMaster: Int!
   idSystemObjectDerived: Int!
+  objectTypeDerived: Int!
 }
 
 type DeleteIdentifierResult {

--- a/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
+++ b/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
@@ -1381,8 +1381,8 @@ export function isValidParentChildRelationship(parent: DBAPI.eSystemObjectType, 
         -skip on stakeholders for now
         xitem child to only 1 parent project parent
         xitem child to multiple subject parent
-        xCD child to only 1 item parent
-        xmodel child only 1 parent Item
+        xCD child to 1 - many item parent
+        xmodel child to 1 - many parent Item
         xscene child to 1 or more item parent
         xmodel child to 0 - many CD parent
         xCD child to 0 - many CD parent
@@ -1413,26 +1413,10 @@ export function isValidParentChildRelationship(parent: DBAPI.eSystemObjectType, 
             break;
         }
         case DBAPI.eSystemObjectType.eCaptureData: {
-            if (parent === DBAPI.eSystemObjectType.eItem) {
-                if (isAddingSource) {
-                    result = maximumConnections(existingAndNewRelationships, DBAPI.eSystemObjectType.eItem, 2);
-                } else {
-                    result = maximumConnections(existingAndNewRelationships, DBAPI.eSystemObjectType.eItem, 1);
-                }
-            }
-
-            if (parent === DBAPI.eSystemObjectType.eCaptureData) result = true;
+            if (parent === DBAPI.eSystemObjectType.eCaptureData || parent === DBAPI.eSystemObjectType.eItem) result = true;
             break;
         }
         case DBAPI.eSystemObjectType.eModel: {
-            if (parent === DBAPI.eSystemObjectType.eItem) {
-                if (isAddingSource) {
-                    result = maximumConnections(existingAndNewRelationships, DBAPI.eSystemObjectType.eItem, 2);
-                } else {
-                    result = maximumConnections(existingAndNewRelationships, DBAPI.eSystemObjectType.eItem, 1);
-                }
-            }
-
             if (parent === DBAPI.eSystemObjectType.eScene) {
                 if (isAddingSource) {
                     result = maximumConnections(existingAndNewRelationships, DBAPI.eSystemObjectType.eScene, 2);
@@ -1441,7 +1425,7 @@ export function isValidParentChildRelationship(parent: DBAPI.eSystemObjectType, 
                 }
             }
 
-            if (parent === DBAPI.eSystemObjectType.eCaptureData || parent === DBAPI.eSystemObjectType.eModel) result = true;
+            if (parent === DBAPI.eSystemObjectType.eCaptureData || parent === DBAPI.eSystemObjectType.eModel || parent === DBAPI.eSystemObjectType.eItem) result = true;
             break;
         }
         case DBAPI.eSystemObjectType.eScene: {

--- a/server/graphql/schema/systemobject/mutations.graphql
+++ b/server/graphql/schema/systemobject/mutations.graphql
@@ -191,7 +191,9 @@ type DeleteObjectConnectionResult {
 
 input DeleteObjectConnectionInput {
     idSystemObjectMaster: Int!
+    objectTypeMaster: Int!
     idSystemObjectDerived: Int!
+    objectTypeDerived: Int!
 }
 
 type DeleteIdentifierResult {

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -1571,7 +1571,9 @@ export type DeleteObjectConnectionResult = {
 
 export type DeleteObjectConnectionInput = {
   idSystemObjectMaster: Scalars['Int'];
+  objectTypeMaster: Scalars['Int'];
   idSystemObjectDerived: Scalars['Int'];
+  objectTypeDerived: Scalars['Int'];
 };
 
 export type DeleteIdentifierResult = {


### PR DESCRIPTION
This change will address tickets [470](https://jira.si.edu/browse/DPO3DPKRT-470) and [506](https://jira.si.edu/browse/DPO3DPKRT-506) by:
1) Updating the current relationship checker by allowing models and capture data sets to have 1 - multiple parent Items
2) Toasting error messages indicating that final item parent cannot be removed

Also, this ticket made changes that should address existing issues of "Related" tab not refreshing when an object has been added or deleted.
This is related to ticket [414](https://jira.si.edu/browse/DPO3DPKRT-414).