### PR TITLE
Performance Tuning

### DIFF
--- a/server/cache/LicenseCache.ts
+++ b/server/cache/LicenseCache.ts
@@ -73,10 +73,10 @@ export class LicenseCache {
         return this.licenseEnumMap.get(eState);
     }
 
-    private async getLicenseResolverInternal(idSystemObject: number): Promise<DBAPI.LicenseResolver | undefined> {
+    private async getLicenseResolverInternal(idSystemObject: number, OGD?: DBAPI.ObjectGraphDatabase | undefined): Promise<DBAPI.LicenseResolver | undefined> {
         let licenseResolver: DBAPI.LicenseResolver | undefined | null = this.licenseResolverMap.get(idSystemObject);
         if (!licenseResolver) { // cache miss, look it up
-            licenseResolver = await DBAPI.LicenseResolver.fetch(idSystemObject);
+            licenseResolver = await DBAPI.LicenseResolver.fetch(idSystemObject, OGD);
             if (licenseResolver)
                 this.licenseResolverMap.set(idSystemObject, licenseResolver);
             // LOG.info(`LicenseCache.getLicenseResolverInternal(${idSystemObject}) computed ${JSON.stringify(licenseResolver)}`, LOG.LS.eCACHE);
@@ -131,8 +131,9 @@ export class LicenseCache {
         return await (await this.getInstance()).getLicenseByEnumInternal(eState);
     }
 
-    static async getLicenseResolver(idSystemObject: number): Promise<DBAPI.LicenseResolver | undefined> {
-        return await (await this.getInstance()).getLicenseResolverInternal(idSystemObject);
+    /** If passing in OGD, make sure to compute this navigating through the ancestors of idSystemObject */
+    static async getLicenseResolver(idSystemObject: number, OGD?: DBAPI.ObjectGraphDatabase | undefined): Promise<DBAPI.LicenseResolver | undefined> {
+        return await (await this.getInstance()).getLicenseResolverInternal(idSystemObject, OGD);
     }
 
     static async clearAssignment(idSystemObject: number): Promise<boolean> {

--- a/server/db/api/composite/LicenseResolver.ts
+++ b/server/db/api/composite/LicenseResolver.ts
@@ -15,16 +15,18 @@ export class LicenseResolver {
         this.inherited = inherited;
     }
 
-    public static async fetch(idSystemObject: number): Promise<LicenseResolver | null> {
+    public static async fetch(idSystemObject: number, OGD?: ObjectGraphDatabase | undefined): Promise<LicenseResolver | null> {
         const LR: LicenseResolver | null = await LicenseResolver.fetchSpecificLicense(idSystemObject, false);
         if (LR)
             return LR;
 
-        const OGD: ObjectGraphDatabase = new ObjectGraphDatabase();
-        const OG: ObjectGraph = new ObjectGraph(idSystemObject, eObjectGraphMode.eAncestors, 32, OGD); /* istanbul ignore if */
-        if (!await OG.fetch()) {
-            LOG.error(`LicenseResolver unable to fetch object graph for ${idSystemObject}`, LOG.LS.eDB);
-            return null;
+        if (!OGD) {
+            OGD = new ObjectGraphDatabase();
+            const OG: ObjectGraph = new ObjectGraph(idSystemObject, eObjectGraphMode.eAncestors, 32, OGD); /* istanbul ignore if */
+            if (!await OG.fetch()) {
+                LOG.error(`LicenseResolver unable to fetch object graph for ${idSystemObject}`, LOG.LS.eDB);
+                return null;
+            }
         }
 
         return await LicenseResolver.fetchParentsLicense(OGD, idSystemObject, 32, new Map<number, LicenseResolver | null>());

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -11,20 +11,32 @@ import {
 } from '../../../../../types/graphql';
 import { Parent } from '../../../../../types/resolvers';
 import * as LOG from '../../../../../utils/logger';
+import * as H from '../../../../../utils/helpers';
 
 export default async function getSystemObjectDetails(_: Parent, args: QueryGetSystemObjectDetailsArgs): Promise<GetSystemObjectDetailsResult> {
     const { input } = args;
     const { idSystemObject } = input;
+    LOG.info('getSystemObjectDetails 0', LOG.LS.eGQL);
 
     const oID: DBAPI.ObjectIDAndType | undefined = await CACHE.SystemObjectCache.getObjectFromSystem(idSystemObject);
-    const { unit, project, subject, item, objectAncestors } = await getObjectAncestors(idSystemObject);
+    LOG.info('getSystemObjectDetails 1', LOG.LS.eGQL);
+
+    const OGD: DBAPI.ObjectGraphDatabase = new DBAPI.ObjectGraphDatabase();
+    const OG: DBAPI.ObjectGraph = new DBAPI.ObjectGraph(idSystemObject, DBAPI.eObjectGraphMode.eAncestors, 32, OGD);
+    const { unit, project, subject, item, objectAncestors } = await getObjectAncestors(OG);
+    LOG.info('getSystemObjectDetails 2', LOG.LS.eGQL);
 
     const systemObject: SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObject);
     const sourceObjects: RelatedObject[] = await getRelatedObjects(idSystemObject, RelatedObjectType.Source);
+    LOG.info('getSystemObjectDetails 3', LOG.LS.eGQL);
     const derivedObjects: RelatedObject[] = await getRelatedObjects(idSystemObject, RelatedObjectType.Derived);
+    LOG.info('getSystemObjectDetails 4', LOG.LS.eGQL);
     const objectVersions: DBAPI.SystemObjectVersion[] | null = await DBAPI.SystemObjectVersion.fetchFromSystemObject(idSystemObject);
+    LOG.info('getSystemObjectDetails 5', LOG.LS.eGQL);
     const { publishedState, publishedEnum, publishable } = await getPublishedState(idSystemObject, oID);
+    LOG.info('getSystemObjectDetails 6', LOG.LS.eGQL);
     const identifiers = await getIngestIdentifiers(idSystemObject);
+    LOG.info('getSystemObjectDetails 7', LOG.LS.eGQL);
 
     if (!oID) {
         const message: string = `No object ID found for ID: ${idSystemObject}`;
@@ -34,24 +46,25 @@ export default async function getSystemObjectDetails(_: Parent, args: QueryGetSy
 
     if (!systemObject) {
         const message: string = `No system object found for ID: ${idSystemObject}`;
-        LOG.error(message, LOG.LS.eGQL);
+        LOG.error(`getSystemObjectDetails: ${message}`, LOG.LS.eGQL);
         throw new Error(message);
     }
 
     if (!objectVersions) {
         const message: string = `No SystemObjectVersions found for ID: ${idSystemObject}`;
-        LOG.error(message, LOG.LS.eGQL);
+        LOG.error(`getSystemObjectDetails: ${message}`, LOG.LS.eGQL);
         throw new Error(message);
     }
 
-    const idObject: number = oID.idObject;
-    const name: string = await resolveNameForObjectType(systemObject, oID.eObjectType);
+    const name: string = await resolveNameForObject(idSystemObject);
+    LOG.info('getSystemObjectDetails 8', LOG.LS.eGQL);
 
-    const LR: DBAPI.LicenseResolver | undefined = await CACHE.LicenseCache.getLicenseResolver(idSystemObject);
+    const LR: DBAPI.LicenseResolver | undefined = await CACHE.LicenseCache.getLicenseResolver(idSystemObject, OGD);
+    LOG.info('getSystemObjectDetails 9', LOG.LS.eGQL);
 
     return {
         idSystemObject,
-        idObject,
+        idObject: oID.idObject,
         name,
         retired: systemObject.Retired,
         objectType: oID.eObjectType,
@@ -114,7 +127,7 @@ export async function getRelatedObjects(idSystemObject: number, type: RelatedObj
 
         const sourceObject: RelatedObject = {
             idSystemObject: relatedSystemObject.idSystemObject,
-            name: await resolveNameForObjectType(relatedSystemObject, oID.eObjectType),
+            name: await resolveNameForObject(relatedSystemObject.idSystemObject),
             identifier: identifier?.[0]?.IdentifierValue ?? null,
             objectType: oID.eObjectType
         };
@@ -145,14 +158,13 @@ type GetObjectAncestorsResult = {
     objectAncestors: RepositoryPath[][];
 };
 
-async function getObjectAncestors(idSystemObject: number): Promise<GetObjectAncestorsResult> {
-    const objectGraph = new DBAPI.ObjectGraph(idSystemObject, DBAPI.eObjectGraphMode.eAncestors);
+async function getObjectAncestors(OG: DBAPI.ObjectGraph): Promise<GetObjectAncestorsResult> {
     let unit: RepositoryPath | null = null;
     let project: RepositoryPath | null = null;
     let subject: RepositoryPath | null = null;
     let item: RepositoryPath | null = null;
 
-    if (!(await objectGraph.fetch())) {
+    if (!(await OG.fetch())) {
         return {
             unit,
             project,
@@ -161,43 +173,45 @@ async function getObjectAncestors(idSystemObject: number): Promise<GetObjectAnce
             objectAncestors: []
         };
     }
+    LOG.info('getSystemObjectDetails 1a', LOG.LS.eGQL);
 
     const objectAncestors: RepositoryPath[][] = [];
 
-    if (objectGraph.unit) {
-        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(objectGraph.unit, DBAPI.eSystemObjectType.eUnit);
+    if (OG.unit) {
+        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(OG.unit, DBAPI.eSystemObjectType.eUnit);
         unit = objectAncestor[0];
         objectAncestors.push(objectAncestor);
     }
 
-    if (objectGraph.project) {
-        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(objectGraph.project, DBAPI.eSystemObjectType.eProject);
+    if (OG.project) {
+        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(OG.project, DBAPI.eSystemObjectType.eProject);
         project = objectAncestor[0];
         objectAncestors.push(objectAncestor);
     }
 
-    if (objectGraph.subject) {
-        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(objectGraph.subject, DBAPI.eSystemObjectType.eSubject);
+    if (OG.subject) {
+        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(OG.subject, DBAPI.eSystemObjectType.eSubject);
         subject = objectAncestor[0];
         objectAncestors.push(objectAncestor);
     }
 
-    if (objectGraph.item) {
-        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(objectGraph.item, DBAPI.eSystemObjectType.eItem);
+    if (OG.item) {
+        const objectAncestor: RepositoryPath[] = await objectToRepositoryPath(OG.item, DBAPI.eSystemObjectType.eItem);
         item = objectAncestor[0];
         objectAncestors.push(objectAncestor);
     }
 
-    if (objectGraph.captureData) objectAncestors.push(await objectToRepositoryPath(objectGraph.captureData, DBAPI.eSystemObjectType.eCaptureData));
-    if (objectGraph.model) objectAncestors.push(await objectToRepositoryPath(objectGraph.model, DBAPI.eSystemObjectType.eModel));
-    if (objectGraph.scene) objectAncestors.push(await objectToRepositoryPath(objectGraph.scene, DBAPI.eSystemObjectType.eScene));
-    if (objectGraph.intermediaryFile) objectAncestors.push(await objectToRepositoryPath(objectGraph.intermediaryFile, DBAPI.eSystemObjectType.eIntermediaryFile));
-    if (objectGraph.projectDocumentation) objectAncestors.push(await objectToRepositoryPath(objectGraph.projectDocumentation, DBAPI.eSystemObjectType.eProjectDocumentation));
-    if (objectGraph.asset) objectAncestors.push(await objectToRepositoryPath(objectGraph.asset, DBAPI.eSystemObjectType.eAsset));
-    if (objectGraph.assetVersion) objectAncestors.push(await objectToRepositoryPath(objectGraph.assetVersion, DBAPI.eSystemObjectType.eAssetVersion));
-    if (objectGraph.actor) objectAncestors.push(await objectToRepositoryPath(objectGraph.actor, DBAPI.eSystemObjectType.eActor));
-    if (objectGraph.stakeholder) objectAncestors.push(await objectToRepositoryPath(objectGraph.stakeholder, DBAPI.eSystemObjectType.eStakeholder));
+    if (OG.captureData) objectAncestors.push(await objectToRepositoryPath(OG.captureData, DBAPI.eSystemObjectType.eCaptureData));
+    if (OG.model) objectAncestors.push(await objectToRepositoryPath(OG.model, DBAPI.eSystemObjectType.eModel));
+    if (OG.scene) objectAncestors.push(await objectToRepositoryPath(OG.scene, DBAPI.eSystemObjectType.eScene));
+    if (OG.intermediaryFile) objectAncestors.push(await objectToRepositoryPath(OG.intermediaryFile, DBAPI.eSystemObjectType.eIntermediaryFile));
+    if (OG.projectDocumentation) objectAncestors.push(await objectToRepositoryPath(OG.projectDocumentation, DBAPI.eSystemObjectType.eProjectDocumentation));
+    if (OG.asset) objectAncestors.push(await objectToRepositoryPath(OG.asset, DBAPI.eSystemObjectType.eAsset));
+    if (OG.assetVersion) objectAncestors.push(await objectToRepositoryPath(OG.assetVersion, DBAPI.eSystemObjectType.eAssetVersion));
+    if (OG.actor) objectAncestors.push(await objectToRepositoryPath(OG.actor, DBAPI.eSystemObjectType.eActor));
+    if (OG.stakeholder) objectAncestors.push(await objectToRepositoryPath(OG.stakeholder, DBAPI.eSystemObjectType.eStakeholder));
 
+    LOG.info('getSystemObjectDetails 1b', LOG.LS.eGQL);
     return {
         unit,
         project,
@@ -227,49 +241,57 @@ type Objects =
 async function objectToRepositoryPath(objects: Objects, objectType: DBAPI.eSystemObjectType): Promise<RepositoryPath[]> {
     const paths: RepositoryPath[] = [];
     for (const object of objects) {
-        let SystemObject: SystemObject | null = null;
+        let idObject: number | null = null;
 
-        if (object instanceof DBAPI.Unit && objectType === DBAPI.eSystemObjectType.eUnit)
-            SystemObject = await DBAPI.SystemObject.fetchFromUnitID(object.idUnit);
-        if (object instanceof DBAPI.Project && objectType === DBAPI.eSystemObjectType.eProject)
-            SystemObject = await DBAPI.SystemObject.fetchFromProjectID(object.idProject);
-        if (object instanceof DBAPI.Subject && objectType === DBAPI.eSystemObjectType.eSubject)
-            SystemObject = await DBAPI.SystemObject.fetchFromSubjectID(object.idSubject);
-        if (object instanceof DBAPI.Item && objectType === DBAPI.eSystemObjectType.eItem)
-            SystemObject = await DBAPI.SystemObject.fetchFromItemID(object.idItem);
-        if (object instanceof DBAPI.CaptureData && objectType === DBAPI.eSystemObjectType.eCaptureData)
-            SystemObject = await DBAPI.SystemObject.fetchFromCaptureDataID(object.idCaptureData);
-        if (object instanceof DBAPI.Model && objectType === DBAPI.eSystemObjectType.eModel)
-            SystemObject = await DBAPI.SystemObject.fetchFromModelID(object.idModel);
-        if (object instanceof DBAPI.Scene && objectType === DBAPI.eSystemObjectType.eScene)
-            SystemObject = await DBAPI.SystemObject.fetchFromSceneID(object.idScene);
-        if (object instanceof DBAPI.IntermediaryFile && objectType === DBAPI.eSystemObjectType.eIntermediaryFile)
-            SystemObject = await DBAPI.SystemObject.fetchFromIntermediaryFileID(object.idIntermediaryFile);
-        if (object instanceof DBAPI.ProjectDocumentation && objectType === DBAPI.eSystemObjectType.eProjectDocumentation)
-            SystemObject = await DBAPI.SystemObject.fetchFromProjectDocumentationID(object.idProjectDocumentation);
-        if (object instanceof DBAPI.Asset && objectType === DBAPI.eSystemObjectType.eAsset)
-            SystemObject = await DBAPI.SystemObject.fetchFromAssetID(object.idAsset);
-        if (object instanceof DBAPI.AssetVersion && objectType === DBAPI.eSystemObjectType.eAssetVersion)
-            SystemObject = await DBAPI.SystemObject.fetchFromAssetVersionID(object.idAssetVersion);
-        if (object instanceof DBAPI.Actor && objectType === DBAPI.eSystemObjectType.eActor)
-            SystemObject = await DBAPI.SystemObject.fetchFromActorID(object.idActor);
-        if (object instanceof DBAPI.Stakeholder && objectType === DBAPI.eSystemObjectType.eStakeholder)
-            SystemObject = await DBAPI.SystemObject.fetchFromStakeholderID(object.idStakeholder);
+        if (object instanceof DBAPI.Unit)
+            idObject = object.idUnit;
+        else if (object instanceof DBAPI.Project)
+            idObject = object.idProject;
+        else if (object instanceof DBAPI.Subject)
+            idObject = object.idSubject;
+        else if (object instanceof DBAPI.Item)
+            idObject = object.idItem;
+        else if (object instanceof DBAPI.CaptureData)
+            idObject = object.idCaptureData;
+        else if (object instanceof DBAPI.Model)
+            idObject = object.idModel;
+        else if (object instanceof DBAPI.Scene)
+            idObject = object.idScene;
+        else if (object instanceof DBAPI.IntermediaryFile)
+            idObject = object.idIntermediaryFile;
+        else if (object instanceof DBAPI.ProjectDocumentation)
+            idObject = object.idProjectDocumentation;
+        else if (object instanceof DBAPI.Asset)
+            idObject = object.idAsset;
+        else if (object instanceof DBAPI.AssetVersion)
+            idObject = object.idAssetVersion;
+        else if (object instanceof DBAPI.Actor)
+            idObject = object.idActor;
+        else if (object instanceof DBAPI.Stakeholder)
+            idObject = object.idStakeholder;
+        else {
+            LOG.error(`getSystemObjectDetails unable to determine type and id from ${JSON.stringify(object, H.Helpers.saferStringify)}`, LOG.LS.eGQL);
+            continue;
+        }
 
-        const path: RepositoryPath = {
-            idSystemObject: SystemObject?.idSystemObject ?? 0,
-            name: await resolveNameForObjectType(SystemObject, objectType),
-            objectType
-        };
-        paths.push(path);
+        const oID: DBAPI.ObjectIDAndType | undefined = { idObject, eObjectType: objectType };
+        const SOI: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromObjectID(oID);
+        if (SOI) {
+            const path: RepositoryPath = {
+                idSystemObject: SOI.idSystemObject,
+                name: await resolveNameForObject(SOI.idSystemObject),
+                objectType
+            };
+            paths.push(path);
+        } else
+            LOG.error(`getSystemObjectDetails could not compute system object info from ${JSON.stringify(oID)}`, LOG.LS.eGQL);
     }
 
+    LOG.info(`getSystemObjectDetails 1b-${DBAPI.eSystemObjectType[objectType]} ${objects.length}`, LOG.LS.eGQL);
     return paths;
 }
 
-async function resolveNameForObjectType(systemObject: SystemObject | null, _objectType: DBAPI.eDBObjectType): Promise<string> {
-    if (!systemObject)
-        return unknownName;
-    const name: string | undefined = await CACHE.SystemObjectCache.getObjectNameByID(systemObject.idSystemObject);
+async function resolveNameForObject(idSystemObject: number): Promise<string> {
+    const name: string | undefined = await CACHE.SystemObjectCache.getObjectNameByID(idSystemObject);
     return name || unknownName;
 }


### PR DESCRIPTION
Cache object graph calculation and reuse when handling getSystemObjectDetails; cache system object names.  Debugging logic has been put in place in order to measure server performance.  This will be removed once tuning is complete.

GraphQL:
* Avoid unnecessary SystemObject fetches when computing repository paths

Cache:
* Make use of cached object graph database, if available, when computing LicenseResolvers.
* Cache computed system object names