### PR TITLE
Fix for DPO3DPKRT-523: compute model assets present in .zips in ingestData in order to identify textures correctly

### DIFF
--- a/server/db/api/Model.ts
+++ b/server/db/api/Model.ts
@@ -33,6 +33,28 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
 
     public fetchTableName(): string { return 'Model'; }
     public fetchID(): number { return this.idModel; }
+    public cloneData(model: Model): void {
+        this.Name = model.Name;
+        this.DateCreated = model.DateCreated;
+        this.idVCreationMethod = model.idVCreationMethod;
+        this.idVModality = model.idVModality;
+        this.idVPurpose = model.idVPurpose;
+        this.idVUnits = model.idVUnits;
+        this.idVFileType = model.idVFileType;
+        this.idAssetThumbnail = model.idAssetThumbnail;
+        this.CountAnimations = model.CountAnimations;
+        this.CountCameras = model.CountCameras;
+        this.CountFaces = model.CountFaces;
+        this.CountLights = model.CountLights;
+        this.CountMaterials = model.CountMaterials;
+        this.CountMeshes = model.CountMeshes;
+        this.CountVertices = model.CountVertices;
+        this.CountEmbeddedTextures = model.CountEmbeddedTextures;
+        this.CountLinkedTextures = model.CountLinkedTextures;
+        this.FileEncoding = model.FileEncoding;
+        this.IsDracoCompressed = model.IsDracoCompressed;
+        this.AutomationTag = model.AutomationTag;
+    }
 
     protected async createWorker(): Promise<boolean> {
         try {

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -113,11 +113,12 @@ export class JobCookSIPackratInspectOutput implements H.IOResults {
         // map and validate assets:
         if (this.modelConstellation.ModelAssets) {
             for (const modelAsset of this.modelConstellation.ModelAssets) {
-                let mappedId: number | undefined = assetMap.get(modelAsset.Asset.FileName);
+                const fileName: string = modelAsset.Asset.FileName.trim();
+                let mappedId: number | undefined = assetMap.get(fileName);
                 if (!mappedId) // try again, with just filename
-                    mappedId = assetMap.get(path.basename(modelAsset.Asset.FileName));
+                    mappedId = assetMap.get(path.basename(fileName));
                 if (!mappedId) {
-                    const error: string = `Missing ${modelAsset.Asset.FileName} and ${path.basename(modelAsset.Asset.FileName)} from assetMap ${JSON.stringify(assetMap, H.Helpers.saferStringify)}`;
+                    const error: string = `Missing ${fileName} and ${path.basename(fileName)} from assetMap ${JSON.stringify(assetMap, H.Helpers.saferStringify)}`;
                     LOG.error(`JobCookSIPackratInspectOutput.persist: ${error}`, LOG.LS.eJOB);
                     // return { success: false, error };
                     continue;
@@ -416,6 +417,7 @@ export class JobCookSIPackratInspectOutput implements H.IOResults {
                                 case 'uri':
                                     materialUri = maybeString(value);
                                     if (materialUri) {
+                                        materialUri = materialUri.trim();
                                         // detect and handle UV Maps embedded in the geometry file:
                                         if (materialUri.toLowerCase().startsWith('embedded*')) {
                                             materialUri = null;

--- a/server/tests/db/dbcreation.test.ts
+++ b/server/tests/db/dbcreation.test.ts
@@ -1079,20 +1079,19 @@ describe('DB Creation Test Suite', () => {
     });
 
     test('DB Creation: Model With Nulls', async () => {
-        if (vocabulary)
-            modelNulls = await UTIL.createModelTest({
-                Name: 'Test Model with Nulls',
-                DateCreated: UTIL.nowCleansed(),
-                idVCreationMethod: null,
-                idVModality: null,
-                idVUnits: null,
-                idVPurpose: null,
-                idVFileType: null,
-                idAssetThumbnail: null,
-                CountAnimations: 0, CountCameras: 0, CountFaces: 0, CountLights: 0, CountMaterials: 0, CountMeshes: 0, CountVertices: 0,
-                CountEmbeddedTextures: 0, CountLinkedTextures: 0, FileEncoding: 'BINARY', IsDracoCompressed: false, AutomationTag: null,
-                idModel: 0
-            });
+        modelNulls = await UTIL.createModelTest({
+            Name: 'Test Model with Nulls',
+            DateCreated: UTIL.nowCleansed(),
+            idVCreationMethod: null,
+            idVModality: null,
+            idVUnits: null,
+            idVPurpose: null,
+            idVFileType: null,
+            idAssetThumbnail: null,
+            CountAnimations: 0, CountCameras: 0, CountFaces: 0, CountLights: 0, CountMaterials: 0, CountMeshes: 0, CountVertices: 0,
+            CountEmbeddedTextures: 0, CountLinkedTextures: 0, FileEncoding: 'BINARY', IsDracoCompressed: false, AutomationTag: null,
+            idModel: 0
+        });
         expect(modelNulls).toBeTruthy();
     });
 
@@ -4881,6 +4880,48 @@ describe('DB Fetch Special Test Suite', () => {
             }
         }
         expect(modelFetch).toBeTruthy();
+    });
+
+    test('DB Fetch Special: Model.cloneData', async () => {
+        const modelClone: DBAPI.Model = await UTIL.createModelTest({
+            Name: 'Test Model with Nulls',
+            DateCreated: UTIL.nowCleansed(),
+            idVCreationMethod: null,
+            idVModality: null,
+            idVUnits: null,
+            idVPurpose: null,
+            idVFileType: null,
+            idAssetThumbnail: null,
+            CountAnimations: 0, CountCameras: 0, CountFaces: 0, CountLights: 0, CountMaterials: 0, CountMeshes: 0, CountVertices: 0,
+            CountEmbeddedTextures: 0, CountLinkedTextures: 0, FileEncoding: 'BINARY', IsDracoCompressed: false, AutomationTag: null,
+            idModel: 0
+        });
+        expect(modelClone).toBeTruthy();
+        expect(model).toBeTruthy();
+        if (model) {
+            modelClone.cloneData(model);
+            expect(modelClone.idModel).not.toEqual(model.idModel);
+            expect(modelClone.Name).toEqual(model.Name);
+            expect(modelClone.DateCreated).toEqual(model.DateCreated);
+            expect(modelClone.idVCreationMethod).toEqual(model.idVCreationMethod);
+            expect(modelClone.idVModality).toEqual(model.idVModality);
+            expect(modelClone.idVPurpose).toEqual(model.idVPurpose);
+            expect(modelClone.idVUnits).toEqual(model.idVUnits);
+            expect(modelClone.idVFileType).toEqual(model.idVFileType);
+            expect(modelClone.idAssetThumbnail).toEqual(model.idAssetThumbnail);
+            expect(modelClone.CountAnimations).toEqual(model.CountAnimations);
+            expect(modelClone.CountCameras).toEqual(model.CountCameras);
+            expect(modelClone.CountFaces).toEqual(model.CountFaces);
+            expect(modelClone.CountLights).toEqual(model.CountLights);
+            expect(modelClone.CountMaterials).toEqual(model.CountMaterials);
+            expect(modelClone.CountMeshes).toEqual(model.CountMeshes);
+            expect(modelClone.CountVertices).toEqual(model.CountVertices);
+            expect(modelClone.CountEmbeddedTextures).toEqual(model.CountEmbeddedTextures);
+            expect(modelClone.CountLinkedTextures).toEqual(model.CountLinkedTextures);
+            expect(modelClone.FileEncoding).toEqual(model.FileEncoding);
+            expect(modelClone.IsDracoCompressed).toEqual(model.IsDracoCompressed);
+            expect(modelClone.AutomationTag).toEqual(model.AutomationTag);
+        }
     });
 
     test('DB Fetch Special: Model.fetchByFileNameAndAssetType', async () => {


### PR DESCRIPTION
GraphQL:
* Updated ingestData to compute the assets present in an ingested zip representing a model; these assets need to be given to the JobCookSIPackratInspect logic used to extract model constellation data from an inspected model.  In particular, the asset map needs to be populated in order for texture maps to be handled correctly.

Also added hyperlinks to the workflow report for ingestion for subjects, projects, and items.

Cook:
* Trim spaces from start and end of filenames, as cook sometimes emits filenames with trailing spaces.

DBAPI:
* Added Model.cloneData()