### PR TITLE
Fix for 496: compute object from ancestors which is the license source for a given, inherited license

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -171,7 +171,7 @@ function DetailsView(): React.ReactElement {
         sourceObjects,
         derivedObjects,
         objectVersions,
-        licenseInherited = null
+        licenseInheritance = null
     } = data.getSystemObjectDetails;
 
     const disabled: boolean = !allowed;
@@ -467,7 +467,7 @@ function DetailsView(): React.ReactElement {
                     originalFields={data.getSystemObjectDetails}
                     license={withDefaultValueNumber(details.idLicense, 0)}
                     idSystemObject={idSystemObject}
-                    licenseInherited={licenseInherited}
+                    licenseInheritance={licenseInheritance}
                     path={objectAncestors}
                 />
                 <Box display='flex' flex={2.2} flexDirection='column'>

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -1913,7 +1913,7 @@ export type GetSystemObjectDetailsResult = {
   subject?: Maybe<RepositoryPath>;
   item?: Maybe<RepositoryPath>;
   license?: Maybe<License>;
-  licenseInherited?: Maybe<Scalars['Boolean']>;
+  licenseInheritance?: Maybe<Scalars['Int']>;
 };
 
 export type GetSourceObjectIdentiferInput = {
@@ -3664,7 +3664,7 @@ export type GetSystemObjectDetailsQuery = (
   { __typename?: 'Query' }
   & { getSystemObjectDetails: (
     { __typename?: 'GetSystemObjectDetailsResult' }
-    & Pick<GetSystemObjectDetailsResult, 'idSystemObject' | 'idObject' | 'name' | 'retired' | 'objectType' | 'allowed' | 'publishedState' | 'publishedEnum' | 'publishable' | 'thumbnail' | 'licenseInherited'>
+    & Pick<GetSystemObjectDetailsResult, 'idSystemObject' | 'idObject' | 'name' | 'retired' | 'objectType' | 'allowed' | 'publishedState' | 'publishedEnum' | 'publishable' | 'thumbnail' | 'licenseInheritance'>
     & { identifiers: Array<(
       { __typename?: 'IngestIdentifier' }
       & Pick<IngestIdentifier, 'identifier' | 'identifierType' | 'idIdentifier'>
@@ -6544,7 +6544,7 @@ export const GetSystemObjectDetailsDocument = gql`
       Comment
       CommentLink
     }
-    licenseInherited
+    licenseInheritance
     license {
       idLicense
       Name

--- a/server/graphql/api/queries/systemobject/getSystemObjectDetails.ts
+++ b/server/graphql/api/queries/systemobject/getSystemObjectDetails.ts
@@ -63,7 +63,7 @@ const getSystemObjectDetails = gql`
                 Comment
                 CommentLink
             }
-            licenseInherited
+            licenseInheritance
             license {
                 idLicense
                 Name

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -1447,7 +1447,7 @@ type GetSystemObjectDetailsResult {
   subject: RepositoryPath
   item: RepositoryPath
   license: License
-  licenseInherited: Boolean
+  licenseInheritance: Int
 }
 
 input GetSourceObjectIdentiferInput {

--- a/server/graphql/schema/systemobject/queries.graphql
+++ b/server/graphql/schema/systemobject/queries.graphql
@@ -177,7 +177,7 @@ type GetSystemObjectDetailsResult {
     subject: RepositoryPath
     item: RepositoryPath
     license: License
-    licenseInherited: Boolean
+    licenseInheritance: Int
 }
 
 input GetSourceObjectIdentiferInput {

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -76,7 +76,7 @@ export default async function getSystemObjectDetails(_: Parent, args: QueryGetSy
         derivedObjects,
         objectVersions,
         license: LR?.License,
-        licenseInherited: LR?.inherited,
+        licenseInheritance: LR?.inherited ? LR?.LicenseAssignment?.idSystemObject : undefined,
     };
 }
 

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -1910,7 +1910,7 @@ export type GetSystemObjectDetailsResult = {
   subject?: Maybe<RepositoryPath>;
   item?: Maybe<RepositoryPath>;
   license?: Maybe<License>;
-  licenseInherited?: Maybe<Scalars['Boolean']>;
+  licenseInheritance?: Maybe<Scalars['Int']>;
 };
 
 export type GetSourceObjectIdentiferInput = {


### PR DESCRIPTION
GraphQL:
* Update getSystemObjectDetails to return idSystemObject of license inheritance source, in licenseInheritance

Client:
* Compute correct object from ancestors which is the license source for a given, inherited license