### PR TITLE
Fix for 514: avoid running post-ingestion workflows if no assets were updated

### DIFF
--- a/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
+++ b/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
@@ -1275,12 +1275,17 @@ class IngestDataWorker extends ResolverBase {
             }
             await this.appendToWFReport(message);
 
+            const parameters = {
+                modelTransformUpdated,
+                assetsIngested: IAR.assetsIngested
+            };
+
             const workflowParams: WF.WorkflowParameters = {
                 eWorkflowType: null,
                 idSystemObject,
                 idProject: null, // TODO: update with project ID
                 idUserInitiator: user.idUser,
-                parameters: modelTransformUpdated ? { modelTransformUpdated } : null
+                parameters
             };
 
             // send workflow engine event, but don't wait for results

--- a/server/navigation/impl/NavigationSolr/IndexSolr.ts
+++ b/server/navigation/impl/NavigationSolr/IndexSolr.ts
@@ -75,9 +75,9 @@ export class IndexSolr implements NAV.IIndexer {
                 if (res.success)
                     res = await solrClient.commit();
                 if (!res.success)
-                    LOG.error(`IndexSolr.indexObject failed: ${res.error}`, LOG.LS.eNAV);
+                    LOG.error(`IndexSolr.indexObject failed: ${res.error}, docs=${JSON.stringify(docs, H.Helpers.saferStringify)}`, LOG.LS.eNAV);
             } catch (error) {
-                LOG.error(`IndexSolr.indexObject(${idSystemObject}) failed`, LOG.LS.eNAV, error);
+                LOG.error(`IndexSolr.indexObject(${idSystemObject}) failed, docs=${JSON.stringify(docs, H.Helpers.saferStringify)}`, LOG.LS.eNAV, error);
                 return false;
             }
 


### PR DESCRIPTION
Storage:
* Compute if assets are updated during AssetStorageAdapter.ingestAsset.  This is always true if a single asset is ingested, and will be true when zips are ingested if they create new asset versions

Workflow:
* When handling post-ingestion workflow events, extract assetIngested workflow parameter, and use this to determine if post-ingestion workflow events should be executed

GraphQL:
* Pass along 'assetsIngested' from ingestAsset results to workfow event

Solr:
* Add solr document logging to failed indexObject attempts