### PR TITLE
update repository filter to also create chips for everything in the s…

### DIFF
--- a/client/src/components/controls/IndentedReadOnlyRow.tsx
+++ b/client/src/components/controls/IndentedReadOnlyRow.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
     container: {
         display: 'grid',
         alignItems: 'center',
-        gridTemplateColumns: ({ indentation }: IndentedReadOnlyRowProps) => indentation ? `${15*indentation}px 15% 15px 1fr` : '15px 15% 15px 1fr',
+        gridTemplateColumns: ({ indentation }: IndentedReadOnlyRowProps) => indentation ? `${15*indentation}px 20% 15px 1fr` : '15px 20% 15px 1fr',
         padding: 10,
         borderRadius: 5,
         width: ({ width }: IndentedReadOnlyRowProps) => width || '100%',

--- a/client/src/components/controls/RepositoryIcon.tsx
+++ b/client/src/components/controls/RepositoryIcon.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { eSystemObjectType } from '../../types/server';
-import { getTermForSystemObjectType } from '../../utils/repository';
+import { getTermForSystemObjectType, getDetailsUrlForObject } from '../../utils/repository';
 
 export interface RepositoryIconProps {
     objectType: eSystemObjectType;
@@ -13,14 +13,24 @@ export interface RepositoryIconProps {
     textColor: string;
     overrideText?: string | undefined;
     makeStyles?: { [key: string]: string };
+    idSystemObject: number;
 }
 
 export function RepositoryIcon(props: RepositoryIconProps): React.ReactElement {
-    const { objectType, overrideText, makeStyles } = props;
+    const { objectType, overrideText, makeStyles, idSystemObject } = props;
     const initial = !overrideText ? getTermForSystemObjectType(objectType).toUpperCase().slice(0, 1) : overrideText;
     return (
         <div className={makeStyles?.container} style={{ backgroundColor: makeStyles?.backgroundColor }}>
-            <p className={makeStyles?.initial} style={{ color: '#232023' }}>{initial}</p>
+            <a
+                href={getDetailsUrlForObject(idSystemObject)}
+                onClick={event => event.stopPropagation()}
+                target='_blank'
+                rel='noopener noreferrer'
+                aria-label={`link to view system object of id ${idSystemObject}`}
+                style={{ textDecoration: 'none' }}
+            >
+                <p className={makeStyles?.initial} style={{ color: '#232023' }}>{initial}</p>
+            </a>
         </div>
     );
 }

--- a/client/src/constants/helperfunctions.ts
+++ b/client/src/constants/helperfunctions.ts
@@ -26,7 +26,7 @@ export function formatISOToHoursMinutes(time: string): string {
     return `${hours}:${minutes}`;
 }
 
-export function extractISOMonthDateYear(iso: string | Date, materialUI = false): string | null {
+export function extractISOMonthDateYear(iso: string | Date | null, materialUI = false): string | null {
     if (!iso)
         return null;
 

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -21,7 +21,9 @@ const useStyles = makeStyles(() => ({
     container: {
         display: 'flex',
         flexDirection: 'column',
-        flex: 1
+        flex: 1,
+        width: 'fit-content',
+        minWidth: '100%'
     },
     content: {
         display: 'flex',

--- a/client/src/pages/Ingestion/components/Metadata/Model/ObjectMeshTable.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/ObjectMeshTable.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles(theme => ({
     unindentedFields: {
         '& > :first-child': {
             minHeight: '20px',
+            height: 'fit-content',
             borderBottom: '0.5px solid #D8E5EE',
             borderTop: '0.5px solid #D8E5EE'
         },
@@ -69,9 +70,11 @@ const useStyles = makeStyles(theme => ({
         borderRadius: 5,
         padding: 10,
         backgroundColor: theme.palette.primary.light,
-        width: 'fit-content',
+        minWidth: '750px',
+        maxWidth: '40vw',
         display: 'flex',
-        flexDirection: 'column'
+        flexDirection: 'column',
+        wordBreak: 'break-word'
     },
     captionContainer: {
         flex: '1 1 0%',

--- a/client/src/pages/Ingestion/components/Metadata/Model/ObjectSelectModal.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/ObjectSelectModal.tsx
@@ -25,7 +25,7 @@ import RepositoryTreeView from '../../../../Repository/components/RepositoryTree
 import { isValidParentChildRelationship } from '../../../../../utils/repository';
 import { useRepositoryStore } from '../../../../../store/repository';
 
-const useStyles = makeStyles(({ palette, spacing, breakpoints }) => ({
+const useStyles = makeStyles(({ palette, spacing }) => ({
     title: {
         marginLeft: spacing(2),
         textAlign: 'center',
@@ -33,16 +33,14 @@ const useStyles = makeStyles(({ palette, spacing, breakpoints }) => ({
     },
     appBar: {
         position: 'relative',
-        color: palette.background.paper
+        color: palette.background.paper,
+        width: '100%'
     },
     repositoryContainer: {
         display: 'flex',
         flexDirection: 'column',
         padding: 20,
-        paddingBottom: 0,
-        [breakpoints.down('lg')]: {
-            padding: 10
-        }
+        paddingBottom: 0
     },
     loader: {
         color: palette.background.paper
@@ -181,23 +179,26 @@ function ObjectSelectModal(props: ObjectSelectModalProps): React.ReactElement {
             }}
             maxWidth='xl'
         >
-            <AppBar className={classes.appBar}>
-                <Toolbar>
-                    <Button autoFocus color='inherit' onClick={onModalClose}>
-                        Close
-                    </Button>
-                    <Typography variant='h6' className={classes.title}>
-                        Select {props?.relationship === 'Source' ? 'Parent(s)' : 'Child(ren)'}
-                    </Typography>
-                    <Button autoFocus color='inherit' onClick={onClick}>
-                        {isSaving ? 'Saving...' : 'Save'}
-                    </Button>
-                </Toolbar>
-            </AppBar>
-            <Box className={classes.repositoryContainer}>
-                <RepositoryFilterView />
-                <RepositoryTreeView isModal selectedItems={selected} onSelect={onSelect} onUnSelect={onUnSelect} />
+            <Box width='fit-content'>
+                <AppBar className={classes.appBar}>
+                    <Toolbar>
+                        <Button autoFocus color='inherit' onClick={onModalClose}>
+                            Close
+                        </Button>
+                        <Typography variant='h6' className={classes.title}>
+                            Select {props?.relationship === 'Source' ? 'Parent(s)' : 'Child(ren)'}
+                        </Typography>
+                        <Button autoFocus color='inherit' onClick={onClick}>
+                            {isSaving ? 'Saving...' : 'Save'}
+                        </Button>
+                    </Toolbar>
+                </AppBar>
+                <Box className={classes.repositoryContainer}>
+                    <RepositoryFilterView />
+                    <RepositoryTreeView isModal selectedItems={selected} onSelect={onSelect} onUnSelect={onUnSelect} />
+                </Box>
             </Box>
+
         </Dialog>
     );
 }

--- a/client/src/pages/Repository/components/RepositoryFilterView/RepositoryFilterOptions.ts
+++ b/client/src/pages/Repository/components/RepositoryFilterView/RepositoryFilterOptions.ts
@@ -8,6 +8,19 @@ import { eMetadata, eSystemObjectType, eVocabularySetID } from '../../../../type
 import { getTermForSystemObjectType } from '../../../../utils/repository';
 import lodash from 'lodash';
 
+export enum eRepositoryChipFilterType {
+    eProject,
+    eUnit,
+    eHas,
+    eMissing,
+    eCaptureMethod,
+    eVariantType,
+    eModelPurpose,
+    eModelFileType,
+    eDateCreatedFrom,
+    eDateCreatedTo
+}
+
 export type FilterOption = {
     label: string;
     value: number;
@@ -15,7 +28,7 @@ export type FilterOption = {
 
 export type ChipOption = {
     id: number;
-    type: eSystemObjectType;
+    type: eRepositoryChipFilterType;
     name: string;
 };
 
@@ -140,12 +153,12 @@ export function getRepositoryFilterOptions({ units, projects, data, getEntries }
 
     if (getFilterViewData?.units && getFilterViewData.units.length) {
         unitsOptions = sortOptionsAlphabetically(getFilterViewData?.units.map(({ Name, SystemObject }) => ({ label: Name, value: SystemObject?.idSystemObject ?? 0 })));
-        chipsOptions.push(...filterOptionToChipOption(units, unitsOptions, eSystemObjectType.eUnit));
+        chipsOptions.push(...filterOptionToChipOption(units, unitsOptions, eRepositoryChipFilterType.eUnit));
     }
 
     if (getFilterViewData?.projects && getFilterViewData.projects.length) {
         projectsOptions = sortOptionsAlphabetically(getFilterViewData?.projects.map(({ Name, SystemObject }) => ({ label: Name, value: SystemObject?.idSystemObject ?? 0 })));
-        chipsOptions.push(...filterOptionToChipOption(projects, projectsOptions, eSystemObjectType.eProject));
+        chipsOptions.push(...filterOptionToChipOption(projects, projectsOptions, eRepositoryChipFilterType.eProject));
     }
 
     const repositoryRootTypesOptions: FilterOption[] = systemObjectTypes;
@@ -177,11 +190,26 @@ function vocabulariesToFilterOption(vocabularies: Pick<Vocabulary, 'idVocabulary
     return vocabularies.map(({ idVocabulary, Term }) => ({ label: Term, value: idVocabulary }));
 }
 
-function filterOptionToChipOption(selectedIds: number[], options: FilterOption[], type: eSystemObjectType): ChipOption[] {
+function filterOptionToChipOption(selectedIds: number[], options: FilterOption[], type: eRepositoryChipFilterType): ChipOption[] {
     const selectedOptions: FilterOption[] = options.filter(({ value }) => selectedIds.includes(value));
     return selectedOptions.map(({ label: name, value: id }: FilterOption) => ({ id, name, type }));
 }
 
 function sortOptionsAlphabetically(options: FilterOption[]): FilterOption[] {
     return lodash.orderBy(options, [({ label }: FilterOption) => label.toLowerCase().trim()], ['asc']);
+}
+
+export function getTermForRepositoryFilterType(filterType: eRepositoryChipFilterType): string {
+    switch (filterType) {
+        case eRepositoryChipFilterType.eUnit:                   return 'Unit';
+        case eRepositoryChipFilterType.eProject:                return 'Project';
+        case eRepositoryChipFilterType.eHas:                    return 'Has';
+        case eRepositoryChipFilterType.eMissing:                return 'Missing';
+        case eRepositoryChipFilterType.eCaptureMethod:          return 'Capture Method';
+        case eRepositoryChipFilterType.eVariantType:            return 'Variant Type';
+        case eRepositoryChipFilterType.eModelPurpose:           return 'Model Purpose';
+        case eRepositoryChipFilterType.eModelFileType:          return 'Model File Type';
+        case eRepositoryChipFilterType.eDateCreatedFrom:        return 'Created From';
+        case eRepositoryChipFilterType.eDateCreatedTo:          return 'Created To';
+    }
 }

--- a/client/src/pages/Repository/components/RepositoryTreeView/InViewTreeItem.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/InViewTreeItem.tsx
@@ -11,10 +11,11 @@ interface InViewTreeItemProps {
     color: string;
     label: React.ReactNode;
     onView: () => Promise<void>;
+    id: string;
 }
 
 function InViewTreeItem(props: InViewTreeItemProps): React.ReactElement {
-    const { nodeId, triggerOnce, childNodesContent, icon, color, label, onView } = props;
+    const { nodeId, triggerOnce, childNodesContent, icon, color, label, onView, id } = props;
     const [loading, setLoading] = useState(false);
     return (
         <InView
@@ -30,7 +31,13 @@ function InViewTreeItem(props: InViewTreeItemProps): React.ReactElement {
             {({ ref }) => {
                 return (
                     <div ref={ref}>
-                        <StyledTreeItem nodeId={nodeId} color={color} label={label} icon={icon}>
+                        <StyledTreeItem
+                            id={id}
+                            nodeId={nodeId}
+                            color={color}
+                            label={label}
+                            icon={icon}
+                        >
                             {childNodesContent}
                         </StyledTreeItem>
                         {loading ? <TreeLabelLoading /> : <TreeLabelEllipsis />}

--- a/client/src/pages/Repository/components/RepositoryTreeView/MetadataView.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/MetadataView.tsx
@@ -35,7 +35,7 @@ function MetadataView(props: MetadataViewProps): React.ReactElement {
             return (
                 <div key={index} className={makeStyles?.column} style={{ width, color: palette.primary.dark, fontSize: undefined }}>
                     <span className={makeStyles?.text} title={header ? undefined : label} data-tooltip-position='bottom'>
-                        {trimmedMetadataField(label, 20, 10)}
+                        {trimmedMetadataField(label, 14, 7)}
                     </span>
                 </div>
             );

--- a/client/src/pages/Repository/components/RepositoryTreeView/RepositoryTreeHeader.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/RepositoryTreeHeader.tsx
@@ -6,15 +6,15 @@
 import { Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { useControlStore } from '../../../../store';
 import { eMetadata } from '../../../../types/server';
-import { getTreeViewColumns, getTreeWidth } from '../../../../utils/repository';
+import { getTreeViewColumns } from '../../../../utils/repository';
 import MetadataView from './MetadataView';
 
 const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     container: {
         display: 'flex',
-        height: 50,
+        minHeight: 50,
+        height: 'fit-content',
         backgroundColor: palette.primary.light,
         borderRadius: 5,
         marginBottom: 5,
@@ -22,12 +22,11 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         top: 0,
         zIndex: 20,
         [breakpoints.down('lg')]: {
-            height: 40
+            minHeight: 40
         }
     },
     treeView: {
         display: 'flex',
-        flex: 1,
         position: 'sticky',
         left: 0,
         alignItems: 'center',
@@ -36,7 +35,11 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         fontWeight: typography.fontWeightRegular,
         [breakpoints.down('lg')]: {
             fontSize: typography.pxToRem(15)
-        }
+        },
+        width: 'calc(30vw + 25px)',
+        minWidth: '325px',
+        maxWidth: '525px'
+
     },
     treeViewText: {
         left: 20,
@@ -79,15 +82,13 @@ interface RepositoryTreeHeaderProps {
 }
 
 function RepositoryTreeHeader(props: RepositoryTreeHeaderProps): React.ReactElement {
-    const { fullWidth = false, metadataColumns } = props;
+    const { metadataColumns } = props;
     const classes = useStyles();
 
-    const sideBarExpanded = useControlStore(state => state.sideBarExpanded);
     const treeColumns = getTreeViewColumns(metadataColumns, true);
-    const width = getTreeWidth(treeColumns.length, sideBarExpanded, fullWidth);
 
     return (
-        <Box className={classes.container} style={{ width }}>
+        <Box className={classes.container}>
             <Box className={classes.treeView}>
                 <Box className={classes.treeViewText} />
             </Box>

--- a/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
@@ -19,9 +19,6 @@ import {
     getRepositoryTreeNodeId,
     getTreeColorVariant,
     getTreeViewColumns,
-    getTreeViewStyleHeight,
-    getTreeViewStyleWidth,
-    getTreeWidth,
     isRepositoryItemSelected
 } from '../../../../utils/repository';
 import RepositoryTreeHeader from './RepositoryTreeHeader';
@@ -34,15 +31,18 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     container: {
         display: 'flex',
         flex: 5,
-        maxHeight: ({ isExpanded, isModal }: StyleProps) => getTreeViewStyleHeight(isExpanded, isModal, 'xl'),
-        maxWidth: ({ sideBarExpanded }: StyleProps) => getTreeViewStyleWidth(sideBarExpanded, 'xl'),
+        height: 'fit-content',
+        minWidth: '60vw',
+        width: 'fit-content',
         flexDirection: 'column',
-        overflow: 'hidden',
+        overflowY: 'hidden',
         transition: '250ms height, width ease',
+        // paddingRight is needed so that a second horizontal scrollbar isn't created when hovering a row
+        paddingRight: 20,
         [breakpoints.down('lg')]: {
-            maxHeight: ({ isExpanded, isModal }: StyleProps) => getTreeViewStyleHeight(isExpanded, isModal, 'lg'),
-            maxWidth: ({ sideBarExpanded }: StyleProps) => getTreeViewStyleWidth(sideBarExpanded, 'lg')
-        }
+            paddingRight: 10
+        },
+        paddingBottom: 10
     },
     tree: {
         display: 'flex',
@@ -76,7 +76,9 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     },
     label: {
         display: 'flex',
-        flex: 0.9,
+        width: '30vw',
+        minWidth: '300px',
+        maxWidth: '500px',
         alignItems: 'center',
         position: 'sticky',
         left: 45,
@@ -132,11 +134,6 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
     }
 }));
 
-type StyleProps = {
-    sideBarExpanded: boolean;
-    isExpanded: boolean;
-    isModal: boolean;
-};
 
 interface RepositoryTreeViewProps {
     isModal?: boolean;
@@ -196,7 +193,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
             }
 
             const variant = getTreeColorVariant(index);
-            const { icon, color } = getObjectInterfaceDetails(objectType, variant, { container: classes.iconContainer, initial: classes.iconInitial });
+            const { icon, color } = getObjectInterfaceDetails(objectType, variant, { container: classes.iconContainer, initial: classes.iconInitial }, idSystemObject);
 
             const treeColumns = getTreeViewColumns(metadataColumns, false, metadata);
 
@@ -240,6 +237,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
             if ((index + 1) % repositoryRowCount === 0 && index + 1 === children.length && isChild) {
                 return (
                     <InViewTreeItem
+                        id={`repository row id ${idSystemObject}`}
                         key={idSystemObject}
                         nodeId={nodeId}
                         icon={icon}
@@ -263,6 +261,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
             if ((index + 1) % repositoryRowCount === 0 && index + 1 === children.length) {
                 return (
                     <InViewTreeItem
+                        id={`repository row id ${idSystemObject}`}
                         key={idSystemObject}
                         nodeId={nodeId}
                         icon={icon}
@@ -277,7 +276,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
 
             // base case
             return (
-                <StyledTreeItem key={idSystemObject} nodeId={nodeId} icon={icon} color={color} label={label}>
+                <StyledTreeItem id={`repository row id ${idSystemObject}`} key={idSystemObject} nodeId={nodeId} icon={icon} color={color} label={label}>
                     {childNodesContent}
                 </StyledTreeItem>
             );
@@ -287,18 +286,16 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
     let content: React.ReactNode = <Loader maxWidth='85vw' minHeight='40vh' size={20} />;
 
     if (!loading) {
-        const treeColumns = getTreeViewColumns(metadataColumns, false);
-        const width = getTreeWidth(treeColumns.length, sideBarExpanded, isModal);
         const children = tree.get(treeRootKey);
         content = (
-            <TreeView className={classes.tree} defaultCollapseIcon={<ExpandMoreIcon />} defaultExpandIcon={<ChevronRightIcon />} onNodeToggle={onNodeToggle} style={{ width }}>
+            <TreeView className={classes.tree} defaultCollapseIcon={<ExpandMoreIcon />} defaultExpandIcon={<ChevronRightIcon />} onNodeToggle={onNodeToggle}>
                 <RepositoryTreeHeader fullWidth={isModal} metadataColumns={metadataColumns} />
                 {renderTree(children)}
             </TreeView>
         );
     }
 
-    const fullWidthStyles = isModal ? { maxWidth: '98vw' } : {};
+    const fullWidthStyles = isModal ? { minWidth: '90%' } : {};
 
     return (
         <div className={classes.container} style={fullWidthStyles}>

--- a/client/src/pages/Repository/index.tsx
+++ b/client/src/pages/Repository/index.tsx
@@ -26,14 +26,13 @@ const useStyles = makeStyles(({ breakpoints }) => ({
     container: {
         display: 'flex',
         flex: 1,
-        maxWidth: (sideBarExpanded: boolean) => (sideBarExpanded ? '85vw' : '93vw'),
+        width: 'fit-content',
         flexDirection: 'column',
         padding: 20,
         paddingBottom: 0,
         paddingRight: 0,
         [breakpoints.down('lg')]: {
-            paddingRight: 20,
-            maxWidth: (sideBarExpanded: boolean) => (sideBarExpanded ? '85vw' : '92vw')
+            paddingRight: 20
         }
     }
 }));

--- a/client/src/store/repository.ts
+++ b/client/src/store/repository.ts
@@ -12,6 +12,7 @@ import { parseRepositoryTreeNodeId, validateArray, getTermForSystemObjectType } 
 import { apolloClient } from '../graphql';
 import { GetSystemObjectDetailsDocument } from '../types/graphql';
 import { toast } from 'react-toastify';
+import { eRepositoryChipFilterType } from '../pages/Repository/components/RepositoryFilterView/RepositoryFilterOptions';
 
 type RepositoryStore = {
     isExpanded: boolean;
@@ -39,7 +40,7 @@ type RepositoryStore = {
     repositoryBrowserRootObjectType: string | null;
     repositoryBrowserRootName: string | null;
     getFilterState: () => RepositoryFilter;
-    removeUnitsOrProjects: (id: number, type: eSystemObjectType) => void;
+    removeChipOption: (id: number, type: eRepositoryChipFilterType) => void;
     updateFilterValue: (name: string, value: number | number[] | Date | null) => void;
     resetRepositoryFilter: (modifyCookie?: boolean) => void;
     resetKeywordSearch: () => void;
@@ -186,25 +187,76 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             }
         }
     },
-    removeUnitsOrProjects: (id: number, type: eSystemObjectType): void => {
-        const { units, projects, setCookieToState, initializeTree, keyword } = get();
-        let updatedUnits: number[] = units.slice();
-        let updatedProjects: number[] = projects.slice();
+    removeChipOption: (id: number, type: eRepositoryChipFilterType): void => {
+        const { units, projects, has, missing, captureMethod, variantType, modelPurpose, modelFileType, setCookieToState, initializeTree, keyword } = get();
 
         switch (type) {
-            case eSystemObjectType.eUnit: {
+            case eRepositoryChipFilterType.eUnit: {
+                let updatedUnits: number[] = units.slice();
                 if (updatedUnits.length === 1) updatedUnits = [];
                 else updatedUnits = updatedUnits.filter(unit => unit !== id);
+                set({ units: updatedUnits });
                 break;
             }
-            case eSystemObjectType.eProject: {
+            case eRepositoryChipFilterType.eProject: {
+                let updatedProjects = projects.slice();
                 if (updatedProjects.length === 1) updatedProjects = [];
                 else updatedProjects = updatedProjects.filter(project => project !== id);
+                set({ projects: updatedProjects });
+                break;
+            }
+            case eRepositoryChipFilterType.eHas: {
+                let updatedHas: eSystemObjectType[] = has.slice();
+                if (updatedHas.length === 1) updatedHas = [];
+                else updatedHas = updatedHas.filter(has => has !== id);
+                set({ has: updatedHas });
+                break;
+            }
+            case eRepositoryChipFilterType.eMissing: {
+                let updatedMissing: eSystemObjectType[] = missing.slice();
+                if (updatedMissing.length === 1) updatedMissing = [];
+                else updatedMissing = updatedMissing.filter(missing => missing !== id);
+                set({ missing: updatedMissing });
+                break;
+            }
+            case eRepositoryChipFilterType.eCaptureMethod: {
+                let updatedCaptureMethod: eSystemObjectType[] = captureMethod.slice();
+                if (updatedCaptureMethod.length === 1) updatedCaptureMethod = [];
+                else updatedCaptureMethod = updatedCaptureMethod.filter(captureMethod => captureMethod !== id);
+                set({ captureMethod: updatedCaptureMethod });
+                break;
+            }
+            case eRepositoryChipFilterType.eVariantType: {
+                let updatedVariantType: eSystemObjectType[] = variantType.slice();
+                if (updatedVariantType.length === 1) updatedVariantType = [];
+                else updatedVariantType = updatedVariantType.filter(variantType => variantType !== id);
+                set({ variantType: updatedVariantType });
+                break;
+            }
+            case eRepositoryChipFilterType.eModelPurpose: {
+                let updatedModelPurpose: eSystemObjectType[] = modelPurpose.slice();
+                if (updatedModelPurpose.length === 1) updatedModelPurpose = [];
+                else updatedModelPurpose = updatedModelPurpose.filter(modelPurpose => modelPurpose !== id);
+                set({ modelPurpose: updatedModelPurpose });
+                break;
+            }
+            case eRepositoryChipFilterType.eModelFileType: {
+                let updatedModelFileType: eSystemObjectType[] = modelFileType.slice();
+                if (updatedModelFileType.length === 1) updatedModelFileType = [];
+                else updatedModelFileType = updatedModelFileType.filter(modelFileType => modelFileType !== id);
+                set({ modelFileType: updatedModelFileType });
+                break;
+            }
+            case eRepositoryChipFilterType.eDateCreatedFrom: {
+                set({ dateCreatedFrom: null });
+                break;
+            }
+            case eRepositoryChipFilterType.eDateCreatedTo: {
+                set({ dateCreatedTo: null });
                 break;
             }
         }
-
-        set({ units: updatedUnits, projects: updatedProjects, search: keyword });
+        set({ search: keyword });
         setCookieToState();
         initializeTree();
     },

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -148,7 +148,7 @@ export function getTreeWidth(columnSize: number, sideBarExpanded: boolean, fullW
     const isXLScreen = window.innerWidth >= 1600;
 
     if (fullWidth) {
-        return '98vw';
+        return '90vw';
     }
 
     if (computedWidth <= 80) {
@@ -174,6 +174,7 @@ let metadataTitleMap: Map<eMetadata, string> | null = null;
 // prettier-ignore
 export function getTreeViewColumns(metadataColumns: eMetadata[], isHeader: boolean, values?: string[]): TreeViewColumn[] {
     const treeColumns: TreeViewColumn[] = [];
+    // width of each column
     const MIN_SIZE = 5;
 
     if (!metadataTitleMap) {
@@ -215,12 +216,12 @@ type ObjectInterfaceDetails = {
 };
 
 // prettier-ignore
-export function getObjectInterfaceDetails(objectType: eSystemObjectType, variant: RepositoryColorVariant, makeStyles: any): ObjectInterfaceDetails {
+export function getObjectInterfaceDetails(objectType: eSystemObjectType, variant: RepositoryColorVariant, makeStyles: any, idSystemObject: number): ObjectInterfaceDetails {
     const color: string = Colors.repository[objectType][variant];
     const textColor: string = Colors.defaults.white;
     const backgroundColor: string = Colors.repository[objectType][RepositoryColorVariant.dark] || Colors.repository.default[RepositoryColorVariant.dark];
 
-    const iconProps: RepositoryIconProps = { objectType, backgroundColor, textColor, overrideText: undefined };
+    const iconProps: RepositoryIconProps = { objectType, backgroundColor, textColor, overrideText: undefined, idSystemObject };
 
     switch (objectType) {
         default:                                        break;


### PR DESCRIPTION
This PR will address the bugs found in the bug fix for 446 and 483
1) Fix weird model mesh/object behavior when on different screen sizes
2) Fix wide repository behavior

In addition, this PR includes the following work:
1) Chips now represent more than just select projects and units: they now represent every repository filter option in the second and third column
2) Repository tree view now has filter and tree extending horizontally and vertically rather than having its own container scrollbar
3) Repository tree row has removed the link icon. Instead, the system object type icon acts as a link
4) Double clicking on the repository tree row name as opens up a new tab for that system object
5) Fix the app header to extend as far as the contents of the page (to remove dead white space)