### PR TITLE
Build fixes for production container images

### DIFF
--- a/conf/docker/server-dev.Dockerfile
+++ b/conf/docker/server-dev.Dockerfile
@@ -1,30 +1,26 @@
 FROM node:14.17.1-alpine AS base
-# Add a work directory
+# Add a work directory, copy package.json for caching, copy app files
 WORKDIR /app
-# Copy package.json for caching
-ADD package*.json .
-# Copy app files
+ADD package.json .
 COPY . .
 
-# Build server from common base
-FROM base AS server
 # Remove client files, except server.ts, to prevent duplication
 RUN rm -rf client/build
 RUN rm -rf client/node_modules
 RUN rm -rf client/public
 RUN find client/src -maxdepth 1 ! -path client/src/types ! -path client/src -type d -exec rm -rf {} +
 RUN find client -type f -not -name 'server.ts' -delete
-# Install perl, needed by exiftool
+
+# Install perl, needed by exiftool, and git, needed to fetch npm-server-webdav
 RUN apk update
 RUN apk add perl
-# Install git, needed to fetch npm-server-webdav
 RUN apk add git
-# Expose port(s)
-EXPOSE 4000
-# Install dependencies
+
+# Install dependencies and build development
 WORKDIR /app
 RUN yarn
-# build
 RUN yarn build:dev
-# Start on excecution
+
+# Expose port, and provide start command on execution
+EXPOSE 4000
 CMD [ "yarn", "start:server" ]

--- a/conf/docker/server-prod.Dockerfile
+++ b/conf/docker/server-prod.Dockerfile
@@ -1,33 +1,33 @@
 FROM node:14.17.1-alpine AS base
-# Add a work directory
+# Add a work directory, copy package.json for caching, copy app files
 WORKDIR /app
-# Copy package.json for caching
 ADD package.json yarn.lock ./
-# Copy app files
 COPY . .
 
-# Build server from common base
-FROM base AS server-builder
 # Remove client files, except server.ts, to prevent duplication
 RUN rm -rf client/build
 RUN rm -rf client/node_modules
 RUN rm -rf client/public
 RUN find client/src -maxdepth 1 ! -path client/src/types ! -path client/src -type d -exec rm -rf {} +
 RUN find client -type f -not -name 'server.ts' -delete
-# Install git, needed to fetch npm-server-webdav
-RUN apk update
-RUN apk add git
-# Install dependencies (production mode) and build
-RUN yarn install --frozen-lockfile && yarn build:prod
 
-# Server's production image
-FROM node:14.17.1-alpine AS server
-# Add a work directory
+# Install perl, needed by exiftool, and git, needed to fetch npm-server-webdav
+RUN apk update
+RUN apk add perl
+RUN apk add git
+
+# Install dependencies and build production
 WORKDIR /app
-# Copy from server-builder
-COPY --from=server-builder /app/node_modules ./node_modules
-COPY --from=server-builder /app/server ./server
-# Expose port(s)
+RUN yarn install --frozen-lockfile
+RUN yarn build:prod
+
+# Server's production image; add a work directory and copy from base
+FROM node:14.17.1-alpine AS server
+WORKDIR /app
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/server ./server
+COPY --from=base /app/client ./client
+
+# Expose port, and provide start command on execution
 EXPOSE 4000
-# Start on excecution
-CMD [ "node", "server/build/index.js" ]
+CMD [ "node", "server/build/server/index.js" ]

--- a/server/package.json
+++ b/server/package.json
@@ -22,13 +22,13 @@
       "url": "https://github.com/karanpratapsingh"
     }
   ],
-  "main": "build/index.js",
-  "typings": "build/index.d.ts",
+  "main": "build/server/index.js",
+  "typings": "build/server/index.d.ts",
   "scripts": {
     "start": "nodemon --ignore var/ --ignore build/ --ignore coverage/ --ignore node_modules/ --ignore tests/ --exec yarn ts-node index.ts -e ts,js,json,graphql",
-    "start:prod": "node build/index.js",
-    "build:dev": "tsc --build && copyfiles db/**/*.* graphql/**/**.graphql build/",
-    "build:prod": "tsc --build && copyfiles db/**/*.* graphql/**/**.graphql build/",
+    "start:prod": "node build/server/index.js",
+    "build:dev": "tsc --build && copyfiles db/**/*.* graphql/**/**.graphql build/server/",
+    "build:prod": "tsc --build && copyfiles db/**/*.* graphql/**/**.graphql build/server/",
     "clean": "rm -rf node_modules/ build/",
     "generate": "graphql-codegen --config ./graphql/codegen.yml && npx prisma db pull --schema=./db/prisma/schema.prisma && npx prisma generate --schema=./db/prisma/schema.prisma",
     "generate:graphql": "npx graphql-codegen --config ./graphql/codegen.yml",


### PR DESCRIPTION
Build:
* Update server's prod and dev dockerfile, rationalizing/eliminating unneeded differences between the two
* Copy trimmed client logic from "base" image to server-prod image
* Use correct entry point for server app - server/build/server/index.js
* Updated server package.json to reflect updated location of build server output (build/server) now that we're depending on a file in the client source tree for server builds (for shared definitions)

Metadata:
* First try to import ExtractorImageExiftool.ts; if that fails, fall back to ExtractorImageExiftool.js -- this is necessary in production builds.