### PR TITLE
Go-live fix for production access to storage

### DIFF
--- a/server/storage/impl/LocalStorage/SharedTypes.ts
+++ b/server/storage/impl/LocalStorage/SharedTypes.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 export const OCFLStorageRootNamasteFilename: string = '0=ocfl_1.0';
 export const OCFLStorageRootLayoutFilename: string = 'ocfl_layout.json';
 export const OCFLStorageRootSpecFilename: string = 'ocfl_1.0.html';
@@ -9,6 +11,6 @@ export const OCFLStorageObjectContentFolder: string = 'content';
 export const OCFLStorageObjectInventoryFilename: string = 'inventory.json';
 export const OCFLStorageObjectInventoryDigestFilename: string = 'inventory.json.' + OCFLDigestAlgorithm;
 
-export const OCFLSourceDocsPath: string =  './assets/storage/';
+export const OCFLSourceDocsPath: string =  path.join(__dirname, '../../../assets/storage');
 
 export const OCFLMetadataFilename: string = '0=metadata.json';


### PR DESCRIPTION
Storage:
* Update location of OCFL source docs to be a relative path from the location of SharedTypes.ts, instead of a hard-coded, relative path from an assumed working directory