### PR TITLE
546 + UI Tweaks

### DIFF
--- a/client/src/components/controls/DateInputField.tsx
+++ b/client/src/components/controls/DateInputField.tsx
@@ -17,8 +17,7 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         background: palette.background.paper,
         border: ({ updated }: DateInputFieldProps) => `1px solid ${fade(updated ? palette.secondary.main : palette.primary.contrastText, 0.4)}`,
         backgroundColor: ({ updated }: DateInputFieldProps) => (updated ? palette.secondary.light : palette.background.paper),
-        paddingLeft: '10px',
-        paddingRight: '10px',
+
         color: Colors.defaults.white,
         marginTop: 0,
         fontFamily: typography.fontFamily,
@@ -27,12 +26,12 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         },
         [breakpoints.down('lg')]: {
             '& > div':  {
-                width: '97px'
+                width: '117px'
             }
         },
         [breakpoints.up('xl')]: {
             '& > div': {
-                width: '114px'
+                width: '134px'
             }
         },
         borderRadius: 5,
@@ -68,7 +67,7 @@ function DateInputField(props: DateInputFieldProps): React.ReactElement {
                 InputProps={{ disableUnderline: true, style: { height: '100%' } }}
                 onChange={onChange}
                 autoOk
-                inputProps={{ style: { alignSelf: 'center' } }}
+                inputProps={{ style: { alignSelf: 'center', paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                 KeyboardButtonProps={{ style: { padding: 0 }, size: 'small' }}
             />
         </MuiPickersUtilsProvider>

--- a/client/src/components/controls/SelectField.tsx
+++ b/client/src/components/controls/SelectField.tsx
@@ -15,7 +15,6 @@ import FieldType from '../shared/FieldType';
 export const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     select: {
         width: ({ selectFitContent }: SelectFieldProps) => selectFitContent ? 'fit-content' : '54%',
-        padding: '0px 10px',
         background: palette.background.paper,
         border: ({ updated }: SelectFieldProps) => `1px solid ${fade(updated ? palette.secondary.main : palette.primary.contrastText, 0.4)}`,
         backgroundColor: ({ updated }: SelectFieldProps) => (updated ? palette.secondary.light : palette.background.paper),
@@ -70,7 +69,7 @@ function SelectField(props: SelectFieldProps): React.ReactElement {
             padding={padding}
             gridGap={gridGap}
         >
-            <Select value={value || ''} className={classes.select} name={name} onChange={onChange} disabled={disabled} disableUnderline inputProps={{ 'title': `${name} select`, style: { width: '100%' } }}>
+            <Select value={value || ''} className={classes.select} name={name} onChange={onChange} disabled={disabled} disableUnderline inputProps={{ 'title': `${name} select`, style: { width: '100%' } }} SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}>
                 {options.map(({ idVocabulary, Term }, index) => (
                     <MenuItem key={index} value={idVocabulary}>
                         {Term}

--- a/client/src/components/shared/DataGridWithPagination.tsx
+++ b/client/src/components/shared/DataGridWithPagination.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { DataGrid, GridColumns, GridSortModel, GridSortModelParams, GridPageChangeParams } from '@material-ui/data-grid';
 import { useHistory } from 'react-router-dom';
 
-const useStyles = makeStyles(({ palette, breakpoints, typography }) => ({
+const useStyles = makeStyles(({ palette, typography }) => ({
     Container: {
         display: 'flex',
         flex: 1,
@@ -81,13 +81,9 @@ const useStyles = makeStyles(({ palette, breakpoints, typography }) => ({
         width: 'fit-content',
         height: 30,
         marginLeft: 10,
-        padding: '0px 5px',
         color: palette.primary.dark,
         borderRadius: 5,
-        border: `0.5px solid ${palette.primary.contrastText}`,
-        [breakpoints.down('lg')]: {
-            height: 26
-        }
+        border: `0.5px solid ${palette.primary.contrastText}`
     },
     searchFilter: {
         width: '380px'
@@ -220,6 +216,7 @@ function DataGridWithPagination(props: DataGridWithPaginationProps): React.React
                                     onChange={handleDropDown}
                                     id='searchDropdown'
                                     disableUnderline
+                                    SelectDisplayProps={{ style: { paddingLeft: '5px', borderRadius: '5px' } }}
                                 >
                                     {DropDown.options.map(option => (
                                         <MenuItem value={option.value} key={option.value}>

--- a/client/src/components/shared/IdentifierList.tsx
+++ b/client/src/components/shared/IdentifierList.tsx
@@ -21,8 +21,7 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     identifierInput: {
         width: '75%',
         border: 'none',
-        padding: '0px 2px',
-        paddingBottom: 5,
+        padding: '5px 2px 5px 2px',
         backgroundColor: 'transparent',
         fontSize: '0.8em',
         fontWeight: typography.fontWeightRegular,
@@ -37,7 +36,7 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     },
     identifierSelect: {
         width: 'fit-content',
-        padding: '0px 10px',
+        padding: 0,
         marginLeft: 20,
         background: palette.background.paper,
         border: `1px solid ${fade(palette.primary.contrastText, 0.4)}`,
@@ -121,7 +120,7 @@ function IdentifierList(props: IdentifierListProps): React.ReactElement {
                                 placeholder='Add new identifer'
                                 disabled={disabled}
                             />
-                            <Select value={identifierType} className={classes.identifierSelect} name='identifierType' onChange={update} disableUnderline disabled={disabled}>
+                            <Select value={identifierType} className={classes.identifierSelect} name='identifierType' onChange={update} disableUnderline disabled={disabled} SelectDisplayProps={{ style: { paddingLeft: '10px' } }}>
                                 {identifierTypes.map(({ idVocabulary, Term }, index) => (
                                     <MenuItem key={index} value={idVocabulary}>
                                         {Term}

--- a/client/src/global/datepicker.css
+++ b/client/src/global/datepicker.css
@@ -18,7 +18,8 @@
     border: 0px;
     padding: 0px 0px 0px 6px;
     background: none;
-    width: 100%;
+    width: 93%;
+    height: 23px;
 }
 .react-datepicker__input-container input:focus,
 .react-datepicker-ignore-onclickoutside {

--- a/client/src/pages/Admin/components/AdminSidebarMenu.tsx
+++ b/client/src/pages/Admin/components/AdminSidebarMenu.tsx
@@ -50,13 +50,11 @@ function AdminSidebarMenuRow({ path, selected }: { path: string; selected: boole
     const classes = useStyles();
 
     return (
-        <MenuItem className={classes.AdminSidebarMenuRow} selected={selected}>
-            <Link style={{ textDecoration: 'none', color: 'rgb(0, 110, 190)', width: '100%', height: '100%', fontSize: '0.875rem' }} to={`/admin/${path}`}>
-                <Typography variant='inherit' noWrap>
-                    {toTitleCase(path)}
-                </Typography>
-            </Link>
-        </MenuItem>
+        <Link style={{ textDecoration: 'none', color: 'rgb(0, 110, 190)', width: '100%', height: '100%', fontSize: '0.875rem' }} to={`/admin/${path}`}>
+            <MenuItem className={classes.AdminSidebarMenuRow} selected={selected}>
+                <Typography noWrap>{toTitleCase(path)}</Typography>
+            </MenuItem>
+        </Link>
     );
 }
 

--- a/client/src/pages/Admin/components/AdminUsersFilter.tsx
+++ b/client/src/pages/Admin/components/AdminUsersFilter.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { User_Status } from '../../../types/graphql';
 import { useHistory } from 'react-router-dom';
 
-const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
+const useStyles = makeStyles(({ typography, palette }) => ({
     searchUsersFilterButton: {
         backgroundColor: '#3854d0',
         color: 'white',
@@ -58,13 +58,9 @@ const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
         width: 'fit-content',
         height: 30,
         marginLeft: 10,
-        padding: '0px 5px',
         color: palette.primary.dark,
         borderRadius: 5,
-        border: `0.5px solid ${palette.primary.contrastText}`,
-        [breakpoints.down('lg')]: {
-            height: 26
-        }
+        border: `0.5px solid ${palette.primary.contrastText}`
     },
     labelSelectContainer: {
         display: 'flex',
@@ -114,6 +110,7 @@ function AdminUsersFilter({ queryUsersByFilter }: { queryUsersByFilter: (newActi
                             onChange={handleActiveStatusFilterChange}
                             name='activeStatus'
                             displayEmpty
+                            SelectDisplayProps={{ style: { paddingLeft: '5px', borderRadius: '5px' } }}
                         >
                             <MenuItem value={User_Status.EAll}>All</MenuItem>
                             <MenuItem value={User_Status.EActive}>Active</MenuItem>

--- a/client/src/pages/Admin/components/Subject/SubjectForm.tsx
+++ b/client/src/pages/Admin/components/Subject/SubjectForm.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/jsx-max-props-per-line, @typescript-eslint/no-explicit-any, react-hooks/exhaustive-deps*/
 
-import { Box, Button, Select, MenuItem } from '@material-ui/core';
+import { Box, Button, Select, MenuItem, Typography, Table, TableBody, TableCell, TableContainer, TableRow } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect, useState } from 'react';
-import { FieldType, InputField } from '../../../../components';
 import { useSubjectStore, StateIdentifier, useVocabularyStore, eObjectMetadataType, useObjectMetadataStore } from '../../../../store';
 import SearchList from '../../../Ingestion/components/SubjectItem/SearchList';
 import { RotationOriginInput, RotationQuaternionInput } from '../../../Repository/components/DetailsView/DetailsTab/SubjectDetails';
@@ -16,6 +15,9 @@ import { useHistory } from 'react-router-dom';
 import { CreateSubjectWithIdentifiersInput } from '../../../../types/graphql';
 import { Helmet } from 'react-helmet';
 import MetadataControlTable from '../../../Repository/components/DetailsView/DetailsTab/MetadataControlTable';
+import { DebounceInput } from 'react-debounce-input';
+import { useStyles as useTableStyles, updatedFieldStyling } from '../../../Repository/components/DetailsView/DetailsTab/CaptureDataDetails';
+import clsx from 'clsx';
 
 const useStyles = makeStyles(({ palette }) => ({
     container: {
@@ -75,6 +77,7 @@ export type CoordinateValues = {
 
 function SubjectForm(): React.ReactElement {
     const classes = useStyles();
+    const tableClasses = useTableStyles();
     const history = useHistory();
     const [subjectName, setSubjectName] = useState('');
     const [subjectUnit, setSubjectUnit] = useState(0);
@@ -298,32 +301,104 @@ function SubjectForm(): React.ReactElement {
             </Helmet>
             <Box className={classes.content}>
                 <SearchList EdanOnly />
-                <Box style={{ marginTop: '10px', marginBottom: '10px', width: '600px', backgroundColor: 'rgb(236, 245, 253)' }}>
-                    <InputField viewMode required label='Name' value={subjectName} name='Name' onChange={({ target }) => setSubjectName(target.value)} updated={!validName} valueLeftAligned gridLabel={2} />
-                    <FieldType width='auto' direction='row' label='Unit' required containerProps={{ justifyContent: 'space-between', marginBottom: '10px', alignItems: 'center' }} valueLeftAligned gridLabel={2}>
-                        <Select value={subjectUnit} onChange={handleUnitSelectChange} error={!validUnit} style={{ height: '21px' }}>
-                            <MenuItem value={0} key={0}>
-                                None
-                            </MenuItem>
-                            {unitList.map(unit => (
-                                <MenuItem value={unit.idUnit} key={unit.idUnit}>
-                                    {unit.Name}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </FieldType>
-                    <InputField viewMode required type='number' label='Latitude' value={coordinateValues.Latitude} name='Latitude' onChange={handleCoordinateChange} valueLeftAligned gridLabel={2} />
-                    <InputField viewMode required type='number' label='Longitude' value={coordinateValues.Longitude} name='Longitude' onChange={handleCoordinateChange} valueLeftAligned gridLabel={2} />
-                    <InputField viewMode required type='number' label='Altitude' value={coordinateValues.Altitude} name='Altitude' onChange={handleCoordinateChange} valueLeftAligned gridLabel={2} />
-                    <RotationOriginInput TS0={coordinateValues.TS0} TS1={coordinateValues.TS1} TS2={coordinateValues.TS2} onChange={handleCoordinateChange} ignoreUpdate />
-                    <RotationQuaternionInput
-                        R0={coordinateValues.R0}
-                        R1={coordinateValues.R1}
-                        R2={coordinateValues.R2}
-                        R3={coordinateValues.R3}
-                        onChange={handleCoordinateChange}
-                        ignoreUpdate
-                    />
+                <Box style={{ marginTop: '10px', marginBottom: '10px', width: '600px', backgroundColor: 'rgb(236, 245, 253)', paddingTop: '5px', paddingBottom: '5px', borderRadius: '5px' }}>
+                    <TableContainer>
+                        <Table>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell className={tableClasses.tableCell}>
+                                        <Typography className={clsx(tableClasses.labelText)}>Name</Typography>
+                                    </TableCell>
+                                    <TableCell className={clsx(tableClasses.tableCell, tableClasses.valueText)}>
+                                        <DebounceInput
+                                            element='input'
+                                            title='Name-input'
+                                            value={subjectName}
+                                            type='string'
+                                            name='Name'
+                                            className={tableClasses.input}
+                                            onChange={({ target }) => setSubjectName(target.value)}
+                                            style={{ ...updatedFieldStyling(!validName) }}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell className={tableClasses.tableCell}>
+                                        <Typography className={clsx(tableClasses.labelText)}>Unit</Typography>
+                                    </TableCell>
+                                    <TableCell className={clsx(tableClasses.tableCell, tableClasses.valueText)}>
+                                        <Select value={subjectUnit} onChange={handleUnitSelectChange} error={!validUnit} style={{ height: '18px', fontSize: '0.8rem' }} SelectDisplayProps={{ style: { paddingTop: 0, paddingBottom: 0, paddingLeft: '10px' } }}>
+                                            <MenuItem value={0} key={0}>
+                                                None
+                                            </MenuItem>
+                                            {unitList.map(unit => (
+                                                <MenuItem value={unit.idUnit} key={unit.idUnit}>
+                                                    {unit.Name}
+                                                </MenuItem>
+                                            ))}
+                                        </Select>
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell className={tableClasses.tableCell}>
+                                        <Typography className={tableClasses.labelText}>Latitude</Typography>
+                                    </TableCell>
+                                    <TableCell className={clsx(tableClasses.tableCell, tableClasses.valueText)}>
+                                        <DebounceInput
+                                            element='input'
+                                            title='Latitude-input'
+                                            value={coordinateValues.Latitude || ''}
+                                            type='number'
+                                            name='Latitude'
+                                            onChange={handleCoordinateChange}
+                                            className={tableClasses.input}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell className={tableClasses.tableCell}>
+                                        <Typography className={tableClasses.labelText}>Longitude</Typography>
+                                    </TableCell>
+                                    <TableCell className={clsx(tableClasses.tableCell, tableClasses.valueText)}>
+                                        <DebounceInput
+                                            element='input'
+                                            title='Longitude-input'
+                                            value={coordinateValues.Longitude || ''}
+                                            type='number'
+                                            name='Longitude'
+                                            onChange={handleCoordinateChange}
+                                            className={tableClasses.input}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell className={tableClasses.tableCell}>
+                                        <Typography className={tableClasses.labelText}>Altitude</Typography>
+                                    </TableCell>
+                                    <TableCell className={clsx(tableClasses.tableCell, tableClasses.valueText)}>
+                                        <DebounceInput
+                                            element='input'
+                                            title='Altitude-input'
+                                            value={coordinateValues.Altitude || ''}
+                                            type='number'
+                                            name='Altitude'
+                                            onChange={handleCoordinateChange}
+                                            className={tableClasses.input}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                                <RotationOriginInput TS0={coordinateValues.TS0} TS1={coordinateValues.TS1} TS2={coordinateValues.TS2} onChange={handleCoordinateChange} ignoreUpdate />
+                                <RotationQuaternionInput
+                                    R0={coordinateValues.R0}
+                                    R1={coordinateValues.R1}
+                                    R2={coordinateValues.R2}
+                                    R3={coordinateValues.R3}
+                                    onChange={handleCoordinateChange}
+                                    ignoreUpdate
+                                />
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
                 </Box>
                 <AssetIdentifiers
                     systemCreated={systemCreated}

--- a/client/src/pages/Ingestion/components/Metadata/Attachment/AttachmentMetadataForm.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Attachment/AttachmentMetadataForm.tsx
@@ -67,6 +67,7 @@ function AttachmentMetadataForm(props: AttachmentMetadataProps): React.ReactElem
                     onChange={setNameField}
                     disableUnderline
                     className={clsx(classes.select, classes.datasetFieldSelect)}
+                    color='primary'
                 >
                     {options.map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                 </Select>

--- a/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
@@ -352,6 +352,7 @@ function Model(props: ModelProps): React.ReactElement {
                                                     onChange={setIdField}
                                                     disableUnderline
                                                     className={clsx(tableClasses.select, tableClasses.datasetFieldSelect)}
+                                                    SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                                 >
                                                     {getEntries(eVocabularySetID.eModelCreationMethod).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                                 </Select>
@@ -366,6 +367,7 @@ function Model(props: ModelProps): React.ReactElement {
                                                     onChange={setIdField}
                                                     disableUnderline
                                                     className={clsx(tableClasses.select, tableClasses.datasetFieldSelect)}
+                                                    SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                                 >
                                                     {getEntries(eVocabularySetID.eModelModality).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                                 </Select>
@@ -380,6 +382,7 @@ function Model(props: ModelProps): React.ReactElement {
                                                     onChange={setIdField}
                                                     disableUnderline
                                                     className={clsx(tableClasses.select, tableClasses.datasetFieldSelect)}
+                                                    SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                                 >
                                                     {getEntries(eVocabularySetID.eModelUnits).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                                 </Select>
@@ -394,6 +397,7 @@ function Model(props: ModelProps): React.ReactElement {
                                                     onChange={setIdField}
                                                     disableUnderline
                                                     className={clsx(tableClasses.select, tableClasses.datasetFieldSelect)}
+                                                    SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                                 >
                                                     {getEntries(eVocabularySetID.eModelPurpose).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                                 </Select>
@@ -408,6 +412,7 @@ function Model(props: ModelProps): React.ReactElement {
                                                     onChange={setIdField}
                                                     disableUnderline
                                                     className={clsx(tableClasses.select, tableClasses.datasetFieldSelect)}
+                                                    SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                                 >
                                                     {getEntries(eVocabularySetID.eModelFileType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                                 </Select>

--- a/client/src/pages/Ingestion/components/Metadata/Photogrammetry/AssetContents.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Photogrammetry/AssetContents.tsx
@@ -20,7 +20,6 @@ export const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     },
     select: {
         height: 24,
-        padding: '0px 10px',
         background: palette.background.paper,
         border: `1px solid ${fade(palette.primary.contrastText, 0.4)}`,
         borderRadius: 5,
@@ -96,6 +95,7 @@ function AssetContents(props: AssetContentsProps): React.ReactElement {
                                             onChange={update}
                                             disableUnderline
                                             className={classes.select}
+                                            SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                         >
                                             {options.map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                         </Select>

--- a/client/src/pages/Ingestion/components/Metadata/Photogrammetry/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Photogrammetry/index.tsx
@@ -237,6 +237,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
                                         onChange={setIdField}
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetTypeSelect)}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataDatasetType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -283,6 +284,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
                                         onChange={setIdField}
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataItemPositionType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -331,6 +333,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
                                         onChange={setIdField}
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataFocusType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -347,6 +350,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
                                         onChange={setIdField}
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataLightSourceType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -363,6 +367,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
                                         onChange={setIdField}
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataBackgroundRemovalMethod).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -379,6 +384,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
                                         onChange={setIdField}
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataClusterType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>

--- a/client/src/pages/Ingestion/components/Metadata/Scene/SceneDataForm.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Scene/SceneDataForm.tsx
@@ -121,6 +121,7 @@ function SceneDataForm(props: SceneDataProps): React.ReactElement {
                                 checked={approvedForPublication}
                                 title='approvedForPublication-input'
                                 size='small'
+                                color='primary'
                             />
                         </TableCell>
                     </TableRow>
@@ -139,6 +140,7 @@ function SceneDataForm(props: SceneDataProps): React.ReactElement {
                                     checked={posedAndQCd}
                                     title='posedAndQCd-input'
                                     size='small'
+                                    color='primary'
                                 />
                             </Tooltip>
                         </TableCell>

--- a/client/src/pages/Ingestion/components/SubjectItem/ProjectList.tsx
+++ b/client/src/pages/Ingestion/components/SubjectItem/ProjectList.tsx
@@ -12,7 +12,6 @@ import { useProjectStore } from '../../../../store';
 const useStyles = makeStyles(({ palette }) => ({
     projectSelect: {
         width: '100%',
-        padding: '0px 10px',
         backgroundColor: palette.background.paper,
         fontSize: '0.8em'
     }
@@ -35,6 +34,7 @@ function ProjectList(): React.ReactElement {
             renderValue={() => `${selectedProject?.name || 'none'}`}
             onChange={({ target: { value } }) => updateSelectedProject(value as number)}
             disableUnderline
+            SelectDisplayProps={{ style: { paddingLeft: '5px' } }}
         >
             <MenuItem value='none'>none</MenuItem>
             {uniqueSortedProjects.map(({ id, name }, index: number) => <MenuItem key={index} value={id}>{name}</MenuItem>)}

--- a/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
@@ -92,7 +92,6 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     typeSelect: {
         maxWidth: 250,
         minWidth: 250,
-        padding: '0px 4px',
         borderRadius: 5,
         fontSize: '0.8rem',
         border: `1px solid ${fade(palette.primary.main, 0.3)}`,
@@ -225,13 +224,13 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
     // completed list || pending list
     if (idAsset || (uploadPendingList && mode === String(eIngestionMode.eUpdate))) {
         content =  (
-            <Select value={updateWorkflowFileType || type} disabled className={classes.typeSelect} disableUnderline>
+            <Select value={updateWorkflowFileType || type} disabled className={classes.typeSelect} disableUnderline SelectDisplayProps={{ style: { paddingLeft: '5px', borderRadius: '5px' } }}>
                 <MenuItem value={updateWorkflowFileType || type}>Update</MenuItem>
             </Select>
         );
     } else if (idSOAttachment || (uploadPendingList && mode === String(eIngestionMode.eAttach))) {
         content = (
-            <Select value={updateWorkflowFileType || type} disabled className={classes.typeSelect} disableUnderline>
+            <Select value={updateWorkflowFileType || type} disabled className={classes.typeSelect} disableUnderline SelectDisplayProps={{ style: { paddingLeft: '5px', borderRadius: '5px' } }}>
                 <MenuItem value={updateWorkflowFileType || type}>Attachment</MenuItem>
             </Select>
         );
@@ -243,6 +242,7 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
                 className={classes.typeSelect}
                 onChange={({ target: { value } }) => onChangeType(id, value as number)}
                 disableUnderline
+                SelectDisplayProps={{ style: { paddingLeft: '5px', borderRadius: '5px' } }}
             >
                 {typeOptions.map((option: VocabularyOption, index) => (
                     <MenuItem key={index} value={option.idVocabulary}>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetVersionsTable.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetVersionsTable.tsx
@@ -139,6 +139,7 @@ function AssetVersionsTable(props: AssetVersionsTableProps): React.ReactElement 
                                     <CheckboxNoPadding
                                         disabled
                                         checked={version.ingested ?? false}
+                                        color='primary'
                                     />
                                 </td>
                                 <td>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
@@ -58,7 +58,6 @@ export const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     },
     select: {
         height: 24,
-        padding: '0px 10px',
         background: palette.background.paper,
         border: `1px solid ${fade(palette.primary.contrastText, 0.4)}`,
         borderRadius: 5,
@@ -66,9 +65,9 @@ export const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         fontSize: '0.8rem'
     },
     checkbox: {
-        border: '0px',
+        border: 'none !important',
         padding: '0px',
-        height: '16px',
+        height: '18px',
     },
     input: {
         height: 22,
@@ -225,6 +224,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetTypeSelect)}
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'datasetType')) }}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataDatasetType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -277,6 +277,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'itemPositionType')) }}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataItemPositionType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -331,6 +332,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'focusType')) }}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataFocusType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -349,6 +351,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'lightsourceType')) }}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataLightSourceType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -367,6 +370,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'backgroundRemovalMethod')) }}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataBackgroundRemovalMethod).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -385,6 +389,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disableUnderline
                                         className={clsx(classes.select, classes.datasetFieldSelect)}
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'clusterType')) }}
+                                        SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
                                     >
                                         {getEntries(eVocabularySetID.eCaptureDataClusterType).map(({ idVocabulary, Term }, index) => <MenuItem key={index} value={idVocabulary}>{Term}</MenuItem>)}
                                     </Select>
@@ -422,6 +427,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                         disabled={disabled}
                                         size='small'
                                         style={{ ...updatedFieldStyling(isFieldUpdated(CaptureDataDetails, captureDataData, 'cameraSettingUniform')) }}
+                                        color='primary'
                                     />
                                 </TableCell>
                             </TableRow>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/ModelDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/ModelDetails.tsx
@@ -240,7 +240,7 @@ function SelectField(props: SelectFieldProps): React.ReactElement {
                     {label}
                 </Typography>
             </div>
-            <Select value={value || ''} className={classes.select} name={name} onChange={onChange} disabled={disabled} disableUnderline inputProps={{ 'title': `${name} select`, style: { width: '100%' } }} style={{ minWidth: '100%', width: 'fit-content' }}>
+            <Select value={value || ''} className={classes.select} name={name} onChange={onChange} disabled={disabled} disableUnderline inputProps={{ 'title': `${name} select`, style: { width: '100%' } }} style={{ minWidth: '100%', width: 'fit-content' }} SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}>
                 {options.map(({ idVocabulary, Term }, index) => (
                     <MenuItem key={index} value={idVocabulary}>
                         {Term}

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/ObjectVersionTable.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/ObjectVersionTable.tsx
@@ -24,7 +24,8 @@ interface ObjectVersionsTableProps {
 
 interface headerColumn {
     name: string;
-    width: number | string;
+    width?: number | string;
+    flex?: string;
 }
 
 function ObjectVersionsTable(props: ObjectVersionsTableProps): React.ReactElement {
@@ -35,7 +36,24 @@ function ObjectVersionsTable(props: ObjectVersionsTableProps): React.ReactElemen
     const [expanded, setExpanded] = useState<number>(-1);
     const [rollbackNotes, setRollbackNotes] = useState<string>('');
 
-    const headers: headerColumn[] = [{ name: 'Date', width: '10%' }, { name: 'Link', width: '5%' }, { name: 'Published State', width: '15%' }, { name: 'Action', width: '10%' }, { name: 'Notes', width: '60%' }];
+    const headers: headerColumn[] = [
+        {
+            name: 'Link',
+            width: '30px',
+        }, {
+            name: 'Date',
+            width: '70px',
+        }, {
+            name: 'Published State',
+            width: '110px',
+        }, {
+            name: 'Action',
+            width: '70px',
+        },{
+            name: 'Notes',
+            flex: '1'
+        }
+    ];
 
 
     const { data } = useObjectAssets(idSystemObject);
@@ -77,9 +95,9 @@ function ObjectVersionsTable(props: ObjectVersionsTableProps): React.ReactElemen
         <Box style={{ minWidth: '620px' }}>
             <table className={classes.container} style={{ tableLayout: 'fixed', borderCollapse: 'collapse' }}>
                 <thead>
-                    <tr style={{ width: '100%', borderBottom: '1px solid grey' }}>
-                        {headers.map(({ name, width }, index: number) => (
-                            <th key={index} align='center' style={{ width, padding: 5 }}>
+                    <tr style={{ borderBottom: '1px solid grey' }}>
+                        {headers.map(({ name, width, flex }, index: number) => (
+                            <th key={index} align='center' style={{ width, padding: 5, flex }}>
                                 <Typography className={classes.header}>{name}</Typography>
                             </th>
                         ))}
@@ -107,15 +125,15 @@ function ObjectVersionsTable(props: ObjectVersionsTableProps): React.ReactElemen
                             <React.Fragment key={index}>
                                 <tr key={index}>
                                     <td align='center' style={{ padding: 0 }}>
-                                        <Typography className={clsx(classes.value)}>{extractISOMonthDateYear(version.DateCreated)}</Typography>
-                                    </td>
-                                    <td align='center' style={{ padding: 0 }}>
                                         <a
                                             href={getDownloadObjectVersionUrlForObject(serverEndpoint, version.idSystemObjectVersion)}
                                             style={{ textDecoration: 'none', color: 'black', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                                         >
                                             <GetAppIcon />
                                         </a>
+                                    </td>
+                                    <td align='center' style={{ padding: 0 }}>
+                                        <Typography className={clsx(classes.value)}>{extractISOMonthDateYear(version.DateCreated)}</Typography>
                                     </td>
                                     <td align='center' style={{ padding: 0 }}>
                                         <Typography className={clsx(classes.value)}>{PublishedStateEnumToString(version.PublishedState)}</Typography>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SubjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SubjectDetails.tsx
@@ -91,6 +91,7 @@ export function SubjectFields(props: SubjectFieldsProps): React.ReactElement {
                                             disabled={disabled}
                                             size='small'
                                             style={{ ...updatedFieldStyling(isFieldUpdated(ItemDetails, itemData, 'EntireSubject')) }}
+                                            color='primary'
                                         />
                                     </TableCell>
                                 </TableRow>

--- a/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
@@ -258,6 +258,7 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
                             checked={withDefaultValueBoolean(retired, false)}
                             onChange={onRetiredUpdate}
                             {...getUpdatedCheckboxProps(isRetiredUpdated)}
+                            color='primary'
                         />
                     }
                 />

--- a/client/src/pages/Repository/components/RepositoryFilterView/FilterSelect.tsx
+++ b/client/src/pages/Repository/components/RepositoryFilterView/FilterSelect.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles(({ palette, breakpoints }) => ({
         width: 160,
         height: 30,
         marginLeft: 10,
-        padding: '0px 1.5px',
         fontSize: '0.8em',
         color: palette.primary.dark,
         borderRadius: 5,
@@ -86,6 +85,7 @@ function FilterSelect(props: FilterSelectProps): React.ReactElement {
                         return (selected as string[]).join(', ');
                     }}
                     displayEmpty
+                    SelectDisplayProps={{ style: { borderRadius: '5px' } }}
                 >
                     {options.map(({ label, value }: FilterOption, index) => {
                         return (
@@ -105,6 +105,7 @@ function FilterSelect(props: FilterSelectProps): React.ReactElement {
                     onChange={onChange}
                     disableUnderline
                     inputProps={inputProps}
+                    SelectDisplayProps={{ style: { borderRadius: '5px' } }}
                 >
                     {options.map(({ label, value }: FilterOption, index) => (
                         <MenuItem key={index} value={value}>

--- a/client/src/pages/Workflow/components/WorkflowView/WorkflowFilter.tsx
+++ b/client/src/pages/Workflow/components/WorkflowView/WorkflowFilter.tsx
@@ -33,7 +33,6 @@ const useStyles = makeStyles(({ palette }) => ({
         width: 160,
         height: 30,
         marginLeft: 10,
-        padding: '0px 5px',
         fontSize: '0.8em',
         color: palette.primary.dark,
         borderRadius: 5,
@@ -43,7 +42,6 @@ const useStyles = makeStyles(({ palette }) => ({
         width: 223,
         height: 30,
         marginLeft: 10,
-        padding: '0px 5px',
         fontSize: '0.8em',
         color: palette.primary.dark,
         borderRadius: 5,
@@ -178,6 +176,7 @@ function FilterSelect(props: FilterSelectProps): React.ReactElement {
                 disableUnderline
                 inputProps={inputProps}
                 id={name}
+                SelectDisplayProps={{ style: { paddingLeft: '5px' } }}
             >
                 {options.map(({ label, value }: FilterOption, index) => (
                     <MenuItem key={index} value={value}>

--- a/client/src/theme/typography.ts
+++ b/client/src/theme/typography.ts
@@ -76,6 +76,13 @@ function createOverrides(): Overrides {
             root: {
                 outline: '0.5px hidden rgba(141, 171, 196, 0.4)'
             }
+        },
+        MuiSelect: {
+            select: {
+                '&:focus': {
+                    backgroundColor: undefined
+                }
+            }
         }
     };
 }

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -231,7 +231,7 @@ export function getObjectInterfaceDetails(objectType: eSystemObjectType, variant
             aria-label={`link to view system object of id ${idSystemObject}`}
             style={{ textDecoration: 'none', color: 'black' }}
         >
-            <AiOutlineFileText />
+            <AiOutlineFileText style={{ verticalAlign: 'bottom' }} />
         </a>
     );
 


### PR DESCRIPTION
-Address the difference between the input area and effective area for dropdown/selects and have them overlap properly
-Address background color when dropdown/select is in focus
-Vertically align repository icon for asset and asset version
-Table-fy create subject form inputs
-Change padding for identifier text input
-Adjusted column widths for object versions and reordered "Date" and "Link"