### PR TITLE
Prod Server & Proxy Container Fixes

### DIFF
--- a/conf/docker/proxy-prod.Dockerfile
+++ b/conf/docker/proxy-prod.Dockerfile
@@ -2,4 +2,10 @@ FROM nginx:1.17.10 as proxy
 EXPOSE 80
 RUN rm /usr/share/nginx/html/*
 COPY ./conf/nginx/nginx-prod.conf /etc/nginx/nginx.conf
+COPY ./conf/nginx/conf.d/common-locations-prod /etc/nginx/conf.d/common-locations-prod
+COPY ./conf/nginx/conf.d/common-locations-dev /etc/nginx/conf.d/common-locations-dev
+COPY ./conf/nginx/certs/packrat.si.edu.cert /etc/pki/tls/certs/packrat.si.edu.cert
+COPY ./conf/nginx/certs/packrat-test.si.edu.cert /etc/pki/tls/certs/packrat-test.si.edu.cert
+COPY ./conf/nginx/keys/packrat.si.edu.key /etc/pki/tls/private/packrat.si.edu.key
+COPY ./conf/nginx/keys/packrat-test.si.edu.key /etc/pki/tls/private/packrat-test.si.edu.key
 CMD ["nginx", "-g", "daemon off;"]

--- a/conf/docker/server-prod.Dockerfile
+++ b/conf/docker/server-prod.Dockerfile
@@ -13,15 +13,16 @@ RUN apk add perl
 RUN apk add git
 
 # Install dependencies and build production
-RUN mkdir -p /app/node_modules/@dpo-packrat/ && ln -s /app/common /app/node_modules/@dpo-packrat/common
 RUN yarn install --frozen-lockfile
 RUN yarn build:prod
 
 # Server's production image; add a work directory and copy from base
 FROM node:14.17.1-alpine AS server
 WORKDIR /app
-COPY --from=base /app/node_modules ./node_modules
 COPY --from=base /app/server ./server
+COPY --from=base /app/common ./common
+COPY --from=base /app/node_modules ./node_modules
+RUN mkdir -p /app/node_modules/@dpo-packrat/ && ln -s /app/common /app/node_modules/@dpo-packrat/common
 
 # Expose port, and provide start command on execution
 EXPOSE 4000

--- a/server/metadata/MetadataExtractor.ts
+++ b/server/metadata/MetadataExtractor.ts
@@ -74,10 +74,12 @@ export class MetadataExtractor {
             return results;
 
         try {
-            // try to load .ts first, then fall back to .js ... needed for production builds!
-            let exifModule: ExifModule | null = await this.importModule(path.join(__dirname, 'ExtractorImageExiftool.ts'), false);
-            if (!exifModule)
-                exifModule = await this.importModule(path.join(__dirname, 'ExtractorImageExiftool.js'), true);
+            const exifModule: ExifModule | null = await this.importModule(path.join(__dirname, 'ExtractorImageExiftool.ts'), false);
+            // Disabled for now, as importing ExtractorImageExiftool.ts seems to cause the current thread to never complete, or perhaps exit
+            // // try to load .ts first, then fall back to .js ... needed for production builds!
+            // let exifModule: ExifModule | null = await this.importModule(path.join(__dirname, 'ExtractorImageExiftool.ts'), false);
+            // if (!exifModule)
+            //     exifModule = await this.importModule(path.join(__dirname, 'ExtractorImageExiftool.js'), true);
             if (exifModule) {
                 const extractor: IExtractor = new exifModule.ExtractorImageExiftool();
                 results = await extractor.initialize();
@@ -87,7 +89,7 @@ export class MetadataExtractor {
                     return results;
                 }
             }
-            LOG.info(`MetadataExtractor.initializeExtractorImage failed to initialize exiftool: ${results.error}`, LOG.LS.eMETA);
+            LOG.info(`MetadataExtractor.initializeExtractorImage failed to initialize exiftool: ${results.error ?? 'ExtractorImageExiftool import failed'}`, LOG.LS.eMETA);
         } catch (err) {
             LOG.error('MetadataExtractor.initializeExtractorImage failed to initialize exiftool', LOG.LS.eMETA, err);
         }


### PR DESCRIPTION
Build:
* In prod server container definition, copy common source, and create a link from /app/node_modules/@dpo-packrat/common to /app/common, to enable resolution of @dpo-packrat/common references
* Copy nginx configuration, certs, and keys in prod container setup.  Note that the certs and keys are not committed to our source vault and must be staged in the conf/nginx/certs and conf/nginx/keys folders.

Metadata:
* For now, if importing ExtractorImageExiftool.ts fails, do not attempt to import ExtractorImageExiftool.js -- this import seems to never return in our production container.  More work is needed here