### PR TITLE
Prod Proxy CI container fix

### DIFF
--- a/conf/docker/proxy-prod.Dockerfile
+++ b/conf/docker/proxy-prod.Dockerfile
@@ -4,8 +4,8 @@ RUN rm /usr/share/nginx/html/*
 COPY ./conf/nginx/nginx-prod.conf /etc/nginx/nginx.conf
 COPY ./conf/nginx/conf.d/common-locations-prod /etc/nginx/conf.d/common-locations-prod
 COPY ./conf/nginx/conf.d/common-locations-dev /etc/nginx/conf.d/common-locations-dev
-COPY ./conf/nginx/certs/packrat.si.edu.cert /etc/pki/tls/certs/packrat.si.edu.cert
-COPY ./conf/nginx/certs/packrat-test.si.edu.cert /etc/pki/tls/certs/packrat-test.si.edu.cert
-COPY ./conf/nginx/keys/packrat.si.edu.key /etc/pki/tls/private/packrat.si.edu.key
-COPY ./conf/nginx/keys/packrat-test.si.edu.key /etc/pki/tls/private/packrat-test.si.edu.key
+# COPY ./conf/nginx/certs/packrat.si.edu.cert /etc/pki/tls/certs/packrat.si.edu.cert
+# COPY ./conf/nginx/certs/packrat-test.si.edu.cert /etc/pki/tls/certs/packrat-test.si.edu.cert
+# COPY ./conf/nginx/keys/packrat.si.edu.key /etc/pki/tls/private/packrat.si.edu.key
+# COPY ./conf/nginx/keys/packrat-test.si.edu.key /etc/pki/tls/private/packrat-test.si.edu.key
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Build:
* Disable specification of certs and keys in prod proxy Dockerfile -- these files are not checked in, and github CI attempts to construct this proxy container ... which in turn fails if the file is missing