### PR TITLE
Fix for 552:  compute and display update context when uploading an update to an existing asset/object

### DIFF
--- a/client/src/pages/Ingestion/components/Uploads/FileList.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/FileList.tsx
@@ -33,7 +33,7 @@ function FileList(props: FileListProps): React.ReactElement {
 
     const onSelect = (id: FileId, selected: boolean): void => selectFile(id, selected);
 
-    const getFileList = ({ id, name, size, status, selected, progress, type, idAsset, idSOAttachment }: IngestionFile, index: number) => {
+    const getFileList = ({ id, name, size, status, selected, progress, type, idAsset, idSOAttachment, updateContext }: IngestionFile, index: number) => {
         const uploading = (status === FileUploadStatus.UPLOADING || status === FileUploadStatus.PROCESSING);
         const complete = status === FileUploadStatus.COMPLETE;
         const failed = status === FileUploadStatus.FAILED;
@@ -48,6 +48,7 @@ function FileList(props: FileListProps): React.ReactElement {
                     name={name}
                     size={size}
                     type={type}
+                    updateContext={updateContext}
                     typeOptions={typeOptions}
                     selected={selected}
                     uploading={uploading}

--- a/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
@@ -59,7 +59,15 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         fontWeight: typography.fontWeightMedium,
         color: 'black',
         zIndex: 'inherit',
-        wordBreak: 'break-all'
+        wordBreak: 'break-all',
+    },
+    updateContext: {
+        fontWeight: typography.fontWeightLight,
+        fontStyle: 'italic',
+        color: 'black',
+        zIndex: 'inherit',
+        wordBreak: 'break-all',
+        display: 'flex',
     },
     status: {
         display: 'flex',
@@ -145,6 +153,7 @@ interface FileListItemProps {
     idAsset: number | undefined;
     idSOAttachment: number | undefined;
     uploadPendingList: boolean | undefined;
+    updateContext: string | undefined;
     onSelect: (id: FileId, selected: boolean) => void;
     onUpload: (id: FileId) => void;
     onCancel: (id: FileId) => void;
@@ -169,6 +178,7 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
         idAsset,
         idSOAttachment,
         uploadPendingList,
+        updateContext,
         onChangeType,
         onUpload,
         onCancel,
@@ -262,6 +272,13 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
                             {name}
                         </Typography>
                     </Box>
+                    {(updateContext &&
+                        <Box>
+                            <Typography className={classes.updateContext} variant='caption'>
+                                {updateContext}
+                            </Typography>
+                        </Box>
+                    )}
                     <Box display='flex'>
                         <Box className={classes.status}>
                             <Typography className={classes.caption} variant='caption'>

--- a/client/src/pages/Ingestion/components/Uploads/UploadCompleteList.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/UploadCompleteList.tsx
@@ -71,17 +71,24 @@ function UploadCompleteList(props: UploadListCompleteProps): React.ReactElement 
             if (!sortedAssetVersion)
                 return;
 
+            const UpdatedAssetVersionMetadataMap: Map<number, any> = new Map<number, any>();
+            for (const updatedMetadata of UpdatedAssetVersionMetadata) {
+                if (updatedMetadata.idAssetVersion)
+                    UpdatedAssetVersionMetadataMap.set(updatedMetadata.idAssetVersion, updatedMetadata);
+            }
+
             const completedFiles = sortedAssetVersion.map(assetVersion => {
                 const { idAssetVersion } = assetVersion;
                 const id = String(idAssetVersion);
+                const updatedMetadata = UpdatedAssetVersionMetadataMap.get(idAssetVersion);
+                const updateMediaGroup: string | undefined = updatedMetadata && updatedMetadata.Item ? ` for Media Group ${updatedMetadata.Item.Name}` : undefined;
+                const updateContext: string | undefined = updatedMetadata ? `(Updating ${updatedMetadata.UpdatedObjectName}${updateMediaGroup})` : undefined;
 
                 if (fileIds.includes(id))
                     return completed.find(file => file.id === id) || assetVersion;
 
-                let idAsset = null;
-                if (idAssetVersionsUpdatedSet.has(idAssetVersion))
-                    idAsset = assetVersion.Asset.idAsset;
-                return parseAssetVersionToState(assetVersion, assetVersion.Asset.VAssetType, idAsset);
+                const idAsset = idAssetVersionsUpdatedSet.has(idAssetVersion) ? assetVersion.Asset.idAsset : null;
+                return parseAssetVersionToState(assetVersion, assetVersion.Asset.VAssetType, idAsset, updateContext);
             });
 
             loadCompleted(completedFiles, refetch);

--- a/client/src/store/upload.ts
+++ b/client/src/store/upload.ts
@@ -41,6 +41,7 @@ export type IngestionFile = {
     cancel: (() => void) | null;
     idAsset?: number;
     idSOAttachment?: number;
+    updateContext?: string;
 };
 
 type UploadStore = {

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -52,7 +52,8 @@ export function parseProjectToState(project: Project, selected: boolean): StateP
     };
 }
 
-export function parseAssetVersionToState(assetVersion: AssetVersion, vocabulary: Vocabulary, idAsset: number | null = null): IngestionFile {
+export function parseAssetVersionToState(assetVersion: AssetVersion, vocabulary: Vocabulary,
+    idAsset: number | null, updateContext: string | undefined): IngestionFile {
     const { idAssetVersion, StorageSize, FileName, idSOAttachment } = assetVersion;
     const { idVocabulary } = vocabulary;
 
@@ -66,7 +67,8 @@ export function parseAssetVersionToState(assetVersion: AssetVersion, vocabulary:
         status: FileUploadStatus.COMPLETE,
         progress: 100,
         selected: false,
-        cancel: null
+        cancel: null,
+        updateContext
     };
     if (idAsset) result.idAsset = idAsset;
     if (idSOAttachment) result.idSOAttachment = idSOAttachment;

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -734,6 +734,8 @@ export type UpdateSceneMetadata = {
 export type UpdatedAssetVersionMetadata = {
   __typename?: 'UpdatedAssetVersionMetadata';
   idAssetVersion: Scalars['Int'];
+  UpdatedObjectName: Scalars['String'];
+  Item?: Maybe<Item>;
   CaptureDataPhoto?: Maybe<UpdatePhotogrammetryMetadata>;
   Model?: Maybe<UpdateModelMetadata>;
   Scene?: Maybe<UpdateSceneMetadata>;
@@ -3282,8 +3284,11 @@ export type GetUploadedAssetVersionQuery = (
       )> }
     )>, UpdatedAssetVersionMetadata: Array<(
       { __typename?: 'UpdatedAssetVersionMetadata' }
-      & Pick<UpdatedAssetVersionMetadata, 'idAssetVersion'>
-      & { CaptureDataPhoto?: Maybe<(
+      & Pick<UpdatedAssetVersionMetadata, 'idAssetVersion' | 'UpdatedObjectName'>
+      & { Item?: Maybe<(
+        { __typename?: 'Item' }
+        & Pick<Item, 'Name'>
+      )>, CaptureDataPhoto?: Maybe<(
         { __typename?: 'UpdatePhotogrammetryMetadata' }
         & Pick<UpdatePhotogrammetryMetadata, 'name' | 'dateCaptured' | 'datasetType' | 'description' | 'cameraSettingUniform' | 'datasetFieldId' | 'itemPositionType' | 'itemPositionFieldId' | 'itemArrangementFieldId' | 'focusType' | 'lightsourceType' | 'backgroundRemovalMethod' | 'clusterType' | 'clusterGeometryFieldId'>
         & { folders: Array<(
@@ -5529,6 +5534,10 @@ export const GetUploadedAssetVersionDocument = gql`
     idAssetVersionsUpdated
     UpdatedAssetVersionMetadata {
       idAssetVersion
+      UpdatedObjectName
+      Item {
+        Name
+      }
       CaptureDataPhoto {
         name
         dateCaptured

--- a/server/graphql/api/queries/asset/getUploadedAssetVersion.ts
+++ b/server/graphql/api/queries/asset/getUploadedAssetVersion.ts
@@ -21,6 +21,10 @@ const getUploadedAssetVersion = gql`
             idAssetVersionsUpdated
             UpdatedAssetVersionMetadata {
                 idAssetVersion
+                UpdatedObjectName
+                Item {
+                    Name
+                }
                 CaptureDataPhoto {
                     name
                     dateCaptured

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -332,6 +332,8 @@ type UpdateSceneMetadata {
 
 type UpdatedAssetVersionMetadata {
   idAssetVersion: Int!
+  UpdatedObjectName: String!
+  Item: Item
   CaptureDataPhoto: UpdatePhotogrammetryMetadata
   Model: UpdateModelMetadata
   Scene: UpdateSceneMetadata

--- a/server/graphql/schema/asset/queries.graphql
+++ b/server/graphql/schema/asset/queries.graphql
@@ -168,6 +168,8 @@ type UpdateSceneMetadata {
 
 type UpdatedAssetVersionMetadata {
     idAssetVersion: Int!
+    UpdatedObjectName: String!
+    Item: Item
     CaptureDataPhoto: UpdatePhotogrammetryMetadata
     Model: UpdateModelMetadata
     Scene: UpdateSceneMetadata

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -731,6 +731,8 @@ export type UpdateSceneMetadata = {
 export type UpdatedAssetVersionMetadata = {
   __typename?: 'UpdatedAssetVersionMetadata';
   idAssetVersion: Scalars['Int'];
+  UpdatedObjectName: Scalars['String'];
+  Item?: Maybe<Item>;
   CaptureDataPhoto?: Maybe<UpdatePhotogrammetryMetadata>;
   Model?: Maybe<UpdateModelMetadata>;
   Scene?: Maybe<UpdateSceneMetadata>;


### PR DESCRIPTION
GraphQL:
* Added UpdatedObjectName and Item>Name to getUploadedAssetVersion, for use in providing the user with the context of an update operation.

Client:
* Compute "update context" after successful upload, which is the object being updated plus details about its media group, if any
* When we have an update context, render file list item details with that context