### PR TITLE
Fix for 563: Ensure Voyager Story WebDAV PUT requests are fully handled and avoid clobbering each other

### DIFF
--- a/server/db/connection/DBConnection.ts
+++ b/server/db/connection/DBConnection.ts
@@ -44,14 +44,14 @@ export class DBConnection {
     }
 
     private clearPrismaTransaction(transactionNumber?: number | undefined): void {
-        if (!transactionNumber) {
-            const LS: LocalStore | undefined = ASL.getStore();
-            if (!LS || !LS.transactionNumber)
-                return;
-            transactionNumber = LS.transactionNumber;
+        const LS: LocalStore | undefined = ASL.getStore();
+        if (LS) {
+            if (!transactionNumber)
+                transactionNumber = LS.transactionNumber;
             LS.transactionNumber = undefined;
         }
-        this._prismaTransMap.delete(transactionNumber);
+        if (transactionNumber)
+            this._prismaTransMap.delete(transactionNumber);
     }
 
     private async disconnect(): Promise<void> {

--- a/server/utils/bufferStream.ts
+++ b/server/utils/bufferStream.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+import { Transform, TransformCallback } from 'stream';
+
+type BufferItem = {
+    chunk: any;
+    encoding: BufferEncoding;
+};
+
+/** This Transform stream buffers written chunks until writing is complete.
+ * As a result, this implementation is not memory efficient!  Use cautiously.
+ */
+export class BufferStream extends Transform {
+    private _pending: BufferItem[] = [];
+    constructor(options = {}) {
+        super(options);
+    }
+
+    _transform(chunk: any, encoding: BufferEncoding, callback: TransformCallback): void {
+        this._pending.push({ chunk, encoding });
+        callback();
+    }
+
+    _flush(callback: TransformCallback): void {
+        while (this._pending.length > 0) {
+            const BI: BufferItem | undefined = this._pending.shift();
+            if (BI)
+                this.push(BI.chunk, BI.encoding);
+        }
+        callback();
+    }
+}


### PR DESCRIPTION
UTIL:
* Implemented BufferStream, a Transform stream that buffers written input until writing is complete.  This is not memory efficient, but gets the job done for WebDAV PUTs from Voyager Story

HTTP:
* Use BufferStream in handling of webdav-server's  WebDAVFileSystem._openWriteStream -- make sure we allow writes to continue, to completion, without pausing due to backpressure, before we pass the duplex BufferStream through to ingestion
* Implement WebDAVFileSystem write locking, allowing only one concurrent ingestion per idSystemObject at a time.  This is a band aid to help ensure system object versions are cloned with consistency and prevent simultaneous updates from clobbering each other

DBAPI:
* Work harder to clear prisma transaction number from continuation local storage