### PR TITLE
Fix for 601: index Scene's EDAN UUID, along with other text fields, for SOLR text search

### DIFF
--- a/server/config/solr/data/packrat/conf/schema.xml
+++ b/server/config/solr/data/packrat/conf/schema.xml
@@ -170,7 +170,17 @@
     <copyField source="CommonDescription" dest="_text_"/>
     <copyField source="CommonIdentifier" dest="_text_"/>
     <copyField source="CommonOrganizationName" dest="_text_"/>
+    <copyField source="SubjectIdentifierPreferred" dest="_text_"/>
+    <copyField source="ModelMaterialName" dest="_text_"/>
     <copyField source="AVFileName" dest="_text_"/>
+    <copyField source="AVFilePath" dest="_text_"/>
+    <copyField source="AVUserCreator" dest="_text_"/>
+    <copyField source="AVStorageHash" dest="_text_"/>
+    <copyField source="StakeholderEmailAddress" dest="_text_"/>
+    <copyField source="StakeholderPhoneNumberMobile" dest="_text_"/>
+    <copyField source="StakeholderPhoneNumberOffice" dest="_text_"/>
+    <copyField source="StakeholderMailingAddress" dest="_text_"/>
+    <copyField source="SceneEdanUUID" dest="_text_"/>
 
     <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field


### PR DESCRIPTION
SOLR:
* Update list of fields copied to _text_ to include SceneEdanUUID, as well as other text-based fields that might be of use during searching