### PR TITLE
Fix for 598: Ensure rights are title are not overwritten when updating an Edan 3d package

### DIFF
--- a/server/collections/impl/EdanCollection.ts
+++ b/server/collections/impl/EdanCollection.ts
@@ -160,9 +160,10 @@ export class EdanCollection implements COL.ICollection {
         return this.upsertResource(body, 'createEdan3DPackage');
     }
 
-    async updateEdan3DPackage(url: string, sceneContent: COL.Edan3DPackageContent, status: number, publicSearch: boolean): Promise<COL.EdanRecord | null> {
+    async updateEdan3DPackage(url: string, title: string | undefined, sceneContent: COL.Edan3DPackageContent, status: number, publicSearch: boolean): Promise<COL.EdanRecord | null> {
         const body: any = {
             url,
+            title,
             status,
             publicSearch,
             type: '3d_package',
@@ -177,7 +178,7 @@ export class EdanCollection implements COL.ICollection {
         // LOG.info(`EdanCollection.upsertContent: ${JSON.stringify(body)}`, LOG.LS.eCOLL);
         LOG.info('EdanCollection.upsertContent', LOG.LS.eCOLL);
         const reqResult: HttpRequestResult = await this.sendRequest(eAPIType.eEDAN3dApi, eHTTPMethod.ePost, 'api/v1.0/admin/upsertContent', '', JSON.stringify(body), 'application/json');
-        // LOG.info(`EdanCollection.upsertContent: ${JSON.stringify(body)}: ${reqResult.output}`, LOG.LS.eCOLL);
+        // LOG.info(`EdanCollection.upsertContent:\n${JSON.stringify(body)}\n${reqResult.output}`, LOG.LS.eCOLL);
         if (!reqResult.success) {
             LOG.error(`EdanCollection.${caller} failed with ${reqResult.statusText}: ${reqResult.output}`, LOG.LS.eCOLL);
             return null;
@@ -195,7 +196,7 @@ export class EdanCollection implements COL.ICollection {
     private async upsertResource(body: any, caller: string): Promise<COL.EdanRecord | null> {
         LOG.info(`EdanCollection.upsertResource: ${JSON.stringify(body)}`, LOG.LS.eCOLL);
         const reqResult: HttpRequestResult = await this.sendRequest(eAPIType.eEDAN3dApi, eHTTPMethod.ePost, 'api/v1.0/admin/upsertResource', '', JSON.stringify(body), 'application/json');
-        // LOG.info(`EdanCollection.upsertResource: ${JSON.stringify(body)}: ${reqResult.output}`, LOG.LS.eCOLL);
+        // LOG.info(`EdanCollection.upsertResource:\n${JSON.stringify(body)}:\n${reqResult.output}`, LOG.LS.eCOLL);
         if (!reqResult.success) {
             LOG.error(`EdanCollection.${caller} failed with ${reqResult.statusText}: ${reqResult.output}`, LOG.LS.eCOLL);
             return null;

--- a/server/collections/impl/PublishScene.ts
+++ b/server/collections/impl/PublishScene.ts
@@ -98,6 +98,7 @@ export class PublishScene {
             return false;
         }
         LOG.info(`PublishScene.publish ${edanRecord.url} succeeded with Edan status ${edanRecord.status}, publicSearch ${edanRecord.publicSearch}`, LOG.LS.eCOLL);
+        // LOG.info(`PublishScene.publish ${edanRecord.url} succeeded with Edan status ${edanRecord.status}, publicSearch ${edanRecord.publicSearch}:\n${H.Helpers.JSONStringify(edanRecord)}`, LOG.LS.eCOLL);
 
         // stage downloads
         if (!await this.stageDownloads() || !this.edan3DResourceList)
@@ -115,17 +116,17 @@ export class PublishScene {
 
         // update EDAN 3D Package if we have downloads and/or if our published state has changed
         if (this.svxDocument && updatePackage) {
-            const E3DPackage: COL.Edan3DPackageContent = {
-                document: this.svxDocument,
-                resources: (downloads && haveDownloads) ? this.edan3DResourceList : undefined
-            };
+            const E3DPackage: COL.Edan3DPackageContent = { ...edanRecord.content };
+            E3DPackage.document = this.svxDocument;
+            E3DPackage.resources = (downloads && haveDownloads) ? this.edan3DResourceList : [];
 
             LOG.info(`PublishScene.publish updating ${edanRecord.url}`, LOG.LS.eCOLL);
-            edanRecord = await ICol.updateEdan3DPackage(edanRecord.url, E3DPackage, status, publicSearch);
+            edanRecord = await ICol.updateEdan3DPackage(edanRecord.url, edanRecord.title, E3DPackage, status, publicSearch);
             if (!edanRecord) {
                 LOG.error('PublishScene.publish Edan3DPackage update failed', LOG.LS.eCOLL);
                 return false;
             }
+            // LOG.info(`PublishScene.publish updated ${edanRecord.url}:\n${H.Helpers.JSONStringify(edanRecord)}`, LOG.LS.eCOLL);
         }
 
         LOG.info(`PublishScene.publish UUID ${this.scene.EdanUUID}, status ${status}, publicSearch ${publicSearch}, downloads ${downloads}, has downloads ${haveDownloads}`, LOG.LS.eCOLL);

--- a/server/collections/interface/EdanSchemas.ts
+++ b/server/collections/interface/EdanSchemas.ts
@@ -93,7 +93,7 @@ export type Edan3DResource = {          // c.f. https://confluence.si.edu/displa
 };
 
 export type Edan3DPackageContent = {
-    document: IDocument;
+    document?: IDocument;
     resources?: Edan3DResource[];
 };
 

--- a/server/collections/interface/ICollection.ts
+++ b/server/collections/interface/ICollection.ts
@@ -48,7 +48,7 @@ export interface ICollection {
     publish(idSystemObject: number, ePublishState: number): Promise<boolean>;
     createEdanMDM(edanmdm: EdanMDMContent, status: number, publicSearch: boolean): Promise<EdanRecord | null>;
     createEdan3DPackage(path: string, sceneFile?: string | undefined): Promise<EdanRecord | null>;
-    updateEdan3DPackage(url: string, sceneContent: Edan3DPackageContent, status: number, publicSearch: boolean): Promise<EdanRecord | null>;
+    updateEdan3DPackage(url: string, title: string | undefined, sceneContent: Edan3DPackageContent, status: number, publicSearch: boolean): Promise<EdanRecord | null>;
 
     /** Identifier services */
     /** Pass in a null shoulder to use the system shoulder */

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -340,6 +340,7 @@ export abstract class JobCook<T> extends JobPackrat {
                     // in this case, the override stream is for the model geometry file
                     let RSRs: STORE.ReadStreamResult[] | undefined = this._streamOverrideMap.get(idAssetVersion);
                     if (!RSRs) {
+                        // LOG.info(`JobCook [${this.name()}] JobCook.stageFiles found no stream override for idAssetVersion ${idAssetVersion} among ${this._streamOverrideMap.size} overrides`, LOG.LS.eJOB);
                         RSRs = [];
                         RSRs.push(await STORE.AssetStorageAdapter.readAssetVersionByID(idAssetVersion));
                     }

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -709,9 +709,11 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
     private async testForZipOrStream(): Promise<boolean> {
         if (!this._idAssetVersions || this._idAssetVersions.length == 0)
             return false;
+        // LOG.info(`JobCookSIPackratInspect.testForZipOrStream AssetVersion IDs ${H.Helpers.JSONStringify(this._idAssetVersions)}`, LOG.LS.eJOB);
 
         // if we've been handed a stream to act on it ... do so!
         if (this.sourceMeshStream) {
+            // LOG.info('JobCookSIPackratInspect.testForZipOrStream processing stream', LOG.LS.eJOB);
             const RSRs: STORE.ReadStreamResult[] = [{
                 readStream: this.sourceMeshStream,
                 fileName: this.parameters.sourceMeshFile,
@@ -722,19 +724,23 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             return true;
         }
 
-        if (path.extname(this.parameters.sourceMeshFile).toLowerCase() !== '.zip')
+        // LOG.info(`JobCookSIPackratInspect.testForZipOrStream parameters ${H.Helpers.JSONStringify(this.parameters)}`, LOG.LS.eJOB);
+        if (path.extname(this.parameters.sourceMeshFile).toLowerCase() !== '.zip') {
+            // LOG.info('JobCookSIPackratInspect.testForZipOrStream processing non-zip file', LOG.LS.eJOB);
             return false;
+        }
 
+        // LOG.info('JobCookSIPackratInspect.testForZipOrStream processing zip file', LOG.LS.eJOB);
         const RSR: STORE.ReadStreamResult = await STORE.AssetStorageAdapter.readAssetVersionByID(this._idAssetVersions[0]);
         if (!RSR.success || !RSR.readStream) {
-            LOG.error(`JobCookSIPackratInspect.testForZip unable to read asset version ${this._idAssetVersions[0]}: ${RSR.error}`, LOG.LS.eJOB);
+            LOG.error(`JobCookSIPackratInspect.testForZipOrStream unable to read asset version ${this._idAssetVersions[0]}: ${RSR.error}`, LOG.LS.eJOB);
             return false;
         }
 
         const ZS: ZipStream = new ZipStream(RSR.readStream);
         const zipRes: H.IOResults = await ZS.load();
         if (!zipRes.success) {
-            LOG.error(`JobCookSIPackratInspect.testForZip unable to read asset version ${this._idAssetVersions[0]}: ${zipRes.error}`, LOG.LS.eJOB);
+            LOG.error(`JobCookSIPackratInspect.testForZipOrStream unable to read asset version ${this._idAssetVersions[0]}: ${zipRes.error}`, LOG.LS.eJOB);
             return false;
         }
 
@@ -744,6 +750,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         for (const file of files) {
             const eVocabID: COMMON.eVocabularyID | undefined = CACHE.VocabularyCache.mapModelFileByExtensionID(file);
             const extension: string = path.extname(file).toLowerCase() || file.toLowerCase();
+            // LOG.info(`JobCookSIPackratInspect.testForZipOrStream consdiering zip file entry ${file}, extension ${extension}, VocabID ${eVocabID ? COMMON.eVocabularyID[eVocabID] : 'undefined'}`, LOG.LS.eJOB);
 
             // for the time being, only handle model geometry files, OBJ .mtl files, and GLTF .bin files
             if (eVocabID === undefined && extension !== '.mtl' && extension !== '.bin')
@@ -751,10 +758,11 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
 
             const readStream: NodeJS.ReadableStream | null = await ZS.streamContent(file);
             if (!readStream) {
-                LOG.error(`JobCookSIPackratInspect.testForZip unable to fetch read steram for ${file} in zip of idAssetVersion ${this._idAssetVersions[0]}`, LOG.LS.eJOB);
+                LOG.error(`JobCookSIPackratInspect.testForZipOrStream unable to fetch read steram for ${file} in zip of idAssetVersion ${this._idAssetVersions[0]}`, LOG.LS.eJOB);
                 return false;
             }
 
+            LOG.info(`JobCookSIPackratInspect.testForZipOrStream creating stream override for zip file entry ${file}`, LOG.LS.eJOB);
             RSRs.push({
                 readStream,
                 fileName: file,
@@ -771,10 +779,11 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             this.parameters.sourceMeshFile = sourceMeshFile;
             this._dbJobRun.Parameters = JSON.stringify(this.parameters, H.Helpers.saferStringify);
             if (!await this._dbJobRun.update())
-                LOG.error(`JobCookSIPackratInspect.testForZip failed to update JobRun.parameters for ${JSON.stringify(this._dbJobRun, H.Helpers.saferStringify)}`, LOG.LS.eJOB);
+                LOG.error(`JobCookSIPackratInspect.testForZipOrStream failed to update JobRun.parameters for ${JSON.stringify(this._dbJobRun, H.Helpers.saferStringify)}`, LOG.LS.eJOB);
         }
 
         if (RSRs.length > 0) {
+            // LOG.info(`JobCookSIPackratInspect.testForZipOrStream recording ${RSRs.length} stream overrides for idAssetVersion ${this._idAssetVersions[0]}`, LOG.LS.eJOB);
             this._streamOverrideMap.set(this._idAssetVersions[0], RSRs);
             return true;
         }


### PR DESCRIPTION
This fix addresses an issue in Packrat and goes hand-in-hand with a fix deployed to the Edan 3D API, ensuring that the title of an EdanRecord is not overwritten by the `upsertContent` API, as well as allowing an optional title to be specified with that API.

Collections:
* Accept optional title in updateEdan3DPackage API, now that the Edan 3D API upsertContent supports it
* When publishing a scene, if a follow-up updateEdan3DPackage is needed, populate the package content with those contents from the previously created/updated EdanRecord, and pass the EdanRecord title