### PR TITLE
Fix for 603: Provide ingestion API control for system object version creation

### DIFF
--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -159,6 +159,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         const idUserCreator: number = LS?.idUser ?? 0;
 
         for (const [downloadType, downloadFile] of downloadMap) {
+            LOG.info(`JobCookSIGenerateDownloads processing download ${downloadFile} of type ${downloadType}`, LOG.LS.eJOB);
             const RSR: STORE.ReadStreamResult = await this.fetchFile(downloadFile);
             if (!RSR.success || !RSR.readStream) {
                 LOG.error(`JobCookSIGenerateDownloads.createSystemObjects unable to fetch stream for generated download ${downloadFile}: ${RSR.error}`, LOG.LS.eJOB);
@@ -223,7 +224,8 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
                 allowZipCracking: false,
                 idUserCreator,
                 SOBased: model,
-                Comment: 'Created by Cook si-generate-downloads'
+                Comment: 'Created by Cook si-generate-downloads',
+                doNotUpdateParentVersion: true // we create a new system object version below
             };
             const ISR: STORE.IngestStreamOrFileResult = await STORE.AssetStorageAdapter.ingestStreamOrFile(ISI);
             if (!ISR.success) {

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -393,7 +393,8 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
                         allowZipCracking: false,
                         idUserCreator,
                         SOBased: model,
-                        Comment: 'Created by Cook si-voyager-scene'
+                        Comment: 'Created by Cook si-voyager-scene',
+                        doNotUpdateParentVersion: true // if needed, we update the existing system object version below
                     };
                     ISR = await STORE.AssetStorageAdapter.ingestStreamOrFile(ISIModel);
                     if (!ISR.success)


### PR DESCRIPTION
Cook jobs si-generate-downloads and si-voyager-scene create multiple objects, including:
* Models
* Scenes
* Assets
The owning scene object needs a new system object version when this happens -- but just one new version should be created, and it should contain all of the changes.  This PR accomplishes this by allowing the AssetStorageAdapter client to control if the storage framework should update the system object version, or if the calling code will handle it more intelligently.

Job:
* From si-generate-downloads and si-voyager-scene, when ingesting assets, avoid creating new system object versions of the parent object, as we'll let the calling code manage the object version; these updates typically include multiple files ("non-atomic"), and should only be one new object version.

Storage:
* Provide flavors of AssetStorageAdapter.IngestAsset and .IngestStreamOrFileInput that do not create a new system object version for the parent object