### PR TITLE
Fix for 605: identify current scene's models during scene update, when appropriate

### DIFF
--- a/server/db/api/Model.ts
+++ b/server/db/api/Model.ts
@@ -205,24 +205,6 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
         }
     }
 
-    static async fetchByFileNameSizeAndAssetType(FileName: string, StorageSize: BigInt, idVAssetTypes: number[]): Promise<Model[] | null> {
-        try {
-            return DBC.CopyArray<ModelBase, Model>(
-                await DBC.DBConnection.prisma.$queryRaw<Model[]>`
-                SELECT DISTINCT M.*
-                FROM Model AS M
-                JOIN SystemObject AS SOM ON (M.idModel = SOM.idModel)
-                JOIN Asset AS ASS ON (SOM.idSystemObject = ASS.idSystemObject)
-                JOIN AssetVersion AS ASV ON (ASS.idAsset = ASV.idAsset)
-                WHERE ASV.FileName = ${FileName}
-                  AND ASV.StorageSize = ${StorageSize}
-                  AND ASS.idVAssetType IN (${Prisma.join(idVAssetTypes)})`, Model);
-        } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Model.fetchByFileNameSizeAndAssetType', LOG.LS.eDB, error);
-            return null;
-        }
-    }
-
     /** fetches models which are chilren of either the specified idModelParent or idSceneParent, and have matching AutomationTag values */
     static async fetchChildrenModels(idModelParent: number | null, idSceneParent: number | null, AutomationTag: string): Promise<Model[] | null> {
         try {

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -165,6 +165,8 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
     private cleanupCalled: boolean = false;
 
     private static vocabVoyagerSceneModel: DBAPI.Vocabulary | undefined = undefined;
+    private static vocabAssetTypeScene: DBAPI.Vocabulary | undefined = undefined;
+    private static vocabAssetTypeModelGeometryFile: DBAPI.Vocabulary | undefined = undefined;
 
     constructor(jobEngine: JOB.IJobEngine, idAssetVersions: number[] | null, report: REP.IReport | null,
         parameters: JobCookSIVoyagerSceneParameters, dbJobRun: DBAPI.JobRun) {
@@ -221,8 +223,8 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
             return this.logError('JobCookSIVoyagerScene.createSystemObjects called without needed parameters');
 
         const svxFile: string = this.parameters.svxFile ?? 'scene.svx.json';
-        const vScene: DBAPI.Vocabulary | undefined = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eAssetAssetTypeScene);
-        const vModel: DBAPI.Vocabulary | undefined = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eAssetAssetTypeModelGeometryFile);
+        const vScene: DBAPI.Vocabulary | undefined = await this.computeVocabAssetTypeScene();
+        const vModel: DBAPI.Vocabulary | undefined = await this.computeVocabAssetTypeModelGeometryFile();
         if (!vScene || !vModel)
             return this.logError(`JobCookSIVoyagerScene.createSystemObjects unable to calculate vocabulary needed to ingest scene file ${svxFile}`);
 
@@ -484,6 +486,24 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
                 LOG.error('JobCookSIVoyagerScene unable to fetch vocabulary for Voyager Scene Model Model Purpose', LOG.LS.eGQL);
         }
         return JobCookSIVoyagerScene.vocabVoyagerSceneModel;
+    }
+
+    private async computeVocabAssetTypeScene(): Promise<DBAPI.Vocabulary | undefined> {
+        if (!JobCookSIVoyagerScene.vocabAssetTypeScene) {
+            JobCookSIVoyagerScene.vocabAssetTypeScene = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eAssetAssetTypeScene);
+            if (!JobCookSIVoyagerScene.vocabAssetTypeScene)
+                LOG.error('JobCookSIVoyagerScene unable to fetch vocabulary for Asset Type Scene', LOG.LS.eGQL);
+        }
+        return JobCookSIVoyagerScene.vocabAssetTypeScene;
+    }
+
+    private async computeVocabAssetTypeModelGeometryFile(): Promise<DBAPI.Vocabulary | undefined> {
+        if (!JobCookSIVoyagerScene.vocabAssetTypeModelGeometryFile) {
+            JobCookSIVoyagerScene.vocabAssetTypeModelGeometryFile = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eAssetAssetTypeModelGeometryFile);
+            if (!JobCookSIVoyagerScene.vocabAssetTypeModelGeometryFile)
+                LOG.error('JobCookSIVoyagerScene unable to fetch vocabulary for Asset Type Model Geometry File', LOG.LS.eGQL);
+        }
+        return JobCookSIVoyagerScene.vocabAssetTypeModelGeometryFile;
     }
 
     private async logError(errorBase: string): Promise<H.IOResults> {

--- a/server/tests/db/dbcreation.test.ts
+++ b/server/tests/db/dbcreation.test.ts
@@ -5108,13 +5108,6 @@ describe('DB Fetch Special Test Suite', () => {
             expect(modelFetch.length).toEqual(0);
     });
 
-    test('DB Fetch Special: Model.fetchByFileNameSizeAndAssetType', async () => {
-        const modelFetch: DBAPI.Model[] | null = await DBAPI.Model.fetchByFileNameSizeAndAssetType('zzzOBVIOUSLY_INVALID_NAMEzzz', BigInt(100), [0]);
-        expect(modelFetch).toBeTruthy();
-        if (modelFetch)
-            expect(modelFetch.length).toEqual(0);
-    });
-
     test('DB Fetch Special: Model.fetchChildrenModels', async () => {
         const modelFetch1: DBAPI.Model[] | null = await DBAPI.Model.fetchChildrenModels(-1, null, 'zzzOBVIOUSLY_INVALID_NAMEzzz');
         expect(modelFetch1).toBeTruthy();


### PR DESCRIPTION
GraphQL:
* When ingesting scenes, first detect if we're in update mode; if so, compute the SceneConstellation from the to-be-ingested asset, but use the updated scene to guide reuse of ModelSceneXref records

DBAPI:
* Removed defunct Model.fetchByFileNameSizeAndAssetType

Job:
* Use static caching of reused vocabulary in si-generate-downloads and si-voyager-scene