### PR TITLE
address resizing issues and related tab styling

### DIFF
--- a/client/src/pages/Ingestion/components/Metadata/Model/RelatedObjectsList.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/RelatedObjectsList.tsx
@@ -49,6 +49,19 @@ const useStyles = makeStyles(({ palette }) => ({
     addButton: {
         ...sharedButtonProps,
         marginTop: 10
+    },
+    nameCell: {
+        padding: '1px 0px 1px 8px'
+    },
+    objectTypeCell: {
+        padding: '1px 4px 1px 8px',
+        textAlign: 'center'
+    },
+    identifierCell: {
+        padding: '1px 0px 1px 4px'
+    },
+    removeBtnCell: {
+        padding: '1px 8px 0px 0px',
     }
 }));
 
@@ -73,7 +86,7 @@ function RelatedObjectsList(props: RelatedObjectsListProps): React.ReactElement 
 
     return (
         <Box className={classes.container}>
-            <TableContainer style={{ width: 'fit-content' }}>
+            <TableContainer style={{ width: 'fit-content', minWidth: '400px' }}>
                 <Table>
                     <TableHead>
                         <TableRow>
@@ -159,18 +172,18 @@ function Item(props: ItemProps): React.ReactElement {
 
     return (
         <TableRow style={{ backgroundColor: index % 2 !== 0 ? 'white' : '#ffffe0' }}>
-            <TableCell style={{ padding: '1px 0px 1px 8px', borderTopLeftRadius: index === 0 ? '5px' : undefined, borderBottomLeftRadius: finalIndex === index ? '5px' : undefined }}>
+            <TableCell className={classes.nameCell} style={{ borderTopLeftRadius: index === 0 ? '5px' : undefined, borderBottomLeftRadius: finalIndex === index ? '5px' : undefined }}>
                 <NewTabLink to={getDetailsUrlForObject(idSystemObject)} className={clsx(classes.label, classes.labelUnderline)} style={{ fontSize: '0.8rem', verticalAlign: 'middle', wordBreak: 'break-word' }}>
                     {name}
                 </NewTabLink>
             </TableCell>
-            <TableCell style={{ padding: '1px 2px', textAlign: 'center' }}>
+            <TableCell className={classes.objectTypeCell}>
                 <Typography className={classes.label} style={{ fontSize: '0.8rem' }}>{getTermForSystemObjectType(objectType)}</Typography>
             </TableCell>
-            <TableCell style={{ padding: '1px 2px' }}>
+            <TableCell className={classes.identifierCell}>
                 <Typography className={classes.label} style={{ fontSize: '0.8rem', wordBreak: 'break-all' }}>{identifier}</Typography>
             </TableCell>
-            <TableCell style={{ padding: '1px 8px 0px 0px', borderTopRightRadius: index === 0 ? '5px' : undefined, borderBottomRightRadius: finalIndex === index ? '5px' : undefined }}>
+            <TableCell className={classes.removeBtnCell} style={{ borderTopRightRadius: index === 0 ? '5px' : undefined, borderBottomRightRadius: finalIndex === index ? '5px' : undefined }}>
                 {!viewMode && <MdRemoveCircleOutline className={classes.removeIcon} onClick={remove} size={16} style={{ verticalAlign: 'sub' }} />}
             </TableCell>
         </TableRow>

--- a/client/src/pages/Repository/components/RepositoryTreeView/RepositoryTreeHeader.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/RepositoryTreeHeader.tsx
@@ -29,6 +29,7 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
         position: 'sticky',
         top: 0,
         zIndex: 20,
+        paddingRight: 5,
         [breakpoints.down('lg')]: {
             minHeight: 40
         }
@@ -80,13 +81,13 @@ const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
 
 const metadataColumns = {
     [SO_NAME_COLUMN_HEADER]: {
-        width:  ( widths: { [name: string]: string }) => `${widths[SO_NAME_COLUMN_HEADER]}px` || '150px'
+        width:  ( widths: { [name: string]: string }) => `${widths[SO_NAME_COLUMN_HEADER]}px` ?? '150px'
     }
 };
 for (const col in eMetadata) {
     metadataColumns[eMetadata[col]] =  {
         width: (
-            widths: { [name: string]: string }) => `${widths[eMetadata[col]]}px` || '50px'
+            widths: { [name: string]: string }) => `${widths[eMetadata[col]]}px` ?? '50px'
     };
 }
 
@@ -122,7 +123,7 @@ function RepositoryTreeHeader(props: RepositoryTreeHeaderProps): React.ReactElem
             const target = document.getElementById(`column-${col.label}`);
             if (target) {
                 const columnObersver = new ResizeObserver((e) => {
-                    updateWidth(col.metadataColumn as number, String(e[0].contentRect.width));
+                    debounceUpdateWidth(col.metadataColumn as number, String(e[0].contentRect.width));
                 });
                 columnObersver.observe(target);
                 columnSet.add(columnObersver);

--- a/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
@@ -27,7 +27,6 @@ import StyledTreeItem from './StyledTreeItem';
 import TreeLabel, { TreeLabelEmpty, TreeLabelLoading } from './TreeLabel';
 import InViewTreeItem from './InViewTreeItem';
 import { repositoryRowCount } from '@dpo-packrat/common';
-import clsx from 'clsx';
 
 const repositoryRowPrefetchThreshold = 75;
 
@@ -87,7 +86,8 @@ const useStyles = makeStyles(({ breakpoints, typography, palette }) => ({
         [breakpoints.down('lg')]: {
             left: 30
         },
-        flex: 1
+        flex: 1,
+        width: 'min-content'
     },
     labelText: {
         color: 'rgb(44,64,90)',
@@ -150,7 +150,6 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
     ]);
     const metadataColumns = useRepositoryStore(state => state.metadataToDisplay);
     const [initializeWidths] = useTreeColumnsStore((state) => [state.initializeWidth]);
-    const { classes: widthClasses } = useTreeColumnsStore();
     const [loading, isExpanded] = useRepositoryStore(useCallback(state => [state.loading, state.isExpanded], []));
     const sideBarExpanded = useControlStore(state => state.sideBarExpanded);
     const classes = useStyles({ isExpanded, sideBarExpanded, isModal });
@@ -229,7 +228,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
                     objectType={objectType}
                     color={color}
                     treeColumns={treeColumns}
-                    makeStyles={{ container: classes.treeLabelContainer, label: clsx(classes.label, widthClasses['object-name']), labelText: classes.labelText, column: classes.column, text: classes.text, options: classes.options, option: classes.option, link: classes.link }}
+                    makeStyles={{ container: classes.treeLabelContainer, label: classes.label, labelText: classes.labelText, column: classes.column, text: classes.text, options: classes.options, option: classes.option, link: classes.link }}
                 />
             );
 

--- a/client/src/store/treeColumns.ts
+++ b/client/src/store/treeColumns.ts
@@ -55,7 +55,6 @@ export const useTreeColumnsStore = create<TreeColumns>((set: SetState<TreeColumn
         // When unmounting the headers, their observed width is 0 so we want to ignore that
         if (newWidth === '0') return;
         if (widths[colName] === newWidth) return;
-
         const newWidths = Object.assign({}, widths);
         newWidths[colName] = newWidth;
         updateCookie(COL_WIDTH_COOKIE, JSON.stringify(newWidths));


### PR DESCRIPTION
_Clear the colWidths cookie_

Related Tab
-Add equal padding between each column
-Set minimum width for the container

Resizing in Repository
-Prevent expanded children from adding width to the name column
-Snap the resize icon to the end of the SO name column
-Prevent a snapback/shivering effect when resizing the metadata columns