### PR TITLE
Fix for 628: Compute scene and model base filenames and pass to Cook

### DIFF
--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -112,14 +112,16 @@ export class JobCookSIVoyagerSceneParameterHelper {
         if (items.length === 1) {               // Single item
             if (items[0].EntireSubject)         // Comprising whole subject?; use "subject name"
                 sceneTitle = undefined;
-            else                                // Comprising part of subject; use "subject name: item name"
-                sceneTitle = items[0].Name;
+            else                                // Comprising part of subject; use "subject name: item title"
+                sceneTitle = items[0].Title ?? '';
         } else {                                // Multiple items, single subject, use "subject name: item1 name, item2 name, etc."
             sceneTitle = '';
             let first: boolean = true;
             for (const item of items) {
-                sceneTitle += `${first ? '' : ', ' }${item.Name}`;
-                first = false;
+                if (item.Title) {
+                    sceneTitle += `${first ? '' : ', ' }${item.Title}`;
+                    first = false;
+                }
             }
         }
         return { edanRecordId, title, sceneTitle };

--- a/server/package.json
+++ b/server/package.json
@@ -75,6 +75,7 @@
     "node-stream-zip": "1.13.2",
     "passport": "0.4.1",
     "passport-local": "1.0.0",
+    "sanitize-filename": "1.6.3",
     "sharp": "0.29.1",
     "solr-client": "0.8.0",
     "supertest": "4.0.2",

--- a/server/utils/nameHelpers.ts
+++ b/server/utils/nameHelpers.ts
@@ -4,8 +4,9 @@ import * as CACHE from '../cache';
 import * as H from './helpers';
 import * as LOG from './logger';
 import * as COMMON from '@dpo-packrat/common';
+import sanitize from 'sanitize-filename';
 
-const UNKNOWN_NAME: string = '<UNKNOWN>';
+export const UNKNOWN_NAME: string = '<UNKNOWN>';
 
 /** Encapsulates a model and its parent media group(s) and subject(s) */
 export type ModelHierarchy = {
@@ -40,6 +41,10 @@ export class NameHelpers {
 
     static sceneBaseFileName(scene: DBAPI.Scene): string {
         return scene.Name;
+    }
+
+    static sanitizeFileName(fileName: string): string {
+        return sanitize(fileName.replace(/:/g, '-').replace(/ /g, '_'), { replacement: '_' });
     }
 
     static modelTitleOptions(item: DBAPI.Item): IngestTitle {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16910,6 +16910,13 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sanitize-filename@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
 sanitize.css@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-10.0.0.tgz#b5cb2547e96d8629a60947544665243b1dc3657a"
@@ -18479,6 +18486,13 @@ triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
@@ -18941,6 +18955,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
*yarn needed in project root*
Build:
* Added sanitize-filename package to server

Util:
* Added NameHelpers.sanitizeFileName, used to convert a display name into a filename in certain conditions (e.g. for generated file basenames)

Workflow:
* Update logic for computing basenames used for scene and model generation by Cook jobs