### PR TITLE
Fix for 606: compute and display array of ancestor objects (units, projects, subjects, and items)

### DIFF
--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -1936,10 +1936,10 @@ export type GetSystemObjectDetailsResult = {
   derivedObjects: Array<RelatedObject>;
   objectVersions: Array<SystemObjectVersion>;
   metadata: Array<Metadata>;
-  unit?: Maybe<RepositoryPath>;
-  project?: Maybe<RepositoryPath>;
-  subject?: Maybe<RepositoryPath>;
-  item?: Maybe<RepositoryPath>;
+  unit?: Maybe<Array<RepositoryPath>>;
+  project?: Maybe<Array<RepositoryPath>>;
+  subject?: Maybe<Array<RepositoryPath>>;
+  item?: Maybe<Array<RepositoryPath>>;
   asset?: Maybe<RepositoryPath>;
   assetOwner?: Maybe<RepositoryPath>;
   license?: Maybe<License>;
@@ -3724,19 +3724,19 @@ export type GetSystemObjectDetailsQuery = (
     & { identifiers: Array<(
       { __typename?: 'IngestIdentifier' }
       & Pick<IngestIdentifier, 'identifier' | 'identifierType' | 'idIdentifier'>
-    )>, unit?: Maybe<(
+    )>, unit?: Maybe<Array<(
       { __typename?: 'RepositoryPath' }
       & Pick<RepositoryPath, 'idSystemObject' | 'name' | 'objectType'>
-    )>, project?: Maybe<(
+    )>>, project?: Maybe<Array<(
       { __typename?: 'RepositoryPath' }
       & Pick<RepositoryPath, 'idSystemObject' | 'name' | 'objectType'>
-    )>, subject?: Maybe<(
+    )>>, subject?: Maybe<Array<(
       { __typename?: 'RepositoryPath' }
       & Pick<RepositoryPath, 'idSystemObject' | 'name' | 'objectType'>
-    )>, item?: Maybe<(
+    )>>, item?: Maybe<Array<(
       { __typename?: 'RepositoryPath' }
       & Pick<RepositoryPath, 'idSystemObject' | 'name' | 'objectType'>
-    )>, asset?: Maybe<(
+    )>>, asset?: Maybe<(
       { __typename?: 'RepositoryPath' }
       & Pick<RepositoryPath, 'idSystemObject' | 'name' | 'objectType'>
     )>, assetOwner?: Maybe<(

--- a/server/db/api/composite/ObjectAncestors.ts
+++ b/server/db/api/composite/ObjectAncestors.ts
@@ -29,10 +29,10 @@ export class ObjectAncestors {
     OG: ObjectGraph;
     OGDB: ObjectGraphDatabase;
 
-    unit: RepositoryPath | null = null;
-    project: RepositoryPath | null = null;
-    subject: RepositoryPath | null = null;
-    item: RepositoryPath | null = null;
+    unit: RepositoryPath[] | null = null;
+    project: RepositoryPath[] | null = null;
+    subject: RepositoryPath[] | null = null;
+    item: RepositoryPath[] | null = null;
     ancestorStack: RepositoryPath[][] = [];
 
     private handledMap: Map<number, RepositoryPath> = new Map<number, RepositoryPath>();
@@ -167,10 +167,10 @@ export class ObjectAncestors {
             return ancestors;
 
         switch (eObjectType) {
-            case COMMON.eSystemObjectType.eUnit:     this.unit       = ancestors[0]; break;
-            case COMMON.eSystemObjectType.eProject:  this.project    = ancestors[0]; break;
-            case COMMON.eSystemObjectType.eSubject:  this.subject    = ancestors[0]; break;
-            case COMMON.eSystemObjectType.eItem:     this.item       = ancestors[0]; break;
+            case COMMON.eSystemObjectType.eUnit: this.unit = ancestors; break;
+            case COMMON.eSystemObjectType.eProject: this.project = ancestors; break;
+            case COMMON.eSystemObjectType.eSubject: this.subject= ancestors; break;
+            case COMMON.eSystemObjectType.eItem: this.item = ancestors; break;
         }
 
         if (pushAncestors)

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -1463,10 +1463,10 @@ type GetSystemObjectDetailsResult {
   derivedObjects: [RelatedObject!]!
   objectVersions: [SystemObjectVersion!]!
   metadata: [Metadata!]!
-  unit: RepositoryPath
-  project: RepositoryPath
-  subject: RepositoryPath
-  item: RepositoryPath
+  unit: [RepositoryPath!]
+  project: [RepositoryPath!]
+  subject: [RepositoryPath!]
+  item: [RepositoryPath!]
   asset: RepositoryPath
   assetOwner: RepositoryPath
   license: License

--- a/server/graphql/schema/systemobject/queries.graphql
+++ b/server/graphql/schema/systemobject/queries.graphql
@@ -174,10 +174,10 @@ type GetSystemObjectDetailsResult {
     derivedObjects: [RelatedObject!]!
     objectVersions: [SystemObjectVersion!]!
     metadata: [Metadata!]!
-    unit: RepositoryPath
-    project: RepositoryPath
-    subject: RepositoryPath
-    item: RepositoryPath
+    unit: [RepositoryPath!]
+    project: [RepositoryPath!]
+    subject: [RepositoryPath!]
+    item: [RepositoryPath!]
     asset: RepositoryPath
     assetOwner: RepositoryPath
     license: License

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -192,10 +192,10 @@ async function getIngestIdentifiers(idSystemObject: number): Promise<IngestIdent
 type GetObjectAncestorsResult = {
     success: boolean;
     error?: string;
-    unit?: RepositoryPath | null;
-    project?: RepositoryPath | null;
-    subject?: RepositoryPath | null;
-    item?: RepositoryPath | null;
+    unit?: RepositoryPath[] | null;
+    project?: RepositoryPath[] | null;
+    subject?: RepositoryPath[] | null;
+    item?: RepositoryPath[] | null;
     objectAncestors: RepositoryPath[][];
     OGDB?: DBAPI.ObjectGraphDatabase;
 };

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -1933,10 +1933,10 @@ export type GetSystemObjectDetailsResult = {
   derivedObjects: Array<RelatedObject>;
   objectVersions: Array<SystemObjectVersion>;
   metadata: Array<Metadata>;
-  unit?: Maybe<RepositoryPath>;
-  project?: Maybe<RepositoryPath>;
-  subject?: Maybe<RepositoryPath>;
-  item?: Maybe<RepositoryPath>;
+  unit?: Maybe<Array<RepositoryPath>>;
+  project?: Maybe<Array<RepositoryPath>>;
+  subject?: Maybe<Array<RepositoryPath>>;
+  item?: Maybe<Array<RepositoryPath>>;
   asset?: Maybe<RepositoryPath>;
   assetOwner?: Maybe<RepositoryPath>;
   license?: Maybe<License>;


### PR DESCRIPTION
GraphQL:
* Updated getSystemObjectDetails to return an array of RepositoryPaths for unit, project, subject, and item

DBAPI:
* Updated ObjectAncestors to compute an array of RepositoryPaths for unit, project, subject, and item

Client:
* Updated ObjectDetails to consume an array of  RepositoryPaths for unit, project, subject, and item, passing each to an updated Detail object, which in turn renders a comma-separated list of links for each object types