### PR TITLE
Tickets 612, 617, 620, 631

### DIFF
--- a/client/src/pages/Ingestion/index.tsx
+++ b/client/src/pages/Ingestion/index.tsx
@@ -73,9 +73,9 @@ function Ingestion(): React.ReactElement {
         let allowChange: boolean = true;
         const { href: url } = window.location;
 
-        // reset when we navigate to any other part of the app
+        // reset when we navigate to any other part of the app from subject/item or metadata
         if (!pathname.includes(HOME_ROUTES.INGESTION)) {
-            allowChange = !(url.includes(INGESTION_ROUTES_TYPE.METADATA) || url.includes(INGESTION_ROUTES_TYPE.SUBJECT_MEDIA_GROUP) || url.includes(INGESTION_ROUTES_TYPE.UPLOADS));
+            allowChange = !(url.includes(INGESTION_ROUTES_TYPE.METADATA) || url.includes(INGESTION_ROUTES_TYPE.SUBJECT_MEDIA_GROUP));
         }
 
         if (url.includes(INGESTION_ROUTES_TYPE.SUBJECT_MEDIA_GROUP)) {

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetGrid.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetGrid.tsx
@@ -134,7 +134,7 @@ const getMuiTheme = () =>
                 root: {
                     backgroundColor: '#FFFCD1',
                     height: 'fit-content',
-                    padding: '0px 0px 0px 5px',
+                    padding: '0px 3px',
                     margin: '1px',
                     fontSize: '0.8em',
                 },
@@ -351,6 +351,7 @@ function AssetGrid(props: AssetGridProps): React.ReactElement {
         fixedHeader: false,
         pagination: false,
         elevation: 0,
+        viewColumns: false,
         onViewColumnsChange: toggleColumn
     };
 

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SubjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SubjectDetails.tsx
@@ -96,62 +96,68 @@ export function SubjectFields(props: SubjectFieldsProps): React.ReactElement {
                                     </TableCell>
                                 </TableRow>
                             }
-                            <TableRow className={classes.tableRow}>
-                                <TableCell className={classes.tableCell}>
-                                    <Typography className={classes.labelText}>Latitude</Typography>
-                                </TableCell>
-                                <TableCell className={clsx(classes.tableCell, classes.valueText)}>
-                                    <DebounceInput
-                                        element='input'
-                                        title='Latitude-input'
-                                        disabled={disabled}
-                                        value={details.Latitude || ''}
-                                        type='number'
-                                        name='Latitude'
-                                        onChange={onChange}
-                                        className={clsx(classes.input, classes.datasetFieldInput)}
-                                        style={{ ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Latitude')) }}
-                                    />
-                                </TableCell>
-                            </TableRow>
-                            <TableRow className={classes.tableRow}>
-                                <TableCell className={classes.tableCell}>
-                                    <Typography className={classes.labelText}>Longitude</Typography>
-                                </TableCell>
-                                <TableCell className={clsx(classes.tableCell, classes.valueText)}>
-                                    <DebounceInput
-                                        element='input'
-                                        title='Longitude-input'
-                                        disabled={disabled}
-                                        value={details.Longitude || ''}
-                                        type='number'
-                                        name='Longitude'
-                                        onChange={onChange}
-                                        className={clsx(classes.input, classes.datasetFieldInput)}
-                                        style={{ ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Longitude')) }}
-                                    />
-                                </TableCell>
-                            </TableRow>
-                            <TableRow className={classes.tableRow}>
-                                <TableCell className={classes.tableCell}>
-                                    <Typography className={classes.labelText}>Altitude</Typography>
-                                </TableCell>
-                                <TableCell className={clsx(classes.tableCell, classes.valueText)}>
-                                    <DebounceInput
-                                        element='input'
-                                        title='Altitude-input'
-                                        disabled={disabled}
-                                        value={details.Altitude || ''}
-                                        type='number'
-                                        name='Altitude'
-                                        onChange={onChange}
-                                        className={clsx(classes.input, classes.datasetFieldInput)}
-                                        style={{ ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Altitude')) }}
-                                    />
-                                </TableCell>
-                            </TableRow>
-                            <RotationOriginInput originalFields={originalFields} TS0={details.TS0} TS1={details.TS1} TS2={details.TS2} onChange={onChange} />
-                            <RotationQuaternionInput originalFields={originalFields} R0={details.R0} R1={details.R1} R2={details.R2} R3={details.R3} onChange={onChange} />
+                            {
+                                isItemView ? null : (
+                                    <>
+                                        <TableRow className={classes.tableRow}>
+                                            <TableCell className={classes.tableCell}>
+                                                <Typography className={classes.labelText}>Latitude</Typography>
+                                            </TableCell>
+                                            <TableCell className={clsx(classes.tableCell, classes.valueText)}>
+                                                <DebounceInput
+                                                    element='input'
+                                                    title='Latitude-input'
+                                                    disabled={disabled}
+                                                    value={details.Latitude || ''}
+                                                    type='number'
+                                                    name='Latitude'
+                                                    onChange={onChange}
+                                                    className={clsx(classes.input, classes.datasetFieldInput)}
+                                                    style={{ ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Latitude')) }}
+                                                />
+                                            </TableCell>
+                                        </TableRow>
+                                        <TableRow className={classes.tableRow}>
+                                            <TableCell className={classes.tableCell}>
+                                                <Typography className={classes.labelText}>Longitude</Typography>
+                                            </TableCell>
+                                            <TableCell className={clsx(classes.tableCell, classes.valueText)}>
+                                                <DebounceInput
+                                                    element='input'
+                                                    title='Longitude-input'
+                                                    disabled={disabled}
+                                                    value={details.Longitude || ''}
+                                                    type='number'
+                                                    name='Longitude'
+                                                    onChange={onChange}
+                                                    className={clsx(classes.input, classes.datasetFieldInput)}
+                                                    style={{ ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Longitude')) }}
+                                                />
+                                            </TableCell>
+                                        </TableRow>
+                                        <TableRow className={classes.tableRow}>
+                                            <TableCell className={classes.tableCell}>
+                                                <Typography className={classes.labelText}>Altitude</Typography>
+                                            </TableCell>
+                                            <TableCell className={clsx(classes.tableCell, classes.valueText)}>
+                                                <DebounceInput
+                                                    element='input'
+                                                    title='Altitude-input'
+                                                    disabled={disabled}
+                                                    value={details.Altitude || ''}
+                                                    type='number'
+                                                    name='Altitude'
+                                                    onChange={onChange}
+                                                    className={clsx(classes.input, classes.datasetFieldInput)}
+                                                    style={{ ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Altitude')) }}
+                                                />
+                                            </TableCell>
+                                        </TableRow>
+                                        <RotationOriginInput originalFields={originalFields} TS0={details.TS0} TS1={details.TS1} TS2={details.TS2} onChange={onChange} />
+                                        <RotationQuaternionInput originalFields={originalFields} R0={details.R0} R1={details.R1} R2={details.R2} R3={details.R3} onChange={onChange} />
+                                    </>
+                                )
+                            }
                         </TableBody>
                     </Table>
                 </TableContainer>

--- a/client/src/pages/Repository/components/RepositoryTreeView/RepositoryTreeHeader.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/RepositoryTreeHeader.tsx
@@ -13,7 +13,6 @@ import { getTreeViewColumns } from '../../../../utils/repository';
 import MetadataView from './MetadataView';
 import ResizeObserver from 'resize-observer-polyfill';
 import { useTreeColumnsStore } from '../../../../store';
-import { debounce } from 'lodash';
 import clsx from 'clsx';
 
 const SO_NAME_COLUMN_HEADER = 'object-name';
@@ -112,10 +111,9 @@ function RepositoryTreeHeader(props: RepositoryTreeHeaderProps): React.ReactElem
         const columnSet = new Set<ResizeObserver>();
 
         // Debouncing the width update makes the transition smoother
-        const debounceUpdateWidth = debounce(updateWidth, 5);
         const nameHeader = document.getElementById(SO_NAME_COLUMN_HEADER);
         const columnObersver = new ResizeObserver((e) => {
-            debounceUpdateWidth(SO_NAME_COLUMN_HEADER, String(e[0].contentRect.width));
+            updateWidth(SO_NAME_COLUMN_HEADER, String(e[0].contentRect.width));
         });
         if (nameHeader)
             columnObersver.observe(nameHeader);
@@ -123,7 +121,7 @@ function RepositoryTreeHeader(props: RepositoryTreeHeaderProps): React.ReactElem
             const target = document.getElementById(`column-${col.label}`);
             if (target) {
                 const columnObersver = new ResizeObserver((e) => {
-                    debounceUpdateWidth(col.metadataColumn as number, String(e[0].contentRect.width));
+                    updateWidth(col.metadataColumn as number, String(e[0].contentRect.width));
                 });
                 columnObersver.observe(target);
                 columnSet.add(columnObersver);

--- a/client/src/pages/Workflow/components/WorkflowView/WorkflowList.tsx
+++ b/client/src/pages/Workflow/components/WorkflowView/WorkflowList.tsx
@@ -165,7 +165,7 @@ function WorkflowList(): React.ReactElement {
         elevation: 0,
         viewColumns: false,
         rowsPerPage: rowCount,
-        rowsPerPageOptions: [10, 25, 100],
+        rowsPerPageOptions: [50, 100],
         sortOrder: { name: workflowListSortEnumToString(sortBy), direction: sortOrder ? 'asc' : 'desc' },
         onColumnSortChange: (changedColumn: string, direction: string) => paginationUpdateAndRefetchList(ePaginationChange.eSort, null, changedColumn, direction),
         customTableBodyFooterRender: function Pagination() {
@@ -180,6 +180,7 @@ function WorkflowList(): React.ReactElement {
                             onChangePage={(_e, currentPage) => paginationUpdateAndRefetchList(ePaginationChange.ePage, currentPage, null, null)}
                             backIconButtonProps={{ className: classes.footerBtn }}
                             nextIconButtonProps={{ className: classes.footerBtn }}
+                            rowsPerPageOptions={[50, 100]}
                         />
                     </tr>
                 </tfoot>

--- a/client/src/store/workflow.tsx
+++ b/client/src/store/workflow.tsx
@@ -43,7 +43,7 @@ export const useWorkflowStore = create<WorkflowStore>((set: SetState<WorkflowSto
     dateFrom: null,
     dateTo: null,
     pageNumber: 0,
-    rowCount: 10,
+    rowCount: 50,
     sortBy: eWorkflowListSortColumns.eStart,
     sortOrder: false,
     loading: false,


### PR DESCRIPTION
612:
Set default row count to 50 and on changed rowsPerPage option in footer to 50 and 100

617:
Removed location information from items/media groups

620:
Removed the display menu icon on the top right of the AssetGrid (until further notice)

631:
Only issue the prompt when user is in Subject/Item or Metadata step

Repository:
Removed debouncing for column resizing for a smoother transition