### PR TITLE
Fix for 625: update ModelSceneXref when ingesting new svx.json (either directly or via Voyager -> WebDAV)

### DIFF
--- a/server/db/api/ModelSceneXref.ts
+++ b/server/db/api/ModelSceneXref.ts
@@ -49,22 +49,39 @@ export class ModelSceneXref extends DBC.DBObject<ModelSceneXrefBase> implements 
             && this.S2 === MSX.S2;
     }
     /** return true if transform is updated */
-    public updateTransformIfNeeded(MSX: ModelSceneXref): boolean {
-        let retValue: boolean = false;
+    public updateIfNeeded(MSX: ModelSceneXref): { transformUpdated: boolean, updated: boolean } {
+        let updated: boolean = false;
+        let transformUpdated: boolean = false;
         const logContext: string = `${H.Helpers.JSONStringify(this)} vs incoming ${H.Helpers.JSONStringify(MSX)}`;
-        if (H.Helpers.safeRound(this.TS0) !== H.Helpers.safeRound(MSX.TS0)) { this.TS0 = MSX.TS0; retValue = true; }
-        if (H.Helpers.safeRound(this.TS1) !== H.Helpers.safeRound(MSX.TS1)) { this.TS1 = MSX.TS1; retValue = true; }
-        if (H.Helpers.safeRound(this.TS2) !== H.Helpers.safeRound(MSX.TS2)) { this.TS2 = MSX.TS2; retValue = true; }
-        if (H.Helpers.safeRound(this.R0)  !== H.Helpers.safeRound(MSX.R0))  { this.R0  = MSX.R0;  retValue = true; }
-        if (H.Helpers.safeRound(this.R1)  !== H.Helpers.safeRound(MSX.R1))  { this.R1  = MSX.R1;  retValue = true; }
-        if (H.Helpers.safeRound(this.R2)  !== H.Helpers.safeRound(MSX.R2))  { this.R2  = MSX.R2;  retValue = true; }
-        if (H.Helpers.safeRound(this.R3)  !== H.Helpers.safeRound(MSX.R3))  { this.R3  = MSX.R3;  retValue = true; }
-        if (H.Helpers.safeRound(this.S0)  !== H.Helpers.safeRound(MSX.S0))  { this.S0  = MSX.S0; retValue = true; }
-        if (H.Helpers.safeRound(this.S1)  !== H.Helpers.safeRound(MSX.S1))  { this.S1  = MSX.S1; retValue = true; }
-        if (H.Helpers.safeRound(this.S2)  !== H.Helpers.safeRound(MSX.S2))  { this.S2  = MSX.S2; retValue = true; }
-        if (retValue)
-            LOG.info(`ModelSceneXref.updateTransformIfNeeded UPDATED: ${logContext}`, LOG.LS.eDB);
-        return retValue;
+
+        if (this.Name                                   !== MSX.Name)                                   { this.Name             = MSX.Name;             updated = true; }
+        if (this.Usage                                  !== MSX.Usage)                                  { this.Usage            = MSX.Usage;            updated = true; }
+        if (this.Quality                                !== MSX.Quality)                                { this.Quality          = MSX.Quality;          updated = true; }
+        if (this.FileSize                               !== MSX.FileSize)                               { this.FileSize         = MSX.FileSize;         updated = true; }
+        if (this.UVResolution                           !== MSX.UVResolution)                           { this.UVResolution     = MSX.UVResolution;     updated = true; }
+        if (H.Helpers.safeRound(this.BoundingBoxP1X)    !== H.Helpers.safeRound(MSX.BoundingBoxP1X))    { this.BoundingBoxP1X   = MSX.BoundingBoxP1X;   updated = true; }
+        if (H.Helpers.safeRound(this.BoundingBoxP1Y)    !== H.Helpers.safeRound(MSX.BoundingBoxP1Y))    { this.BoundingBoxP1Y   = MSX.BoundingBoxP1Y;   updated = true; }
+        if (H.Helpers.safeRound(this.BoundingBoxP1Z)    !== H.Helpers.safeRound(MSX.BoundingBoxP1Z))    { this.BoundingBoxP1Z   = MSX.BoundingBoxP1Z;   updated = true; }
+        if (H.Helpers.safeRound(this.BoundingBoxP2X)    !== H.Helpers.safeRound(MSX.BoundingBoxP2X))    { this.BoundingBoxP2X   = MSX.BoundingBoxP2X;   updated = true; }
+        if (H.Helpers.safeRound(this.BoundingBoxP2Y)    !== H.Helpers.safeRound(MSX.BoundingBoxP2Y))    { this.BoundingBoxP2Y   = MSX.BoundingBoxP2Y;   updated = true; }
+        if (H.Helpers.safeRound(this.BoundingBoxP2Z)    !== H.Helpers.safeRound(MSX.BoundingBoxP2Z))    { this.BoundingBoxP2Z   = MSX.BoundingBoxP2Z;   updated = true; }
+
+        if (H.Helpers.safeRound(this.TS0)               !== H.Helpers.safeRound(MSX.TS0))               { this.TS0 = MSX.TS0; transformUpdated = true; }
+        if (H.Helpers.safeRound(this.TS1)               !== H.Helpers.safeRound(MSX.TS1))               { this.TS1 = MSX.TS1; transformUpdated = true; }
+        if (H.Helpers.safeRound(this.TS2)               !== H.Helpers.safeRound(MSX.TS2))               { this.TS2 = MSX.TS2; transformUpdated = true; }
+        if (H.Helpers.safeRound(this.R0)                !== H.Helpers.safeRound(MSX.R0))                { this.R0  = MSX.R0;  transformUpdated = true; }
+        if (H.Helpers.safeRound(this.R1)                !== H.Helpers.safeRound(MSX.R1))                { this.R1  = MSX.R1;  transformUpdated = true; }
+        if (H.Helpers.safeRound(this.R2)                !== H.Helpers.safeRound(MSX.R2))                { this.R2  = MSX.R2;  transformUpdated = true; }
+        if (H.Helpers.safeRound(this.R3)                !== H.Helpers.safeRound(MSX.R3))                { this.R3  = MSX.R3;  transformUpdated = true; }
+        if (H.Helpers.safeRound(this.S0)                !== H.Helpers.safeRound(MSX.S0))                { this.S0  = MSX.S0;  transformUpdated = true; }
+        if (H.Helpers.safeRound(this.S1)                !== H.Helpers.safeRound(MSX.S1))                { this.S1  = MSX.S1;  transformUpdated = true; }
+        if (H.Helpers.safeRound(this.S2)                !== H.Helpers.safeRound(MSX.S2))                { this.S2  = MSX.S2;  transformUpdated = true; }
+
+        if (transformUpdated)
+            updated = true;
+        if (updated)
+            LOG.info(`ModelSceneXref.updateTransformIfNeeded ${transformUpdated ? 'TRANSFORM UPDATED' : 'UPDATED'}: ${logContext}`, LOG.LS.eDB);
+        return { transformUpdated, updated };
     }
 
     public computeModelAutomationTag(): string {

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
@@ -181,7 +181,7 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
                 if (!Item)
                     return sendResult(false, `Unable to fetch Media Group with id ${idObject}; update failed`);
 
-                Item.Name = computeNewName(Item.Name, Item.Title, data.Subtitle); // do this before updating .Title
+                Item.Name = (data.Name && !data.Subtitle) ? data.Name : computeNewName(Item.Name, Item.Title, data.Subtitle); // do this before updating .Title
                 Item.Title = data.Subtitle ?? null;
 
                 if (!isNull(EntireSubject) && !isUndefined(EntireSubject))
@@ -323,7 +323,7 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
                     ModelFileType
                 } = data.Model;
 
-                Model.Name = computeNewName(Model.Name, Model.Title, data.Subtitle); // do this before updating .Title
+                Model.Name = (data.Name && !data.Subtitle) ? data.Name : computeNewName(Model.Name, Model.Title, data.Subtitle); // do this before updating .Title
                 Model.Title = data.Subtitle ?? null;
 
                 if (CreationMethod) Model.idVCreationMethod = CreationMethod;
@@ -345,7 +345,7 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
 
             const oldPosedAndQCd: boolean = Scene.PosedAndQCd;
 
-            Scene.Name = computeNewName(Scene.Name, Scene.Title, data.Subtitle); // do this before updated .Title
+            Scene.Name = (data.Name && !data.Subtitle) ? data.Name : computeNewName(Scene.Name, Scene.Title, data.Subtitle); // do this before updated .Title
             Scene.Title = data.Subtitle ?? null;
 
             if (data.Scene) {
@@ -520,6 +520,9 @@ export async function handleMetadata(idSystemObject: number, metadatas: Metadata
 }
 
 function computeNewName(oldName: string, oldTitle: string | null, newTitle: string | null | undefined): string {
-    return ((!oldTitle) ? oldName : oldName.replace(`: ${oldTitle}`, '')) // strip off old title
-        + (newTitle) ? `: ${newTitle}` : '';
+    const oldBaseName: string = (!oldTitle) ? oldName : oldName.replace(`: ${oldTitle}`, ''); // strip off old title
+    const newName: string = oldBaseName + ((newTitle) ? `: ${newTitle}` : '');
+    // LOG.info(`updateObjectDetails computeNewName(${oldName}, ${oldTitle}, ${newTitle}) = ${newName} (oldBaseName = ${oldBaseName})`, LOG.LS.eGQL);
+
+    return newName;
 }

--- a/server/graphql/schema/systemobject/resolvers/queries/AssetGridDetailScene.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/AssetGridDetailScene.ts
@@ -20,6 +20,7 @@ export class AssetGridDetailScene extends AssetGridDetailBase {
     // usage: string | null;
     quality: string | null;
     uvResolution: number | null;
+    boundingBox: string | null;
 
     isAttachment: boolean | null;
     type: string | null;
@@ -44,6 +45,7 @@ export class AssetGridDetailScene extends AssetGridDetailBase {
         // this.usage = H.Helpers.safeString(metadataMap.get('usage'));
         this.quality = H.Helpers.safeString(metadataMap.get('quality'));
         this.uvResolution = H.Helpers.safeNumber(metadataMap.get('uvresolution'));
+        this.boundingBox = H.Helpers.safeString(metadataMap.get('boundingbox'));
 
         this.isAttachment = H.Helpers.safeBoolean(metadataMap.get('isattachment'));
         this.type = H.Helpers.safeString(metadataMap.get('type'));
@@ -70,6 +72,7 @@ export class AssetGridDetailScene extends AssetGridDetailBase {
             // { colName: 'usage', colLabel: 'Usage', colDisplay: true, colType: COMMON.eAssetGridColumnType.eString, colAlign: 'left' },
             { colName: 'quality', colLabel: 'Quality', colDisplay: true, colType: COMMON.eAssetGridColumnType.eString, colAlign: 'center' },
             { colName: 'uvResolution', colLabel: 'UV', colDisplay: true, colType: COMMON.eAssetGridColumnType.eNumber, colAlign: 'center' },
+            { colName: 'boundingBox', colLabel: 'Bounding Box', colDisplay: true, colType: COMMON.eAssetGridColumnType.eString, colAlign: 'center' },
 
             { colName: 'isAttachment', colLabel: 'Att?', colDisplay: true, colType: COMMON.eAssetGridColumnType.eBoolean, colAlign: 'center' },
             { colName: 'type', colLabel: 'Type', colDisplay: true, colType: COMMON.eAssetGridColumnType.eString, colAlign: 'left' },
@@ -84,7 +87,7 @@ export class AssetGridDetailScene extends AssetGridDetailBase {
     }
 
     static getMetadataColumnNames(): string[] {
-        return [/* 'usage', */ 'quality', 'uvresolution', 'isattachment', 'type', 'category', 'units', 'modeltype', 'filetype', 'gltfstandardized', 'dracocompressed', 'title'];
+        return [/* 'usage', */ 'quality', 'uvresolution', 'boundingbox', 'isattachment', 'type', 'category', 'units', 'modeltype', 'filetype', 'gltfstandardized', 'dracocompressed', 'title'];
     }
 }
 

--- a/server/graphql/schema/systemobject/resolvers/queries/getAssetDetailsForSystemObject.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getAssetDetailsForSystemObject.ts
@@ -3,6 +3,7 @@ import * as DBAPI from '../../../../../db';
 import * as CACHE from '../../../../../cache';
 import * as NAV from '../../../../../navigation/interface';
 import * as LOG from '../../../../../utils/logger';
+// import * as H from '../../../../../utils/helpers';
 import { ColumnDefinition, GetAssetDetailsForSystemObjectResult, QueryGetAssetDetailsForSystemObjectArgs } from '../../../../../types/graphql';
 import { Parent } from '../../../../../types/resolvers';
 import { VocabularyCache } from '../../../../../cache';
@@ -167,6 +168,7 @@ async function extractMetadata(idSystemObject: number, metadataColumns: string[]
 
 async function extractSceneAttachmentMetadata(idScene: number, metadataMetaMap: Map<number, Map<string, string>>): Promise<boolean> {
     const MSXs: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromScene(idScene);
+    // LOG.info(`getAssetDetailsForSystemObject MSXs ${H.Helpers.JSONStringify(MSXs)}`, LOG.LS.eGQL);
     if (!MSXs) {
         LOG.error(`getAssetDetailsForSystemObject extractSceneAttachmentMetadata failed to fetch ModelSceneXref for scene ${idScene}`, LOG.LS.eGQL);
         return false;
@@ -202,13 +204,14 @@ async function extractSceneAttachmentMetadata(idScene: number, metadataMetaMap: 
                 metadataMap.set('quality', MSX.Quality);
             if (MSX.UVResolution)
                 metadataMap.set('uvresolution', MSX.UVResolution.toString());
+            if (MSX.BoundingBoxP1X && MSX.BoundingBoxP1Y && MSX.BoundingBoxP1Z && MSX.BoundingBoxP2X && MSX.BoundingBoxP2Y && MSX.BoundingBoxP2Z)
+                metadataMap.set('boundingbox', `(${round(MSX.BoundingBoxP1X)}, ${round(MSX.BoundingBoxP1Y)}, ${round(MSX.BoundingBoxP1Z)}) - (${round(MSX.BoundingBoxP2X)}, ${round(MSX.BoundingBoxP2Y)}, ${round(MSX.BoundingBoxP2Z)})`);
+            // LOG.info(`getAssetDetailsForSystemObject metadataMap[${SOIAV.idSystemObject}]=${H.Helpers.JSONStringify(metadataMap)}`, LOG.LS.eGQL);
         }
-        // if (MSX.BoundingBoxP1X && MSX.BoundingBoxP1Y && MSX.BoundingBoxP1Z && MSX.BoundingBoxP2X && MSX.BoundingBoxP2Y && MSX.BoundingBoxP2Z)
-        //     metadataMap.set('boundingbox', `(${round(MSX.BoundingBoxP1X)}, ${round(MSX.BoundingBoxP1Y)}, ${round(MSX.BoundingBoxP1Z)}) - (${round(MSX.BoundingBoxP2X)}, ${round(MSX.BoundingBoxP2Y)}, ${round(MSX.BoundingBoxP2Z)})`);
     }
     return true;
 }
 
-// function round(num: number): string {
-//     return (Math.ceil(num * 100) / 100).toString();
-// }
+function round(num: number): string {
+    return (Math.ceil(num * 100) / 100).toString();
+}

--- a/server/storage/interface/AssetStorageAdapter.ts
+++ b/server/storage/interface/AssetStorageAdapter.ts
@@ -682,13 +682,16 @@ export class AssetStorageAdapter {
                 const MSXSource: DBAPI.ModelSceneXref | null = (MSXSources && MSXSources.length > 0) ? MSXSources[0] : null;
                 if (MSXSource) {
                     LOG.info(`AssetStorageAdapter.detectAndHandleSceneIngest found existing ModelSceneXref=${JSON.stringify(MSXSource, H.Helpers.saferStringify)} from referenced model ${JSON.stringify(MSX, H.Helpers.saferStringify)}`, LOG.LS.eSTR);
-                    if (MSXSource.updateTransformIfNeeded(MSX)) {
+                    const { transformUpdated: transformUpdatedLocal, updated } = MSXSource.updateIfNeeded(MSX);
+
+                    if (updated) {
                         if (!await MSXSource.update()) {
                             LOG.error(`AssetStorageAdapter.detectAndHandleSceneIngest unable to update ModelSceneXref ${JSON.stringify(MSXSource, H.Helpers.saferStringify)}`, LOG.LS.eSTR);
                             success = false;
                         }
-                        transformUpdated = true;
                     }
+                    if (transformUpdatedLocal)
+                        transformUpdated = true;
                 } else {
                     // Could not find the ModelSceneXref
                     transformUpdated = true;

--- a/server/tests/db/dbcreation.test.ts
+++ b/server/tests/db/dbcreation.test.ts
@@ -5355,51 +5355,130 @@ describe('DB Fetch Special Test Suite', () => {
 
     test('DB Update: ModelSceneXref.isTransformMatching', async () => {
         let modelSceneXrefClone: DBAPI.ModelSceneXref | null = null;
+        let transformUpdated: boolean = false;
+        let updated: boolean = false;
         if (modelSceneXref) {
             modelSceneXrefClone = new DBAPI.ModelSceneXref(modelSceneXref);
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeTruthy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeFalsy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeFalsy();
 
             modelSceneXrefClone.S2 = (modelSceneXref.S2 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.S1 = (modelSceneXref.S1 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.S0 = (modelSceneXref.S0 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.R3 = (modelSceneXref.R3 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.R2 = (modelSceneXref.R2 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.R1 = (modelSceneXref.R1 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.R0 = (modelSceneXref.R0 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.TS2 = (modelSceneXref.TS2 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.TS1 = (modelSceneXref.TS1 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
 
             modelSceneXrefClone.TS0 = (modelSceneXref.TS0 ?? 0) + 1;
             expect(modelSceneXrefClone.isTransformMatching(modelSceneXref)).toBeFalsy();
-            expect(modelSceneXrefClone.updateTransformIfNeeded(modelSceneXref)).toBeTruthy();
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeTruthy();
+            expect(updated).toBeTruthy();
             // LOG.info(`clone = ${JSON.stringify(modelSceneXrefClone, H.Helpers.saferStringify)} vs ${JSON.stringify(modelSceneXref, H.Helpers.saferStringify)}}`, LOG.LS.eTEST);
+
+            modelSceneXrefClone.BoundingBoxP2Z = (modelSceneXref.BoundingBoxP2Z ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.BoundingBoxP2Y = (modelSceneXref.BoundingBoxP2Y ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.BoundingBoxP2X = (modelSceneXref.BoundingBoxP2X ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.BoundingBoxP1Z = (modelSceneXref.BoundingBoxP1Z ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.BoundingBoxP1Y = (modelSceneXref.BoundingBoxP1Y ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.BoundingBoxP1X = (modelSceneXref.BoundingBoxP1X ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.UVResolution = (modelSceneXref.UVResolution ?? 0) + 1;
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.FileSize = (modelSceneXref.FileSize ?? BigInt(0)) + BigInt(1);
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.Quality = (modelSceneXref.Quality ?? '') + 'abba';
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.Usage = (modelSceneXref.Usage ?? '') + 'abba';
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
+
+            modelSceneXrefClone.Name = (modelSceneXref.Name ?? '') + 'abba';
+            ({ transformUpdated, updated } = modelSceneXrefClone.updateIfNeeded(modelSceneXref));
+            expect(transformUpdated).toBeFalsy();
+            expect(updated).toBeTruthy();
 
             const modelAutomationTag: string = modelSceneXrefClone.computeModelAutomationTag();
             expect(modelAutomationTag.includes(modelSceneXrefClone.Usage ?? '')).toBeTruthy();


### PR DESCRIPTION
DBAPI:
* Renamed ModelSceneXref.updateTransformIfNeeded to updateIfNeeded, and update all non-DB ID fields, both transform-related and others

GraphQL:
* If updateObjectDetails input contains a name and no Subtitle, use the name for Item, Model, and Scene updates.
* Add Bounding Box column output to scene asset list
* During ingestData, use updated ModelSceneXref.updateIfNeeded to update all non-DB ID fields (transform and others)

Storage:
* During scene ingestion (such as via WebDAV updates by Voyager Story),  use updated ModelSceneXref.updateIfNeeded to update all non-DB ID fields (transform and others)