### PR TITLE
Address DPO3DPKRT-635 Editable Asset Grid

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetGrid.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetGrid.tsx
@@ -221,7 +221,7 @@ function AssetGrid(props: AssetGridProps): React.ReactElement {
         if (typeof assetColumnsDisplay === 'object')
             return assetColumnsDisplay;
         return false;
-    }
+    };
 
     const formatToDataTableColumns = (fields: any[], classes, displayHash): any[] => {
         const result: any[] = [];


### PR DESCRIPTION
-Persists hidden/shown columns of AssetGrid in cookie
-Performs future renders using saved cookie
-Addressed bug of referencing `column.hide` when it should be referencing `column.display`