### PR TITLE
UI/647&649

### DIFF
--- a/client/src/pages/Admin/components/AdminUsersView.tsx
+++ b/client/src/pages/Admin/components/AdminUsersView.tsx
@@ -49,7 +49,8 @@ function AdminUsersView(): React.ReactElement {
                         active: User_Status.EAll,
                         search: ''
                     }
-                }
+                },
+                fetchPolicy: 'no-cache'
             });
             const {
                 data: {
@@ -70,7 +71,8 @@ function AdminUsersView(): React.ReactElement {
                     active: newActive,
                     search: newSearchText
                 }
-            }
+            },
+            fetchPolicy: 'no-cache'
         });
         const {
             data: {

--- a/client/src/pages/Ingestion/components/Metadata/Photogrammetry/AssetContents.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Photogrammetry/AssetContents.tsx
@@ -12,6 +12,7 @@ import { StateFolder, VocabularyOption } from '../../../../../store';
 import { palette } from '../../../../../theme';
 import { ViewableProps } from '../../../../../types/repository';
 import { getNullableSelectEntries } from '../../../../../utils/controls';
+import { updatedFieldStyling } from '../../../../Repository/components/DetailsView/DetailsTab/CaptureDataDetails';
 
 export const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
     emptyFolders: {
@@ -47,12 +48,13 @@ export const useStyles = makeStyles(({ palette, typography, breakpoints }) => ({
 
 interface AssetContentsProps extends ViewableProps {
     folders: StateFolder[];
+    originalFolders: StateFolder[];
     options: VocabularyOption[];
     onUpdate: (id: number, variantType: number) => void;
 }
 
 function AssetContents(props: AssetContentsProps): React.ReactElement {
-    const { folders, options, onUpdate, disabled = false } = props;
+    const { folders, options, onUpdate, disabled = false, originalFolders } = props;
     const classes = useStyles();
     return (
         <TableContainer component={Paper} className={classes.tableContainer} elevation={0}>
@@ -72,7 +74,7 @@ function AssetContents(props: AssetContentsProps): React.ReactElement {
                     </TableRow>
                     {folders.length > 0 && (folders.map(({ id, name, variantType }: StateFolder, index: number) => {
                         const update = ({ target }) => onUpdate(id, target.value);
-
+                        const originalFolder = originalFolders.find((folder) => folder.name === name);
                         return (
                             <TableRow key={index}>
                                 <TableCell className={classes.paddedCell} style={{ paddingTop: index === 0 ? 5 : 1 }}>
@@ -92,6 +94,7 @@ function AssetContents(props: AssetContentsProps): React.ReactElement {
                                         disableUnderline
                                         className={classes.select}
                                         SelectDisplayProps={{ style: { paddingLeft: '10px', paddingRight: '10px', borderRadius: '5px' } }}
+                                        style={{ ...updatedFieldStyling(originalFolder?.variantType !== variantType) }}
                                     >
                                         {getNullableSelectEntries(options, 'idVocabulary', 'Term').map(({ value, label }, index) => <MenuItem key={index} value={value}>{label}</MenuItem>)}
                                     </Select>

--- a/client/src/pages/Ingestion/components/Metadata/Photogrammetry/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Photogrammetry/index.tsx
@@ -251,6 +251,7 @@ function Photogrammetry(props: PhotogrammetryProps): React.ReactElement {
 
                 <AssetContents
                     folders={photogrammetry.folders}
+                    originalFolders={[...photogrammetry.folders]}
                     options={getEntries(eVocabularySetID.eCaptureDataFileVariantType)}
                     onUpdate={updateFolderVariant}
                 />

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
@@ -169,7 +169,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
 
     const cdDetailsDate = new Date(CaptureDataDetails.dateCaptured as string);
     const cdDataDate = new Date(captureDataData?.dateCaptured as string);
-    console.log(`${cdDataDate.getMonth()}/${cdDataDate.getDate()}/${cdDataDate.getFullYear()}`, `${cdDetailsDate.getMonth()}/${cdDetailsDate.getDate()}/${cdDetailsDate.getFullYear()}`)
+    console.log(`${cdDataDate.getMonth()}/${cdDataDate.getDate()}/${cdDataDate.getFullYear()}`, `${cdDetailsDate.getMonth()}/${cdDetailsDate.getDate()}/${cdDetailsDate.getFullYear()}`);
 
     return (
         <Box>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
@@ -9,7 +9,7 @@
 import { Box, MenuItem, Select, Typography, Table, TableBody, TableCell, TableContainer, TableRow, Paper, Checkbox } from '@material-ui/core';
 import React, { useEffect } from 'react';
 import { DateInputField, Loader } from '../../../../../components';
-import { parseFoldersToState, useVocabularyStore } from '../../../../../store';
+import { parseFoldersToState, StateFolder, useVocabularyStore } from '../../../../../store';
 import { eVocabularySetID, eSystemObjectType } from '@dpo-packrat/common';
 import { isFieldUpdated } from '../../../../../utils/repository';
 import { withDefaultValueNumber } from '../../../../../utils/shared';
@@ -166,6 +166,11 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
     const cdMethods = getEntries(eVocabularySetID.eCaptureDataCaptureMethod);
     const captureMethodidVocabulary = withDefaultValueNumber(CaptureDataDetails?.captureMethod, getInitialEntry(eVocabularySetID.eCaptureDataCaptureMethod));
     const captureMethod = cdMethods.find(method => method.idVocabulary === captureMethodidVocabulary);
+
+    const cdDetailsDate = new Date(CaptureDataDetails.dateCaptured as string);
+    const cdDataDate = new Date(captureDataData?.dateCaptured as string);
+    console.log(`${cdDataDate.getMonth()}/${cdDataDate.getDate()}/${cdDataDate.getFullYear()}`, `${cdDetailsDate.getMonth()}/${cdDetailsDate.getDate()}/${cdDetailsDate.getFullYear()}`)
+
     return (
         <Box>
             <Description
@@ -198,7 +203,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                                 </TableCell>
                                 <TableCell className={classes.tableCell}>
                                     <DateInputField
-                                        updated={isFieldUpdated(CaptureDataDetails, captureDataData, 'dateCaptured')}
+                                        updated={`${cdDataDate.getMonth()}/${cdDataDate.getDate()}/${cdDataDate.getFullYear()}` !== `${cdDetailsDate.getMonth()}/${cdDetailsDate.getDate()}/${cdDetailsDate.getFullYear()}`}
                                         value={new Date(CaptureDataDetails?.dateCaptured ?? Date.now())}
                                         disabled={disabled}
                                         onChange={(_, value) => setDateField('dateCaptured', value)}
@@ -235,6 +240,7 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
                     folders={parseFoldersToState(CaptureDataDetails?.folders ?? [])}
                     options={getEntries(eVocabularySetID.eCaptureDataFileVariantType)}
                     onUpdate={updateFolderVariant}
+                    originalFolders={data?.getDetailsTabDataForObject?.CaptureData?.folders as StateFolder[]}
                 />
 
                 <Box className={classes.fieldTableBoxContainer}>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/CaptureDataDetails.tsx
@@ -169,7 +169,6 @@ function CaptureDataDetails(props: DetailComponentProps): React.ReactElement {
 
     const cdDetailsDate = new Date(CaptureDataDetails.dateCaptured as string);
     const cdDataDate = new Date(captureDataData?.dateCaptured as string);
-    console.log(`${cdDataDate.getMonth()}/${cdDataDate.getDate()}/${cdDataDate.getFullYear()}`, `${cdDetailsDate.getMonth()}/${cdDetailsDate.getDate()}/${cdDetailsDate.getFullYear()}`);
 
     return (
         <Box>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/ItemDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/ItemDetails.tsx
@@ -18,7 +18,8 @@ export interface ItemDetailFields extends SubjectDetailFields {
 }
 
 function ItemDetails(props: DetailComponentProps): React.ReactElement {
-    const { data, loading, disabled, onUpdateDetail, objectType, subtitle, onSubtitleUpdate } = props;
+    const { data, loading, disabled, onUpdateDetail, objectType, subtitle, onSubtitleUpdate, originalSubtitle } = props;
+
     const [ItemDetails, updateDetailField] = useDetailTabStore(state => [state.ItemDetails, state.updateDetailField]);
 
     useEffect(() => {
@@ -50,6 +51,7 @@ function ItemDetails(props: DetailComponentProps): React.ReactElement {
                 disabled={disabled}
                 onChange={onSetField}
                 subtitle={subtitle}
+                originalSubtitle={originalSubtitle}
                 onSubtitleUpdate={onSubtitleUpdate}
                 isItemView
                 setCheckboxField={setCheckboxField}

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/ModelDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/ModelDetails.tsx
@@ -16,6 +16,8 @@ import { DetailComponentProps } from './index';
 import { useStyles as useSelectStyles, SelectFieldProps } from '../../../../../components/controls/SelectField';
 import { DebounceInput } from 'react-debounce-input';
 import ObjectMeshTable from '../../../../Ingestion/components/Metadata/Model/ObjectMeshTable';
+import { updatedFieldStyling } from './CaptureDataDetails';
+import { isFieldUpdated } from '../../../../../utils/repository';
 
 export const useStyles = makeStyles(({ palette, typography }) => ({
     notRequiredFields: {
@@ -85,7 +87,7 @@ export const useStyles = makeStyles(({ palette, typography }) => ({
 
 function ModelDetails(props: DetailComponentProps): React.ReactElement {
     const classes = useStyles();
-    const { data, loading, onUpdateDetail, objectType, subtitle, onSubtitleUpdate } = props;
+    const { data, loading, onUpdateDetail, objectType, subtitle, onSubtitleUpdate, originalSubtitle } = props;
 
     const { ingestionModel, modelObjects } = extractModelConstellation(data?.getDetailsTabDataForObject?.Model);
     const [ModelDetails, updateDetailField] = useDetailTabStore(state => [state.ModelDetails, state.updateDetailField]);
@@ -132,7 +134,7 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                             </Typography>
                         </div>
                         <div style={{ gridColumnStart: 2, gridColumnEnd: 3 }}>
-                            <DebounceInput value={subtitle} onChange={onSubtitleUpdate} className={classes.input} />
+                            <DebounceInput value={subtitle} onChange={onSubtitleUpdate} className={classes.input} style={{ ...updatedFieldStyling(subtitle !== originalSubtitle) }} />
                         </div>
                     </div>
                     <div style={{ display: 'grid', gridTemplateColumns: '120px calc(100% - 120px)', gridColumnGap: 5, padding: '3px 10px 3px 10px', height: 20 }}>
@@ -141,8 +143,8 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                                 Date Created
                             </Typography>
                         </div>
-                        <div style={{ gridColumnStart: 2, gridColumnEnd: 3 }}>
-                            <DateInputField value={ModelDetails.DateCreated} onChange={date => setDateField(date)} dateHeight='22px' />
+                        <div style={{ gridColumnStart: 2, gridColumnEnd: 3 }} >
+                            <DateInputField value={ModelDetails.DateCreated} onChange={date => setDateField(date)} dateHeight='22px' updated={new Date(ingestionModel.DateCreated).toString() !== new Date(ModelDetails?.DateCreated as string)?.toString()} />
                         </div>
                     </div>
                     <SelectField
@@ -155,6 +157,7 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                         selectHeight='24px'
                         valueLeftAligned
                         selectFitContent
+                        updated={isFieldUpdated(ModelDetails, ingestionModel, 'idVCreationMethod')}
                     />
                     <SelectField
                         required
@@ -166,6 +169,7 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                         selectHeight='24px'
                         valueLeftAligned
                         selectFitContent
+                        updated={isFieldUpdated(ModelDetails, ingestionModel, 'idVModality')}
                     />
 
                     <SelectField
@@ -178,6 +182,7 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                         selectHeight='24px'
                         valueLeftAligned
                         selectFitContent
+                        updated={isFieldUpdated(ModelDetails, ingestionModel, 'idVUnits')}
                     />
 
                     <SelectField
@@ -190,6 +195,7 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                         selectHeight='24px'
                         valueLeftAligned
                         selectFitContent
+                        updated={isFieldUpdated(ModelDetails, ingestionModel, 'idVPurpose')}
                     />
 
                     <SelectField
@@ -202,6 +208,7 @@ function ModelDetails(props: DetailComponentProps): React.ReactElement {
                         selectHeight='24px'
                         valueLeftAligned
                         selectFitContent
+                        updated={isFieldUpdated(ModelDetails, ingestionModel, 'idVFileType')}
                     />
                 </Box>
 
@@ -235,7 +242,7 @@ export default ModelDetails;
 
 
 function SelectField(props: SelectFieldProps): React.ReactElement {
-    const { value, name, options, onChange, disabled = false, label } = props;
+    const { value, name, options, onChange, disabled = false, label, updated = false } = props;
     const classes = useSelectStyles(props);
 
     return (
@@ -253,7 +260,7 @@ function SelectField(props: SelectFieldProps): React.ReactElement {
                 disabled={disabled}
                 disableUnderline
                 inputProps={{ 'title': `${name} select`, style: { width: '100%' } }}
-                style={{ minWidth: '100%', width: 'fit-content' }}
+                style={{ minWidth: '100%', width: 'fit-content', ...updatedFieldStyling(updated) }}
                 SelectDisplayProps={{ style: { paddingLeft: '10px', borderRadius: '5px' } }}
             >
                 {options.map(({ idVocabulary, Term }, index) => (

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
@@ -13,6 +13,7 @@ import { apolloClient } from '../../../../../graphql/index';
 import { ReadOnlyRow, CheckboxField, InputField } from '../../../../../components/index';
 import { useDetailTabStore } from '../../../../../store';
 import { eSystemObjectType } from '@dpo-packrat/common';
+import { isFieldUpdated } from '../../../../../utils/repository';
 
 export const useStyles = makeStyles(({ palette }) => ({
     value: {
@@ -36,9 +37,9 @@ export const useStyles = makeStyles(({ palette }) => ({
 function SceneDetails(props: DetailComponentProps): React.ReactElement {
     const classes = useStyles();
     const isMounted = useRef(false);
-    const { data, loading, onUpdateDetail, objectType, subtitle, onSubtitleUpdate } = props;
+    const { data, loading, onUpdateDetail, objectType, subtitle, onSubtitleUpdate, originalSubtitle } = props;
     const [SceneDetails, updateDetailField] = useDetailTabStore(state => [state.SceneDetails, state.updateDetailField]);
-
+    const sceneData = data?.getDetailsTabDataForObject.Scene;
     useEffect(() => {
         const retrieveSceneData = async () => {
             if (data && !loading) {
@@ -100,6 +101,7 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     required
                     padding='3px 10px 1px 10px'
                     containerStyle={{ borderTopLeftRadius: '5px', borderTopRightRadius: '5px', paddingTop: '4px' }}
+                    updated={subtitle !== originalSubtitle}
                 />
                 <CheckboxField
                     label='Approved for Publication'
@@ -109,6 +111,7 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     required
                     padding='1px 10px'
                     containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
+                    updated={isFieldUpdated(SceneDetails, sceneData,'ApprovedForPublication')}
                 />
                 <CheckboxField
                     label="Posed and QC'd"
@@ -120,6 +123,7 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     required
                     padding='1px 10px'
                     containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
+                    updated={isFieldUpdated(SceneDetails, sceneData,'PosedAndQCd')}
                 />
                 <ReadOnlyRow
                     label='EDAN UUID'

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SubjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SubjectDetails.tsx
@@ -52,6 +52,7 @@ interface SubjectFieldsProps extends SubjectDetailFields {
     ItemDetails?: any;
     itemData?: any;
     subtitle?: string;
+    originalSubtitle?: string;
     onSubtitleUpdate?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -75,6 +76,7 @@ export function SubjectFields(props: SubjectFieldsProps): React.ReactElement {
         ItemDetails,
         itemData,
         subtitle,
+        originalSubtitle,
         onSubtitleUpdate
     } = props;
     const classes = useStyles();
@@ -119,7 +121,7 @@ export function SubjectFields(props: SubjectFieldsProps): React.ReactElement {
                                                     padding: '0px 10px',
                                                     borderRadius: 5,
                                                     border: '1px solid rgba(141, 171, 196, 0.4)',
-                                                    ...updatedFieldStyling(isFieldUpdated(details, originalFields, 'Subtitle'))
+                                                    ...updatedFieldStyling(subtitle !== originalSubtitle)
                                                 }}
                                             />
                                         </TableCell>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/index.tsx
@@ -83,6 +83,7 @@ export interface DetailComponentProps extends GetDetailsTabDataForObjectQueryRes
     disabled: boolean;
     objectType: number;
     subtitle: string;
+    originalSubtitle: string;
     onSubtitleUpdate: (e) => void;
     onUpdateDetail: (objectType: number, data: UpdateDataFields) => void;
 }
@@ -113,6 +114,7 @@ type DetailsTabParams = {
     onUpdateDetail: (objectType: number, data: UpdateDataFields) => void;
     onSubtitleUpdate: (e) => void;
     subtitle?: string;
+    originalSubtitle?: string;
     objectVersions: SystemObjectVersion[];
     detailQuery: any;
     metadata: Metadata[]
@@ -131,6 +133,7 @@ function DetailsTab(props: DetailsTabParams): React.ReactElement {
         onUpdateDetail,
         onSubtitleUpdate,
         subtitle,
+        originalSubtitle,
         objectVersions,
         detailQuery,
         metadata
@@ -214,7 +217,8 @@ function DetailsTab(props: DetailsTabParams): React.ReactElement {
         objectType,
         disabled,
         onSubtitleUpdate,
-        subtitle
+        subtitle,
+        originalSubtitle
     };
 
     const detailsProps = {

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -570,6 +570,7 @@ function DetailsView(): React.ReactElement {
                         onUpdateDetail={onUpdateDetail}
                         onSubtitleUpdate={onSubtitleUpdate}
                         subtitle={details?.subtitle}
+                        originalSubtitle={data.getSystemObjectDetails?.subTitle || ''}
                         objectVersions={objectVersions}
                         detailQuery={detailQuery}
                         metadata={metadata}

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -115,6 +115,18 @@ export function parseRepositoryUrl(search: string): any {
         const dateCreatedTo: Date = convertLocalDateToUTC(new Date(dateString));
         filter.dateCreatedTo = safeDate(dateCreatedTo);
     }
+
+    const searchS: RegExpMatchArray | null = search.match(/search=(.*?)([&]|$)/);
+    if (searchS && searchS.length >= 2) {
+        const searchString: string = decodeURIComponent(searchS[1]);
+        filter.search = searchString;
+    }
+
+    const keywordS: RegExpMatchArray | null = search.match(/keyword=(.*?)([&]|$)/);
+    if (keywordS && keywordS.length >= 2) {
+        const keywordString: string = decodeURIComponent(keywordS[1]);
+        filter.keyword = keywordString;
+    }
     return filter;
 }
 

--- a/server/config/solr/data/packrat/conf/schema.xml
+++ b/server/config/solr/data/packrat/conf/schema.xml
@@ -181,6 +181,7 @@
     <copyField source="StakeholderPhoneNumberOffice" dest="_text_"/>
     <copyField source="StakeholderMailingAddress" dest="_text_"/>
     <copyField source="SceneEdanUUID" dest="_text_"/>
+    <copyField source="UnitAbbreviation" dest="_text_"/>
 
     <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field

--- a/server/graphql/schema/systemobject/resolvers/mutations/deleteObjectConnection.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/deleteObjectConnection.ts
@@ -16,7 +16,7 @@ export default async function deleteObjectConnection(_: Parent, args: MutationDe
         const sourceObjectsOfChild = await getRelatedObjects(idSystemObjectDerived, RelatedObjectType.Source);
         const sourceItemCount = sourceObjectsOfChild.filter(source => source.objectType === COMMON.eSystemObjectType.eItem).length;
         if (sourceItemCount <= 1) {
-            return { success: false, details: 'Cannot delete last item parent' };
+            return { success: false, details: 'Cannot delete last media group parent' };
         }
     }
 


### PR DESCRIPTION
This PR will address tickets 647 and 649.
649- Added additional handling for both search and keyword to prevent them from being coerced into numbers.
647- Added notion of originalSubtitle and originalFolders to the appropriate system object types that allow detection of changes

In addition, the following changes were made:
-Disabled caching in admin user UI. Previously, this caused the User List component to not pick up on changes to the User entries
-Changed the error message language of deleteObjectConnection from "item" to "media group"
-Added Unit Abbreviation as a parameter for keyword searches  (Thanks Jon for the educating me on this!)