### PR TITLE
Fix for 659's si-packrat-inspect failures

### DIFF
--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -726,11 +726,11 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         }
 
         // LOG.info(`JobCookSIPackratInspect.testForZipOrStream parameters ${H.Helpers.JSONStringify(this.parameters)}`, LOG.LS.eJOB);
-        if (path.extname(this.parameters.sourceMeshFile).toLowerCase() !== '.zip') {
-            // LOG.info('JobCookSIPackratInspect.testForZipOrStream processing non-zip file', LOG.LS.eJOB);
-            return false;
-        }
-
+        // if (path.extname(this.parameters.sourceMeshFile).toLowerCase() !== '.zip') {
+        //     LOG.info('JobCookSIPackratInspect.testForZipOrStream processing non-zip file', LOG.LS.eJOB);
+        //     return false;
+        // }
+        //
         // LOG.info('JobCookSIPackratInspect.testForZipOrStream processing zip file', LOG.LS.eJOB);
         const RSR: STORE.ReadStreamResult = await STORE.AssetStorageAdapter.readAssetVersionByID(this._idAssetVersions[0]);
         if (!RSR.success || !RSR.readStream) {
@@ -738,6 +738,12 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             return false;
         }
 
+        if (!RSR.fileName || path.extname(RSR.fileName).toLowerCase() !== '.zip') {
+            // LOG.info(`JobCookSIPackratInspect.testForZipOrStream processing non-zip file ${RSR.fileName}`, LOG.LS.eJOB);
+            return false;
+        }
+
+        // LOG.info(`JobCookSIPackratInspect.testForZipOrStream processing zip file ${RSR.fileName}`, LOG.LS.eJOB);
         const ZS: ZipStream = new ZipStream(RSR.readStream);
         const zipRes: H.IOResults = await ZS.load();
         if (!zipRes.success) {
@@ -751,7 +757,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         for (const file of files) {
             const eVocabID: COMMON.eVocabularyID | undefined = CACHE.VocabularyCache.mapModelFileByExtensionID(file);
             const extension: string = path.extname(file).toLowerCase() || file.toLowerCase();
-            // LOG.info(`JobCookSIPackratInspect.testForZipOrStream consdiering zip file entry ${file}, extension ${extension}, VocabID ${eVocabID ? COMMON.eVocabularyID[eVocabID] : 'undefined'}`, LOG.LS.eJOB);
+            // LOG.info(`JobCookSIPackratInspect.testForZipOrStream considering zip file entry ${file}, extension ${extension}, VocabID ${eVocabID ? COMMON.eVocabularyID[eVocabID] : 'undefined'}`, LOG.LS.eJOB);
 
             // for the time being, only handle model geometry files, OBJ .mtl files, and GLTF .bin files
             if (eVocabID === undefined && extension !== '.mtl' && extension !== '.bin')

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -726,12 +726,6 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         }
 
         // LOG.info(`JobCookSIPackratInspect.testForZipOrStream parameters ${H.Helpers.JSONStringify(this.parameters)}`, LOG.LS.eJOB);
-        // if (path.extname(this.parameters.sourceMeshFile).toLowerCase() !== '.zip') {
-        //     LOG.info('JobCookSIPackratInspect.testForZipOrStream processing non-zip file', LOG.LS.eJOB);
-        //     return false;
-        // }
-        //
-        // LOG.info('JobCookSIPackratInspect.testForZipOrStream processing zip file', LOG.LS.eJOB);
         const RSR: STORE.ReadStreamResult = await STORE.AssetStorageAdapter.readAssetVersionByID(this._idAssetVersions[0]);
         if (!RSR.success || !RSR.readStream) {
             LOG.error(`JobCookSIPackratInspect.testForZipOrStream unable to read asset version ${this._idAssetVersions[0]}: ${RSR.error}`, LOG.LS.eJOB);


### PR DESCRIPTION
Cook:
* Updated si-packrat-inspect's test for unzipping to load stream results for the given asset version(s), instead of using the model's name passed in -- the latter may be the name of the uncompressed model file inside a zip