### PR TITLE
Fix for 655 and 656: always reload children of repository item during expansion; Fix for 660

### DIFF
--- a/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
@@ -168,13 +168,16 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
 
     const onNodeToggle = useCallback(
         async (_, nodeIds: string[]) => {
-            if (!nodeIds.length) return;
+            if (!nodeIds.length)
+                return;
             const [nodeId] = nodeIds.slice();
-            const alreadyLoaded = tree.has(nodeId);
+            getChildren(nodeId);
 
-            if (!alreadyLoaded) {
-                getChildren(nodeId);
-            }
+            // const alreadyLoaded = tree.has(nodeId);
+            // if (!alreadyLoaded) {
+            //     getChildren(nodeId);
+            // }
+
         },
         [tree, getChildren]
     );

--- a/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
@@ -17,6 +17,7 @@ import { StateRelatedObject, treeRootKey, useControlStore, useRepositoryStore, u
 import {
     getObjectInterfaceDetails,
     getRepositoryTreeNodeId,
+    parseRepositoryTreeNodeId,
     getTreeColorVariant,
     getTreeViewColumns,
     isRepositoryItemSelected
@@ -148,11 +149,13 @@ interface RepositoryTreeViewProps {
 
 function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement {
     const { isModal = false, selectedItems = [], onSelect, onUnSelect } = props;
-    const [tree, getChildren, getMoreRoot, getMoreChildren, cursors] = useRepositoryStore(state => [
+    const [tree, getChildren, deleteChildren, getMoreRoot, getMoreChildren, setExpandedCount, cursors] = useRepositoryStore(state => [
         state.tree,
         state.getChildren,
+        state.deleteChildren,
         state.getMoreRoot,
         state.getMoreChildren,
+        state.setExpandedCount,
         state.cursors
     ]);
     const metadataColumns = useRepositoryStore(state => state.metadataToDisplay);
@@ -170,16 +173,15 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
         async (_, nodeIds: string[]) => {
             if (!nodeIds.length)
                 return;
-            const [nodeId] = nodeIds.slice();
+            const [nodeId] = nodeIds.slice(); // when expanding, nodeId is from the most recently expanded node. When contracting, nodeId is from the last expanded node that is still expanded.
+            const expanded: boolean = setExpandedCount(nodeIds.length);
+            // console.log(`onNodeToggle nodeId=${nodeId} expanded=${expanded} nodeIds=${JSON.stringify(nodeIds)}`);
+            if (expanded)
+                deleteChildren(nodeId);
+
             getChildren(nodeId);
-
-            // const alreadyLoaded = tree.has(nodeId);
-            // if (!alreadyLoaded) {
-            //     getChildren(nodeId);
-            // }
-
         },
-        [tree, getChildren]
+        [tree, getChildren, deleteChildren]
     );
 
     // recursive
@@ -187,9 +189,15 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
 
         if (!children) return null;
         return children.map((child: NavigationResultEntryState, index: number) => {
-            const { idSystemObject, objectType, idObject, name, metadata } = child;
-            const nodeIndex = child.index;
-            const nodeId: string = getRepositoryTreeNodeId(idSystemObject, objectType, idObject, nodeIndex ? nodeIndex : 0);
+            const { idSystemObject, objectType, idObject, name, metadata, hierarchy } = child;
+            let idSystemObjectParent: number = 0;
+            if (parentNodeId) {
+                const { idSystemObject: idSystemObjectParentUpdated } = parseRepositoryTreeNodeId(parentNodeId);
+                idSystemObjectParent = idSystemObjectParentUpdated;
+            }
+
+            const nodeId: string = getRepositoryTreeNodeId(idSystemObject, objectType, idObject,
+                (hierarchy ? hierarchy + '|' : '') + idSystemObjectParent.toString() );
             const childNodes = tree.get(nodeId);
 
             let childNodesContent: React.ReactNode = <TreeLabelLoading />;

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -58,18 +58,19 @@ export function getTermForSystemObjectType(objectType: eSystemObjectType): strin
     }
 }
 
-export function getRepositoryTreeNodeId(idSystemObject: number, objectType: eSystemObjectType, idObject: number, index: number): string {
-    return `${idSystemObject}-${eSystemObjectType[objectType]}-${idObject}-${index}`;
+export function getRepositoryTreeNodeId(idSystemObject: number, objectType: eSystemObjectType, idObject: number, hierarchy: string): string {
+    return `${idSystemObject}-${eSystemObjectType[objectType]}-${idObject}-${hierarchy}`;
 }
 
 type ParsedNodeId = {
     idSystemObject: number;
     idObject: number;
     objectType: eSystemObjectType;
+    hierarchy: string;
 };
 
 export function parseRepositoryTreeNodeId(nodeId: string): ParsedNodeId {
-    const [nodeSystemObjectId, nodeObjectType, nodeObjectId] = nodeId.split('-');
+    const [nodeSystemObjectId, nodeObjectType, nodeObjectId, hierarchy] = nodeId.split('-');
     const idSystemObject = Number.parseInt(nodeSystemObjectId, 10);
     const objectType = Number.parseInt(nodeObjectType, 10);
     const idObject = Number.parseInt(nodeObjectId, 10);
@@ -77,7 +78,8 @@ export function parseRepositoryTreeNodeId(nodeId: string): ParsedNodeId {
     return {
         idSystemObject,
         objectType,
-        idObject
+        idObject,
+        hierarchy
     };
 }
 

--- a/server/utils/parser/bulkIngestReader.ts
+++ b/server/utils/parser/bulkIngestReader.ts
@@ -25,6 +25,7 @@ export type IngestMetadata = DBAPI.SubjectUnitIdentifier & Omit<Item, '__typenam
 export class BulkIngestReader {
     private _zip: IZip | null = null;
     private _ingestedMetadata: IngestMetadata[] = [];
+    private _errorField: string | null = null;
 
     async loadFromAssetVersion(idAssetVersion: number, autoClose: boolean): Promise<H.IOResults> {
         const assetVersion: DBAPI.AssetVersion | null = await DBAPI.AssetVersion.fetch(idAssetVersion);
@@ -50,6 +51,7 @@ export class BulkIngestReader {
     }
 
     private async extractMetadata(autoClose: boolean): Promise<H.IOResults> {
+        this._errorField = null;
         /* istanbul ignore next */
         if (!this._zip)
             return { success: false, error: 'BulkIngestReader.extractMetadata called with invalid zip' };
@@ -101,6 +103,8 @@ export class BulkIngestReader {
     }
 
     async close(): Promise<H.IOResults> {
+        this._errorField = null;
+
         /* istanbul ignore next */
         if (!this._zip)
             return { success: true };
@@ -130,6 +134,10 @@ export class BulkIngestReader {
         return await DBAPI.Project.fetchRelatedToSubjects([ingestMetadata.idSubject]);
     }
 
+    private computeErrorFieldMessage(): string {
+        return this._errorField ? ', due to an invalid ' + this._errorField : '';
+    }
+
     private async computeCaptureDataPhotos(fileStream: NodeJS.ReadableStream): Promise<H.IOResults> {
         let bagitCDPs: (SubjectsCSVFields & ItemsCSVFields & CaptureDataPhotoCSVFields)[];
         try {
@@ -146,15 +154,15 @@ export class BulkIngestReader {
 
             const subject: DBAPI.SubjectUnitIdentifier | null = await this.extractSubjectFromCSV(bagitCDP); /* istanbul ignore next */
             if (!subject)
-                return { success: false, error: 'BulkIngestReader.computeCaptureDataPhotos could not compute subject' };
+                return { success: false, error: `BulkIngestReader.computeCaptureDataPhotos could not compute subject from ${H.Helpers.JSONStringify(bagitCDP)}${this.computeErrorFieldMessage()}` };
 
             const item: DBAPI.Item | null = await this.extractItemFromCSV(bagitCDP); /* istanbul ignore next */
             if (!item)
-                return { success: false, error: 'BulkIngestReader.computeCaptureDataPhotos could not compute item' };
+                return { success: false, error: `BulkIngestReader.computeCaptureDataPhotos could not compute media group from ${H.Helpers.JSONStringify(bagitCDP)}${this.computeErrorFieldMessage()}` };
 
             const photo: IngestPhotogrammetry | null = await this.extractCaptureDataPhotoFromCSV(bagitCDP); /* istanbul ignore next */
             if (!photo)
-                return { success: false, error: 'BulkIngestReader.computeCaptureDataPhotos could not compute photogrammetry metadata' };
+                return { success: false, error: `BulkIngestReader.computeCaptureDataPhotos could not compute photogrammetry metadata from ${H.Helpers.JSONStringify(bagitCDP)}${this.computeErrorFieldMessage()}` };
 
             this._ingestedMetadata.push({ ...subject, ...item, ...photo });
         }
@@ -177,15 +185,15 @@ export class BulkIngestReader {
 
             const subject: DBAPI.SubjectUnitIdentifier | null = await this.extractSubjectFromCSV(bagitModel); /* istanbul ignore next */
             if (!subject)
-                return { success: false, error: 'BulkIngestReader.computeModels could not compute subject' };
+                return { success: false, error: `BulkIngestReader.computeModels could not compute subject from ${H.Helpers.JSONStringify(bagitModel)}${this.computeErrorFieldMessage()}` };
 
             const item: DBAPI.Item | null = await this.extractItemFromCSV(bagitModel); /* istanbul ignore next */
             if (!item)
-                return { success: false, error: 'BulkIngestReader.computeModels could not compute item' };
+                return { success: false, error: `BulkIngestReader.computeModels could not compute media group from ${H.Helpers.JSONStringify(bagitModel)}${this.computeErrorFieldMessage()}` };
 
             const model: IngestModel | null = await this.extractModelFromCSV(bagitModel); /* istanbul ignore next */
             if (!model)
-                return { success: false, error: 'BulkIngestReader.computeModels could not compute model metadata' };
+                return { success: false, error: `BulkIngestReader.computeModels could not compute model metadata from ${H.Helpers.JSONStringify(bagitModel)}${this.computeErrorFieldMessage()}` };
 
             this._ingestedMetadata.push({ ...subject, ...item, ...model });
         }
@@ -208,15 +216,15 @@ export class BulkIngestReader {
 
             const subject: DBAPI.SubjectUnitIdentifier | null = await this.extractSubjectFromCSV(bagitScene); /* istanbul ignore next */
             if (!subject)
-                return { success: false, error: 'BulkIngestReader.computeScenes could not compute subject' };
+                return { success: false, error: `BulkIngestReader.computeScenes could not compute subject from ${H.Helpers.JSONStringify(bagitScene)}${this.computeErrorFieldMessage()}` };
 
             const item: DBAPI.Item | null = await this.extractItemFromCSV(bagitScene); /* istanbul ignore next */
             if (!item)
-                return { success: false, error: 'BulkIngestReader.computeScenes could not compute item' };
+                return { success: false, error: `BulkIngestReader.computeScenes could not compute media group from ${H.Helpers.JSONStringify(bagitScene)}${this.computeErrorFieldMessage()}` };
 
             const scene: IngestScene | null = await this.extractSceneFromCSV(bagitScene); /* istanbul ignore next */
             if (!scene)
-                return { success: false, error: 'BulkIngestReader.computeScenes could not compute scene metadata' };
+                return { success: false, error: `BulkIngestReader.computeScenes could not compute scene metadata from ${H.Helpers.JSONStringify(bagitScene)}${this.computeErrorFieldMessage()}` };
 
             this._ingestedMetadata.push({ ...subject, ...item, ...scene });
         }
@@ -249,6 +257,7 @@ export class BulkIngestReader {
         // otherwise, we can't spot this subject in our DB; validate unit name and then gather remaining information
         const units: DBAPI.Unit[] | null = await DBAPI.Unit.fetchFromNameSearch(bagitSubject.unit_name); /* istanbul ignore next */
         if (!units || units.length == 0) {
+            this._errorField = 'unit_name';
             LOG.error(`BulkIngestReader.extractSubjectFromCSV unable to load unit from ${JSON.stringify(bagitSubject)}`, LOG.LS.eSYS);
             return null;
         }
@@ -299,6 +308,7 @@ export class BulkIngestReader {
         const error: string = `Unable to find identifiers for items from ${bagitItem.item_guid}`;
         const identifiers: DBAPI.Identifier[] | null = await DBAPI.Identifier.fetchFromIdentifierValue(bagitItem.item_guid);
         if (!identifiers) {
+            this._errorField = 'item_guid';
             LOG.error(error, LOG.LS.eSYS);
             return null;
         }
@@ -310,11 +320,13 @@ export class BulkIngestReader {
             if (SOPair && SOPair.Item) {
                 return SOPair.Item;
             } else {
+                this._errorField = 'item_guid';
                 LOG.error(error, LOG.LS.eSYS);
                 return null;
             }
         }
 
+        this._errorField = 'item_guid';
         LOG.error(error, LOG.LS.eSYS);
         return null;
     }
@@ -324,32 +336,32 @@ export class BulkIngestReader {
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eCaptureDataDatasetType, bagitCDP.capture_dataset_type);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'capture_dataset_type'; return null; }
         const datasetType: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eCaptureDataItemPositionType, bagitCDP.item_position_type);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'item_position_type'; return null; }
         const itemPositionType: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eCaptureDataFocusType, bagitCDP.focus_type);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'focus_type'; return null; }
         const focusType: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eCaptureDataLightSourceType, bagitCDP.light_source_type);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'light_source_type'; return null; }
         const lightsourceType: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eCaptureDataBackgroundRemovalMethod, bagitCDP.background_removal_method);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'background_removal_method'; return null; }
         const backgroundRemovalMethod: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eCaptureDataClusterType, bagitCDP.cluster_type);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'cluster_type'; return null; }
         const clusterType: number = vocabResult.idVocabulary;
 
         const folders: IngestFolder[] = [];
@@ -396,22 +408,22 @@ export class BulkIngestReader {
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eModelCreationMethod, bagitModel.creation_method);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'creation_method'; return null; }
         const creationMethod: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eModelModality, bagitModel.modality);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'modality'; return null; }
         const modality: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eModelPurpose, bagitModel.purpose);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'purpose'; return null; }
         const purpose: number = vocabResult.idVocabulary;
 
         vocabResult = await this.computeVocabulary(COMMON.eVocabularySetID.eModelUnits, bagitModel.units);
         if (vocabResult.error)
-        { LOG.error(vocabResult.error, LOG.LS.eSYS); return null; }
+        { LOG.error(vocabResult.error, LOG.LS.eSYS); this._errorField = 'units'; return null; }
         const units: number = vocabResult.idVocabulary;
 
         return {


### PR DESCRIPTION

Also included a fix for 660.

Client:
* Always reload repository rows when expanding an item.  This allows us to refresh the tree as content is ingested
* Modified Repo Tree's onNodeToggle to determine if a node is being expanded, and if so, delete the children of the specified node from the repository store
* Compute a hierarchy string for tree items recursively, building a hierarchy string of idSystemObject IDs and storing these as part of the tree item's node ID
* Maintain a tree node expandedCount in the repository store; update this via setExpandedCount, which returns whether a node was expanded or collapsed
* Implemented repository store's deleteChildren(), called when expanding a node, to remove that node's information from the tree before we re-query to get that node's children

System:
* Add more details to error messages produced when bulk ingestion fails