### PR TITLE
Telework Timeout Debugging, Continued VI

### DIFF
--- a/client/src/graphql/index.ts
+++ b/client/src/graphql/index.ts
@@ -76,8 +76,9 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
             if (networkError.name === 'ServerParseError') {
                 const bodyText = networkError['bodyText'];
                 if (bodyText && typeof(bodyText) === 'string' && bodyText.includes(SAMLRedirectPath)) {
-                    if (!handleTeleworkSAMLAuthRequest(bodyText))
-                        redirectToLogin = true;
+                    redirectToLogin = true;
+                    // if (!handleTeleworkSAMLAuthRequest(bodyText))
+                    //     redirectToLogin = true;
                 }
             } else {
                 const errMessage: string = networkError.toString();
@@ -96,6 +97,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     }
 });
 
+/*
 function handleTeleworkSAMLAuthRequest(bodyText: string): boolean {
     try {
         const parser: DOMParser = new DOMParser();
@@ -141,6 +143,7 @@ function handleTeleworkSAMLAuthRequest(bodyText: string): boolean {
         return false;
     }
 }
+*/
 
 function configureApolloClient(): ApolloClient<NormalizedCacheObject> {
     const serverEndpoint = API.serverEndpoint();


### PR DESCRIPTION
Client:
* Restore original behavior upon telework SAML reauth responses -- redirect our app back to the login screen.  We need more support here from OCIO to determine and address the underlying issue.