### PR TITLE
Bugfix/671 - 673

### DIFF
--- a/client/src/components/controls/CheckboxField.tsx
+++ b/client/src/components/controls/CheckboxField.tsx
@@ -5,7 +5,7 @@
  *
  * This component renders checkbox field used in ingestion and repository UI.
  */
-import { Checkbox, Tooltip } from '@material-ui/core';
+import { Checkbox } from '@material-ui/core';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -20,7 +20,6 @@ interface CheckboxFieldProps extends ViewableProps {
     value: boolean | null;
     onChange: ((event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void) | undefined;
     required?: boolean;
-    tooltip?: any;
     valueLeftAligned?: boolean;
     gridValue?: number;
     gridLabel?: number;
@@ -37,7 +36,7 @@ export const CheckboxNoPadding = withStyles({
 })(Checkbox);
 
 function CheckboxField(props: CheckboxFieldProps): React.ReactElement {
-    const { label, name, value, onChange, required = false, viewMode = false, disabled = false, updated = false, tooltip, valueLeftAligned = false, gridValue, gridLabel, padding, gridGap, containerStyle } = props;
+    const { label, name, value, onChange, required = false, viewMode = false, disabled = false, updated = false, valueLeftAligned = false, gridValue, gridLabel, padding, gridGap, containerStyle } = props;
     const rowFieldProps = { alignItems: 'center', justifyContent: 'space-between', style: { borderRadius: 0, ...containerStyle } };
     const checkbox = (
         <CheckboxNoPadding
@@ -64,11 +63,7 @@ function CheckboxField(props: CheckboxFieldProps): React.ReactElement {
             padding={padding}
             gridGap={gridGap}
         >
-            {tooltip ? (
-                <Tooltip {...tooltip}>
-                    {checkbox}
-                </Tooltip>
-            ) : checkbox}
+            {checkbox}
         </FieldType>
     );
 }

--- a/client/src/pages/Ingestion/components/Uploads/UploadCompleteList.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/UploadCompleteList.tsx
@@ -22,7 +22,8 @@ const useStyles = makeStyles(({ palette /*, breakpoints*/ }) => ({
     container: {
         display: 'flex',
         flex: 1,
-        flexDirection: 'column'
+        flexDirection: 'column',
+        marginBottom: '50px'
     },
     list: {
         display: 'flex',

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
@@ -117,14 +117,14 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
                     updated={isFieldUpdated(SceneDetails, sceneData,'ApprovedForPublication')}
                 />
-                <FieldType 
+                <FieldType
                     required
                     label="Posed and QC'd"
                     direction='row'
                     containerProps={{ alignItems: 'center', justifyContent: 'space-between', style: { borderRadius: 0 } }}
                     padding='1px 10px'
                 >
-                    <div style={{ display: 'flex' }}> 
+                    <div style={{ display: 'flex' }}>
                         <Tooltip title='When checked, downloads will be generated if this scene has a master model as a parent, as well as every time the scene is re-posed. This item is disabled if the scene is missing thumbnails (either in the svx.json or among its ingested assets)' placement='left'>
                             <HelpOutline
                                 style={{ alignSelf: 'center', cursor: 'pointer', fontSize: '18px' }}

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
@@ -4,16 +4,20 @@
  *
  * This component renders details tab for Scene specific details used in DetailsTab component.
  */
-import { Box, makeStyles } from '@material-ui/core';
+import { Box, makeStyles, Tooltip } from '@material-ui/core';
 import React, { useEffect, useRef } from 'react';
 import { Loader } from '../../../../../components';
 import { GetSceneDocument } from '../../../../../types/graphql';
 import { DetailComponentProps } from './index';
 import { apolloClient } from '../../../../../graphql/index';
-import { ReadOnlyRow, CheckboxField, InputField } from '../../../../../components/index';
+import { ReadOnlyRow, CheckboxField, InputField, FieldType } from '../../../../../components/index';
 import { useDetailTabStore } from '../../../../../store';
 import { eSystemObjectType } from '@dpo-packrat/common';
 import { isFieldUpdated } from '../../../../../utils/repository';
+import { CheckboxNoPadding } from '../../../../../components/controls/CheckboxField';
+import { getUpdatedCheckboxProps } from '../../../../../utils/repository';
+import { withDefaultValueBoolean } from '../../../../../utils/shared';
+import { HelpOutline } from '@material-ui/icons';
 
 export const useStyles = makeStyles(({ palette }) => ({
     value: {
@@ -113,18 +117,29 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
                     updated={isFieldUpdated(SceneDetails, sceneData,'ApprovedForPublication')}
                 />
-                <CheckboxField
-                    label="Posed and QC'd"
-                    name='PosedAndQCd'
-                    value={SceneDetails.PosedAndQCd}
-                    onChange={setCheckboxField}
-                    disabled={!SceneDetails.CanBeQCd}
-                    tooltip={{ title: 'When checked, downloads will be generated if this scene has a master model as a parent, as well as every time the scene is re-posed. This item is disabled if the scene is missing thumbnails (either in the svx.json or among its ingested assets)', placement: 'left' }}
+                <FieldType 
                     required
+                    label="Posed and QC'd"
+                    direction='row'
+                    containerProps={{ alignItems: 'center', justifyContent: 'space-between', style: { borderRadius: 0 } }}
                     padding='1px 10px'
-                    containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
-                    updated={isFieldUpdated(SceneDetails, sceneData,'PosedAndQCd')}
-                />
+                >
+                    <div style={{ display: 'flex' }}> 
+                        <Tooltip title='When checked, downloads will be generated if this scene has a master model as a parent, as well as every time the scene is re-posed. This item is disabled if the scene is missing thumbnails (either in the svx.json or among its ingested assets)' placement='left'>
+                            <HelpOutline
+                                style={{ alignSelf: 'center', cursor: 'pointer', fontSize: '18px' }}
+                            />
+                        </Tooltip>
+                        <CheckboxNoPadding
+                            name='PosedAndQCd'
+                            disabled={!SceneDetails.CanBeQCd}
+                            checked={withDefaultValueBoolean(SceneDetails.PosedAndQCd, false)}
+                            onChange={setCheckboxField}
+                            {...getUpdatedCheckboxProps(isFieldUpdated(SceneDetails, sceneData,'PosedAndQCd'))}
+                            size='small'
+                        />
+                    </div>
+                </FieldType>
                 <ReadOnlyRow
                     label='EDAN UUID'
                     value={SceneDetails.EdanUUID}

--- a/client/src/store/metadata/metadata.defaults.ts
+++ b/client/src/store/metadata/metadata.defaults.ts
@@ -180,7 +180,7 @@ export const modelFieldsSchemaUpdate = yup.object().shape({
     systemCreated: yup.boolean().required(),
     uvMaps: yup.array().of(uvMapSchema),
     sourceObjects: yup.array().of(sourceObjectSchema),
-    dateCreated: yup.date().typeError('Date Created is required'),
+    dateCreated: yup.date().typeError('Date Created is required').max(Date(), 'Date Created cannot be set in the future'),
     creationMethod: yup.number().typeError('Creation method is required'),
     modality: yup.number().typeError('Modality is required'),
     units: yup.number().typeError('Units is required'),


### PR DESCRIPTION
671 - Model Ingestion Disallow Future Date
Added additional validation for model ingestion and adding a new version

672 - Env Banner Blocks Uploaded List
Added additional margin to the bottom of the list

673 - Hoverover Tooltip for Posed and QC'd Control 
Added an explicit help icon instead for the tooltip instead of using the checkbox
Removed tooltip feature for <CheckboxField /> as it's no longer needed