### PR TITLE
Bugfix/670 674

### DIFF
--- a/client/src/components/controls/CheckboxField.tsx
+++ b/client/src/components/controls/CheckboxField.tsx
@@ -5,7 +5,7 @@
  *
  * This component renders checkbox field used in ingestion and repository UI.
  */
-import { Checkbox, Tooltip } from '@material-ui/core';
+import { Checkbox } from '@material-ui/core';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -20,7 +20,6 @@ interface CheckboxFieldProps extends ViewableProps {
     value: boolean | null;
     onChange: ((event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void) | undefined;
     required?: boolean;
-    tooltip?: any;
     valueLeftAligned?: boolean;
     gridValue?: number;
     gridLabel?: number;
@@ -37,7 +36,7 @@ export const CheckboxNoPadding = withStyles({
 })(Checkbox);
 
 function CheckboxField(props: CheckboxFieldProps): React.ReactElement {
-    const { label, name, value, onChange, required = false, viewMode = false, disabled = false, updated = false, tooltip, valueLeftAligned = false, gridValue, gridLabel, padding, gridGap, containerStyle } = props;
+    const { label, name, value, onChange, required = false, viewMode = false, disabled = false, updated = false, valueLeftAligned = false, gridValue, gridLabel, padding, gridGap, containerStyle } = props;
     const rowFieldProps = { alignItems: 'center', justifyContent: 'space-between', style: { borderRadius: 0, ...containerStyle } };
     const checkbox = (
         <CheckboxNoPadding
@@ -64,11 +63,7 @@ function CheckboxField(props: CheckboxFieldProps): React.ReactElement {
             padding={padding}
             gridGap={gridGap}
         >
-            {tooltip ? (
-                <Tooltip {...tooltip}>
-                    {checkbox}
-                </Tooltip>
-            ) : checkbox}
+            {checkbox}
         </FieldType>
     );
 }

--- a/client/src/pages/Admin/components/AdminProjectsView.tsx
+++ b/client/src/pages/Admin/components/AdminProjectsView.tsx
@@ -238,7 +238,8 @@ function AdminProjectsView(): React.ReactElement {
                 input: {
                     search: newSearchText
                 }
-            }
+            },
+            fetchPolicy: 'no-cache'
         });
 
         const {

--- a/client/src/pages/Admin/components/AdminUnitsView.tsx
+++ b/client/src/pages/Admin/components/AdminUnitsView.tsx
@@ -245,7 +245,8 @@ function AdminUnitsView(): React.ReactElement {
                 input: {
                     search: newSearchText
                 }
-            }
+            },
+            fetchPolicy: 'no-cache'
         });
 
         const {

--- a/client/src/pages/Admin/components/License/LicenseView.tsx
+++ b/client/src/pages/Admin/components/License/LicenseView.tsx
@@ -225,7 +225,8 @@ function LicenseView(): React.ReactElement {
                 input: {
                     search: newSearchText
                 }
-            }
+            },
+            fetchPolicy: 'no-cache'
         });
         setLicenseList(newFilterQuery?.data?.getLicenseList?.Licenses);
     };

--- a/client/src/pages/Ingestion/components/Metadata/Control/SubtitleControl.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Control/SubtitleControl.tsx
@@ -12,14 +12,15 @@ interface SubtitleControlProps {
     objectName: string;
     onSelectSubtitle: (id: number) => void;
     onUpdateCustomSubtitle: (event: React.ChangeEvent<HTMLInputElement>, id: number) => void;
-    hasPrimaryTheme: boolean
+    hasPrimaryTheme: boolean;
+    hasError: boolean;
 }
 
 const useStyles = makeStyles(({ palette, typography }) => ({
     container: {
         display: 'flex',
         flexDirection: 'column',
-        backgroundColor: (hasPrimaryTheme) => hasPrimaryTheme ? palette.primary.light : palette.secondary.light,
+        backgroundColor: ({ hasPrimaryTheme, hasError }: { hasPrimaryTheme: boolean, hasError: boolean }) => hasError ? '#e57373' : hasPrimaryTheme ? palette.primary.light : palette.secondary.light,
         width: 'fit-content',
         minWidth: 300,
         borderRadius: 5
@@ -54,15 +55,14 @@ const useStyles = makeStyles(({ palette, typography }) => ({
 }));
 
 function SubtitleControl(props: SubtitleControlProps): React.ReactElement {
-    const { objectName, subtitles, onUpdateCustomSubtitle, onSelectSubtitle, hasPrimaryTheme } = props;
-    const classes = useStyles(hasPrimaryTheme);
+    const { objectName, subtitles, onUpdateCustomSubtitle, onSelectSubtitle, hasPrimaryTheme, hasError } = props;
+    const classes = useStyles({ hasError, hasPrimaryTheme });
     const selectedSubtitle = subtitles.find(subtitle => subtitle.selected === true)?.value;
     const selectedSubtitlesName = selectedSubtitle ? `: ${selectedSubtitle}` : '';
     const sortedSubtitles: SubtitleFields = subtitles.sort((a, b) => a.subtitleOption - b.subtitleOption);
 
 
     const renderSubtitleOptions = (subtitles: SubtitleFields): React.ReactElement => {
-        // console.log('subtitles', subtitles,'objectName', objectName);
         // Case: forced
         if (subtitles.some(option => option.subtitleOption === eSubtitleOption.eForced))
             return (

--- a/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
@@ -349,6 +349,7 @@ function Model(props: ModelProps): React.ReactElement {
                                 onSelectSubtitle={onSelectSubtitle}
                                 onUpdateCustomSubtitle={onUpdateCustomSubtitle}
                                 hasPrimaryTheme={false}
+                                hasError={fieldErrors?.model.subtitles ?? false}
                             />
                         </Box>
                     )}

--- a/client/src/pages/Ingestion/components/Metadata/Scene/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Scene/index.tsx
@@ -9,7 +9,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect, useState, Fragment } from 'react';
 import { AssetIdentifiers } from '../../../../../components';
 import { StateIdentifier, useMetadataStore, StateRelatedObject, useRepositoryStore, useSubjectStore } from '../../../../../store';
-import { MetadataType } from '../../../../../store/metadata';
+import { FieldErrors, MetadataType } from '../../../../../store/metadata';
 import ReferenceModels from './ReferenceModels';
 import NonModelAssets from './NonModelAssets';
 import SceneDataForm from './SceneDataForm';
@@ -35,10 +35,11 @@ const useStyles = makeStyles(() => ({
 interface SceneProps {
     readonly metadataIndex: number;
     setInvalidMetadataStep: (valid: boolean) => void;
+    fieldErrors?: FieldErrors;
 }
 
 function Scene(props: SceneProps): React.ReactElement {
-    const { metadataIndex, setInvalidMetadataStep } = props;
+    const { metadataIndex, setInvalidMetadataStep, fieldErrors } = props;
     const classes = useStyles();
     const metadata = useMetadataStore(state => state.metadatas[metadataIndex]);
     const { scene, file } = metadata;
@@ -320,6 +321,7 @@ function Scene(props: SceneProps): React.ReactElement {
                             onSelectSubtitle={onSelectSubtitle}
                             onUpdateCustomSubtitle={onUpdateCustomSubtitle}
                             hasPrimaryTheme
+                            hasError={fieldErrors?.scene.subtitles ?? false}
                         />
                     </Box>
                 </Fragment>

--- a/client/src/pages/Ingestion/components/Metadata/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/index.tsx
@@ -187,11 +187,10 @@ function Metadata(): React.ReactElement {
         }
 
         if (assetType.scene) {
-            return <Scene metadataIndex={metadataIndex} setInvalidMetadataStep={setInvalidMetadataStep} />;
+            return <Scene metadataIndex={metadataIndex} setInvalidMetadataStep={setInvalidMetadataStep} fieldErrors={fieldErrors} />;
         }
 
         if (assetType.model) {
-            // Model takes in additional props for onPrevious, onClickRight, isLast, and rightLoading because it imports an additional copy of <SidebarBottomNavigator />
             return <Model metadataIndex={metadataIndex} fieldErrors={fieldErrors} />;
         }
 

--- a/client/src/pages/Ingestion/components/Uploads/UploadCompleteList.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/UploadCompleteList.tsx
@@ -22,7 +22,8 @@ const useStyles = makeStyles(({ palette /*, breakpoints*/ }) => ({
     container: {
         display: 'flex',
         flex: 1,
-        flexDirection: 'column'
+        flexDirection: 'column',
+        marginBottom: '50px'
     },
     list: {
         display: 'flex',

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
@@ -117,14 +117,14 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
                     updated={isFieldUpdated(SceneDetails, sceneData,'ApprovedForPublication')}
                 />
-                <FieldType 
+                <FieldType
                     required
                     label="Posed and QC'd"
                     direction='row'
                     containerProps={{ alignItems: 'center', justifyContent: 'space-between', style: { borderRadius: 0 } }}
                     padding='1px 10px'
                 >
-                    <div style={{ display: 'flex' }}> 
+                    <div style={{ display: 'flex' }}>
                         <Tooltip title='When checked, downloads will be generated if this scene has a master model as a parent, as well as every time the scene is re-posed. This item is disabled if the scene is missing thumbnails (either in the svx.json or among its ingested assets)' placement='left'>
                             <HelpOutline
                                 style={{ alignSelf: 'center', cursor: 'pointer', fontSize: '18px' }}

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetails.tsx
@@ -4,16 +4,20 @@
  *
  * This component renders details tab for Scene specific details used in DetailsTab component.
  */
-import { Box, makeStyles } from '@material-ui/core';
+import { Box, makeStyles, Tooltip } from '@material-ui/core';
 import React, { useEffect, useRef } from 'react';
 import { Loader } from '../../../../../components';
 import { GetSceneDocument } from '../../../../../types/graphql';
 import { DetailComponentProps } from './index';
 import { apolloClient } from '../../../../../graphql/index';
-import { ReadOnlyRow, CheckboxField, InputField } from '../../../../../components/index';
+import { ReadOnlyRow, CheckboxField, InputField, FieldType } from '../../../../../components/index';
 import { useDetailTabStore } from '../../../../../store';
 import { eSystemObjectType } from '@dpo-packrat/common';
 import { isFieldUpdated } from '../../../../../utils/repository';
+import { CheckboxNoPadding } from '../../../../../components/controls/CheckboxField';
+import { getUpdatedCheckboxProps } from '../../../../../utils/repository';
+import { withDefaultValueBoolean } from '../../../../../utils/shared';
+import { HelpOutline } from '@material-ui/icons';
 
 export const useStyles = makeStyles(({ palette }) => ({
     value: {
@@ -113,18 +117,29 @@ function SceneDetails(props: DetailComponentProps): React.ReactElement {
                     containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
                     updated={isFieldUpdated(SceneDetails, sceneData,'ApprovedForPublication')}
                 />
-                <CheckboxField
-                    label="Posed and QC'd"
-                    name='PosedAndQCd'
-                    value={SceneDetails.PosedAndQCd}
-                    onChange={setCheckboxField}
-                    disabled={!SceneDetails.CanBeQCd}
-                    tooltip={{ title: 'When checked, downloads will be generated if this scene has a master model as a parent, as well as every time the scene is re-posed. This item is disabled if the scene is missing thumbnails (either in the svx.json or among its ingested assets)', placement: 'left' }}
+                <FieldType 
                     required
+                    label="Posed and QC'd"
+                    direction='row'
+                    containerProps={{ alignItems: 'center', justifyContent: 'space-between', style: { borderRadius: 0 } }}
                     padding='1px 10px'
-                    containerStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
-                    updated={isFieldUpdated(SceneDetails, sceneData,'PosedAndQCd')}
-                />
+                >
+                    <div style={{ display: 'flex' }}> 
+                        <Tooltip title='When checked, downloads will be generated if this scene has a master model as a parent, as well as every time the scene is re-posed. This item is disabled if the scene is missing thumbnails (either in the svx.json or among its ingested assets)' placement='left'>
+                            <HelpOutline
+                                style={{ alignSelf: 'center', cursor: 'pointer', fontSize: '18px' }}
+                            />
+                        </Tooltip>
+                        <CheckboxNoPadding
+                            name='PosedAndQCd'
+                            disabled={!SceneDetails.CanBeQCd}
+                            checked={withDefaultValueBoolean(SceneDetails.PosedAndQCd, false)}
+                            onChange={setCheckboxField}
+                            {...getUpdatedCheckboxProps(isFieldUpdated(SceneDetails, sceneData,'PosedAndQCd'))}
+                            size='small'
+                        />
+                    </div>
+                </FieldType>
                 <ReadOnlyRow
                     label='EDAN UUID'
                     value={SceneDetails.EdanUUID}

--- a/client/src/store/metadata/index.ts
+++ b/client/src/store/metadata/index.ts
@@ -26,7 +26,7 @@ import { StateSubject, useSubjectStore } from '../subject';
 import { FileId, IngestionFile, useUploadStore } from '../upload';
 import { parseFileId, parseFoldersToState, parseIdentifiersToState, parseItemToState, parseProjectToState, parseSubjectUnitIdentifierToState, parseSubtitlesToState } from '../utils';
 import { useVocabularyStore } from '../vocabulary';
-import { defaultModelFields, defaultOtherFields, defaultPhotogrammetryFields, defaultSceneFields, ValidateFieldsSchema, defaultSceneAttachmentFields } from './metadata.defaults';
+import { defaultModelFields, defaultOtherFields, defaultPhotogrammetryFields, defaultSceneFields, ValidateFieldsSchema, defaultSceneAttachmentFields, subtitleFieldsSchema } from './metadata.defaults';
 import {
     FieldErrors,
     MetadataFieldValue,
@@ -42,6 +42,7 @@ import {
     StateIdentifier,
     StateMetadata,
     ValidateFields,
+    SubtitleFields
 } from './metadata.types';
 import { nullableSelectFields } from '../../utils/controls';
 
@@ -60,14 +61,16 @@ type MetadataStore = {
     updateCameraSettings: (metadatas: StateMetadata[]) => Promise<StateMetadata[]>;
     reset: () => void;
     getMetadatas: () => StateMetadata[];
+    getSubtitlesError: (subtitles: SubtitleFields) => boolean;
 };
 
 export const useMetadataStore = create<MetadataStore>((set: SetState<MetadataStore>, get: GetState<MetadataStore>) => ({
     metadatas: [],
     getSelectedIdentifiers: (identifiers: StateIdentifier[]): StateIdentifier[] | undefined => identifiers,
     getFieldErrors: (metadata: StateMetadata): FieldErrors => {
+        // Note: the field errors this function returns is how the UI renders error styling
         const { getAssetType } = useVocabularyStore.getState();
-        // UPDATE these error fields as we include more validation for ingestion
+        const { getSubtitlesError } = get();
         const errors: FieldErrors = {
             photogrammetry: {
                 dateCaptured: false,
@@ -80,7 +83,11 @@ export const useMetadataStore = create<MetadataStore>((set: SetState<MetadataSto
                 modality: false,
                 units: false,
                 purpose: false,
-                modelFileType: false
+                modelFileType: false,
+                subtitles: false,
+            },
+            scene: {
+                subtitles: false
             }
         };
 
@@ -102,6 +109,11 @@ export const useMetadataStore = create<MetadataStore>((set: SetState<MetadataSto
             errors.model.units = lodash.isNull(metadata.model.units);
             errors.model.purpose = lodash.isNull(metadata.model.purpose);
             errors.model.modelFileType = lodash.isNull(metadata.model.modelFileType);
+            errors.model.subtitles = getSubtitlesError(metadata.model.subtitles);
+        }
+
+        if (assetType.scene) {
+            errors.scene.subtitles = getSubtitlesError(metadata.scene.subtitles);
         }
 
         return errors;
@@ -446,9 +458,6 @@ export const useMetadataStore = create<MetadataStore>((set: SetState<MetadataSto
                 toast.error('Failed to fetch titles for ingestion items');
                 return;
             }
-            // console.log('selectedItem', selectedItem);
-            // console.log('ingestTitleInput', { id: Number(selectedItem?.id) || -1, subtitle, name, entireSubject: selectedItem?.entireSubject });
-            // console.log('ingestTitle', ingestTitle);
             const metadatasCopy = lodash.cloneDeep(metadatas);
             const subtitleState = parseSubtitlesToState(ingestTitle);
 
@@ -574,6 +583,22 @@ export const useMetadataStore = create<MetadataStore>((set: SetState<MetadataSto
     getMetadatas: () => {
         const { metadatas } = get();
         return metadatas;
+    },
+    getSubtitlesError: (subtitles: SubtitleFields): boolean => {
+        let hasError: boolean = false;
+        const options: yup.ValidateOptions = {
+            abortEarly: false
+        };
+
+        toast.dismiss();
+
+        try {
+            subtitleFieldsSchema.validateSync(subtitles, options);
+        } catch (error) {
+            hasError = true;
+        }
+
+        return hasError;
     }
 }));
 

--- a/client/src/store/metadata/metadata.defaults.ts
+++ b/client/src/store/metadata/metadata.defaults.ts
@@ -34,6 +34,17 @@ const subtitleSchema = yup.object().shape({
     id: yup.number()
 });
 
+const selectedSubtitleValidation = {
+    test: array => {
+        const selectedSubtitle = array.find(subtitle => subtitle.selected);
+        if (!selectedSubtitle) return false;
+        if (selectedSubtitle.subtitleOption === eSubtitleOption.eInput)
+            return !!selectedSubtitle.value;
+        return true;
+    },
+    message: 'Should provide a valid subtitle/name for ingestion'
+};
+
 const identifierValidation = {
     test: array => array.length && array.every(identifier => identifier.identifier.length),
     message: 'Should provide at least 1 identifier with valid identifier ID'
@@ -54,16 +65,7 @@ const notesWhenUpdate = {
     then: yup.string().required()
 };
 
-const selectedSubtitleValidation = {
-    test: array => {
-        const selectedSubtitle = array.find(subtitle => subtitle.selected);
-        if (!selectedSubtitle) return false;
-        if (selectedSubtitle.subtitleOption === eSubtitleOption.eInput)
-            return !!selectedSubtitle.value;
-        return true;
-    },
-    message: 'Should provide a valid subtitle/name for ingestion'
-};
+export const subtitleFieldsSchema = yup.array().of(subtitleSchema).test(selectedSubtitleValidation);
 
 export const defaultPhotogrammetryFields: PhotogrammetryFields = {
     systemCreated: true,
@@ -165,12 +167,12 @@ export const defaultModelFields: ModelFields = {
     idAsset: 0,
     subtitles: [{
         value: '',
-        selected: true,
+        selected: false,
         subtitleOption: eSubtitleOption.eInput,
         id: 1
     }, {
         value: '',
-        selected: false,
+        selected: true,
         subtitleOption: eSubtitleOption.eNone,
         id: 0
     }]

--- a/client/src/store/metadata/metadata.defaults.ts
+++ b/client/src/store/metadata/metadata.defaults.ts
@@ -180,7 +180,7 @@ export const modelFieldsSchemaUpdate = yup.object().shape({
     systemCreated: yup.boolean().required(),
     uvMaps: yup.array().of(uvMapSchema),
     sourceObjects: yup.array().of(sourceObjectSchema),
-    dateCreated: yup.date().typeError('Date Created is required'),
+    dateCreated: yup.date().typeError('Date Created is required').max(Date(), 'Date Created cannot be set in the future'),
     creationMethod: yup.number().typeError('Creation method is required'),
     modality: yup.number().typeError('Modality is required'),
     units: yup.number().typeError('Units is required'),

--- a/client/src/store/metadata/metadata.types.ts
+++ b/client/src/store/metadata/metadata.types.ts
@@ -56,7 +56,11 @@ export type FieldErrors = {
         units: boolean;
         purpose: boolean;
         modelFileType: boolean;
+        subtitles: boolean;
     };
+    scene: {
+        subtitles: boolean;
+    }
 };
 
 export type MetadataFieldValue = string | number | boolean | null | Date | StateIdentifier[] | StateFolder[] | StateRelatedObject[] | SubtitleFields;

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -127,18 +127,28 @@ export function parseSubtitlesToState(titles: IngestTitle): SubtitleFields {
         subtitle.forEach((subtitleVal, key) => {
             // Supply "None" as an option
             if (subtitleVal === '<None>') {
-                result.push({ value: '', selected: false, subtitleOption: eSubtitleOption.eNone, id: key });
+                result.push({ value: '', selected: true, subtitleOption: eSubtitleOption.eNone, id: key });
             }
             // User Input
             if (subtitleVal === null) {
-                result.push({ value: '', selected: true, subtitleOption: eSubtitleOption.eInput, id: key });
+                result.push({ value: '', selected: false, subtitleOption: eSubtitleOption.eInput, id: key });
             }
             // Inherited Value
             if (typeof subtitleVal === 'string' && subtitleVal !== '<None>') {
                 result.push({ value: subtitleVal, selected: false, subtitleOption: eSubtitleOption.eInherit, id: key });
             }
-
         });
+
+        // handle selecting in case for empty string inherit and input, which would normally both be unselected
+        const hasSelectedOption = result.some((entry) => entry.selected);
+        if (!hasSelectedOption) {
+            for (let i = 0; i < result.length; i++) {
+                if (result[i].subtitleOption === eSubtitleOption.eInherit && result[i].value === '') {
+                    result[i].selected = true;
+                    break;
+                }
+            }
+        }
     }
 
     return result;


### PR DESCRIPTION
670: Admin Project List Outdated Cache
-Prevents usage of cached searched results and applied it to projects, licenses, and units 

674: Subtitle Control Enhancements
-By default, "None" will be selected
-Addressed case where there's an empty string for inherited value + input (previously, neither option was selected)
-Added additional validation for subtitles that's used to render UI for an invalid subtitle