### PR TITLE
address 657, 658, 677

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
@@ -137,7 +137,6 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
     } = props;
     const [licenseList, setLicenseList] = useState<License[]>([]);
     const [loading, setLoading] = useState(false);
-    const [isTooltipOpen, setIsTooltipOpen] = useState(false);
     const isRetiredUpdated: boolean = isFieldUpdated({ retired }, originalFields, 'retired');
     const getEntries = useLicenseStore(state => state.getEntries);
     const classes = useObjectDetailsStyles(props);
@@ -235,7 +234,7 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
                             &nbsp;<LoadingButton onClick={onPublish} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Publish</LoadingButton>
                             &nbsp;<LoadingButton onClick={onAPIOnly} className={classes.loadingBtn} loading={loading} disabled={!publishable}>API Only</LoadingButton>
                             &nbsp;{(publishedEnum !== ePublishedState.eNotPublished) && (<LoadingButton onClick={onUnpublish} className={classes.loadingBtn} loading={loading}>Unpublish</LoadingButton>)}
-                            &nbsp;<Tooltip arrow open={isTooltipOpen} title={ <ToolTip text={scenePublishNotes} />}><HelpOutline onClick={() => setIsTooltipOpen(!isTooltipOpen)} onMouseLeave={() => setIsTooltipOpen(false)} style={{ alignSelf: 'center', cursor: 'pointer' }} /></Tooltip>
+                            &nbsp;<Tooltip arrow title={ <ToolTip text={scenePublishNotes} />}><HelpOutline fontSize='small' style={{ alignSelf: 'center', cursor: 'pointer' }} /></Tooltip>
                         </Box>
                     }
                 />

--- a/client/src/pages/Repository/components/RepositoryTreeView/TreeLabel.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/TreeLabel.tsx
@@ -4,7 +4,7 @@
  * This component renders a tree label for StyledTreeItem.
  * The label includes the SO type icon, SO name, and external link icon
  */
-import { Box } from '@material-ui/core';
+import { Box, Tooltip } from '@material-ui/core';
 import { grey } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
@@ -61,20 +61,22 @@ function TreeLabel(props: TreeLabelProps): React.ReactElement {
     }, [waitTime]);
 
     return (
-        <div className={makeStyles?.container}>
-            <div className={makeStyles?.label}>
-                {renderSelected && (
-                    <Box display='flex' alignItems='center' mr='10px'>
-                        {!selected && <FaRegCircle size={16} color={grey[400]} onClick={onSelect} />}
-                        {selected && <FaCheckCircle size={16} color={palette.primary.main} onClick={onUnSelect} />}
-                    </Box>
-                )}
-                <div className={makeStyles?.labelText} style={{ backgroundColor: color }}>
-                    <span title={objectTitle} onClick={onClick}>{label}</span>
+        <Tooltip placement='left' title={getTermForSystemObjectType(objectType)}>
+            <div className={makeStyles?.container}>
+                <div className={makeStyles?.label}>
+                    {renderSelected && (
+                        <Box display='flex' alignItems='center' mr='10px'>
+                            {!selected && <FaRegCircle size={16} color={grey[400]} onClick={onSelect} />}
+                            {selected && <FaCheckCircle size={16} color={palette.primary.main} onClick={onUnSelect} />}
+                        </Box>
+                    )}
+                    <div className={makeStyles?.labelText} style={{ backgroundColor: color }}>
+                        <span title={objectTitle} onClick={onClick}>{label}</span>
+                    </div>
                 </div>
+                <MetadataView header={false} treeColumns={treeColumns} makeStyles={{ text: makeStyles?.text || '', column: makeStyles?.column || '' }} />
             </div>
-            <MetadataView header={false} treeColumns={treeColumns} makeStyles={{ text: makeStyles?.text || '', column: makeStyles?.column || '' }} />
-        </div>
+        </Tooltip>
     );
 }
 

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -243,6 +243,8 @@ export function getObjectInterfaceDetails(objectType: eSystemObjectType, variant
         case eSystemObjectType.eActor:                  iconProps.overrideText = 'AC'; break;
         case eSystemObjectType.eStakeholder:            iconProps.overrideText = 'ST'; break;
         case eSystemObjectType.eItem:                   iconProps.overrideText = 'MG'; break;
+        case eSystemObjectType.eSubject:                iconProps.overrideText = 'SU'; break;
+        case eSystemObjectType.eCaptureData:            iconProps.overrideText = 'CD'; break;
         case eSystemObjectType.eAsset:
         case eSystemObjectType.eAssetVersion:
             return { icon: fileIcon, color };

--- a/server/workflow/impl/Packrat/WorkflowUpload.ts
+++ b/server/workflow/impl/Packrat/WorkflowUpload.ts
@@ -115,7 +115,7 @@ export class WorkflowUpload implements WF.IWorkflow {
 
                 const files: string[] = await ZS.getJustFiles(null);
                 if (!files || files.length === 0)
-                    return this.handleError(`WorkflowUpload.validateFiles unable to detect files in zip of asset version ${JSON.stringify(assetVersion, H.Helpers.saferStringify)}`);
+                    return this.handleError('Zip file is unexpectedly empty');
                 for (const fileName of files) {
                     const readStream: NodeJS.ReadableStream | null = await ZS.streamContent(fileName);
                     if (!readStream)

--- a/server/workflow/impl/Packrat/WorkflowUpload.ts
+++ b/server/workflow/impl/Packrat/WorkflowUpload.ts
@@ -114,6 +114,8 @@ export class WorkflowUpload implements WF.IWorkflow {
                     return this.handleError(`WorkflowUpload.validateFiles unable to unzip asset version ${RSR.fileName}: ${zipRes.error}`);
 
                 const files: string[] = await ZS.getJustFiles(null);
+                if (!files || files.length === 0)
+                    return this.handleError(`WorkflowUpload.validateFiles unable to detect files in zip of asset version ${JSON.stringify(assetVersion, H.Helpers.saferStringify)}`);
                 for (const fileName of files) {
                     const readStream: NodeJS.ReadableStream | null = await ZS.streamContent(fileName);
                     if (!readStream)


### PR DESCRIPTION
657 & 658
-During file validating process of uploading asset, return an error if an empty zip is detected

677
-Add hoverover for each repository tree row that indicates the object type
-Modified some of the tree row icon initials

Other
-Revised hoverover behavior of scene publish API buttons in scene details to be consistent with other hoverovers (i.e. no need to click)
