### PR TITLE
Enhancement/676

### DIFF
--- a/client/src/pages/Ingestion/components/Metadata/Control/GenerateModelControl.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Control/GenerateModelControl.tsx
@@ -12,7 +12,7 @@ function GenerateModelControl(props: GenerateModelControlProps): React.ReactElem
     const { disabled, selected, setCheckboxField } = props;
     return (
         <Box style={{ display: 'flex', alignItems: 'center', width: 'fit-content', borderRadius: 5, backgroundColor: '#FFFCD1', outline: '1px solid rgba(141, 171, 196, 0.4)', paddingRight: '9px' }}>
-            <Checkbox 
+            <Checkbox
                 disabled={disabled}
                 checked={!selected}
                 onChange={setCheckboxField}

--- a/client/src/pages/Ingestion/components/Metadata/Control/GenerateModelControl.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Control/GenerateModelControl.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, Checkbox, Typography } from '@material-ui/core';
+
+
+interface GenerateModelControlProps {
+    disabled: boolean;
+    selected: boolean;
+    setCheckboxField: ({ target }: { target: EventTarget }) => void;
+}
+
+function GenerateModelControl(props: GenerateModelControlProps): React.ReactElement {
+    const { disabled, selected, setCheckboxField } = props;
+    return (
+        <Box style={{ display: 'flex', alignItems: 'center', width: 'fit-content', borderRadius: 5, backgroundColor: '#FFFCD1', outline: '1px solid rgba(141, 171, 196, 0.4)', paddingRight: '9px' }}>
+            <Checkbox 
+                disabled={disabled}
+                checked={!selected}
+                onChange={setCheckboxField}
+                title='skipSceneGenerate-input'
+                size='small'
+                color='primary'
+                name='skipSceneGenerate'
+            />
+            <span>
+                <Typography style={{ fontSize: '0.8rem' }}>Generate Voyager Scene</Typography>
+                <em style={{ fontSize: '0.7rem', fontWeight: 300 }}>To enable, <b>Units</b> must be set to mm, cm, m, in, ft, or yd, <b>Purpose</b> must be set to Master, and <b>Model File Type</b> must be set to obj, ply, stl, x3d, wrl, dae, or fbx</em>
+            </span>
+        </Box>
+    );
+}
+
+export default GenerateModelControl;

--- a/client/src/pages/Ingestion/components/Metadata/Control/SceneGenerateWorkflowControl.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Control/SceneGenerateWorkflowControl.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Box, Checkbox, Typography } from '@material-ui/core';
 
 
-interface GenerateModelControlProps {
+interface SceneGenerateWorkflowControlProps {
     disabled: boolean;
     selected: boolean;
     setCheckboxField: ({ target }: { target: EventTarget }) => void;
 }
 
-function GenerateModelControl(props: GenerateModelControlProps): React.ReactElement {
+function SceneGenerateWorkflowControl(props: SceneGenerateWorkflowControlProps): React.ReactElement {
     const { disabled, selected, setCheckboxField } = props;
     return (
         <Box style={{ display: 'flex', alignItems: 'center', width: 'fit-content', borderRadius: 5, backgroundColor: '#FFFCD1', outline: '1px solid rgba(141, 171, 196, 0.4)', paddingRight: '9px' }}>
@@ -29,4 +29,4 @@ function GenerateModelControl(props: GenerateModelControlProps): React.ReactElem
     );
 }
 
-export default GenerateModelControl;
+export default SceneGenerateWorkflowControl;

--- a/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
@@ -23,7 +23,7 @@ import { apolloClient } from '../../../../../graphql/index';
 import { useStyles as useTableStyles } from '../../../../Repository/components/DetailsView/DetailsTab/CaptureDataDetails';
 import { errorFieldStyling } from '../Photogrammetry';
 import SubtitleControl from '../Control/SubtitleControl';
-import GenerateModelControl from '../Control/GenerateModelControl';
+import SceneGenerateWorkflowControl from '../Control/SceneGenerateWorkflowControl';
 import { enableSceneGenerateCheck } from '../../../../../store/utils';
 import clsx from 'clsx';
 import lodash from 'lodash';
@@ -375,7 +375,7 @@ function Model(props: ModelProps): React.ReactElement {
                                 />
                             </Box>
                             <Box style={{ marginBottom: 10 }}>
-                                <GenerateModelControl
+                                <SceneGenerateWorkflowControl
                                     selected={model.skipSceneGenerate}
                                     disabled={sceneGenerateDisabled}
                                     setCheckboxField={setSceneGenerate}

--- a/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
+++ b/client/src/pages/Ingestion/components/Metadata/Model/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react/jsx-max-props-per-line */
+/* eslint-disable react-hooks/exhaustive-deps */
 
 /**
  * Metadata - Model
@@ -192,10 +193,9 @@ function Model(props: ModelProps): React.ReactElement {
     useEffect(() => {
         const shouldEnable = enableSceneGenerateCheck(metadata.model, getEntries(eVocabularySetID.eModelUnits), getEntries(eVocabularySetID.eModelPurpose), getEntries(eVocabularySetID.eModelFileType));
         if (!shouldEnable) {
-            updateMetadataField(metadataIndex, 'skipSceneGenerate', true, MetadataType.model)
+            updateMetadataField(metadataIndex, 'skipSceneGenerate', true, MetadataType.model);
             setSceneGenerateDisabled(true);
-        }
-        else {
+        } else {
             updateMetadataField(metadataIndex, 'skipSceneGenerate', false, MetadataType.model);
             setSceneGenerateDisabled(false);
         }

--- a/client/src/pages/Ingestion/hooks/useIngest.ts
+++ b/client/src/pages/Ingestion/hooks/useIngest.ts
@@ -186,7 +186,8 @@ function useIngest(): UseIngest {
                         sourceObjects,
                         derivedObjects,
                         updateNotes,
-                        subtitles
+                        subtitles,
+                        skipSceneGenerate
                     } = model;
 
                     let {
@@ -214,7 +215,8 @@ function useIngest(): UseIngest {
                         directory,
                         systemCreated,
                         sourceObjects,
-                        derivedObjects
+                        derivedObjects,
+                        skipSceneGenerate
                     };
 
                     const idAsset: number | undefined = idToIdAssetMap.get(file.id);

--- a/client/src/store/metadata/metadata.defaults.ts
+++ b/client/src/store/metadata/metadata.defaults.ts
@@ -175,7 +175,8 @@ export const defaultModelFields: ModelFields = {
         selected: true,
         subtitleOption: eSubtitleOption.eNone,
         id: 0
-    }]
+    }],
+    skipSceneGenerate: true
 };
 
 export const modelFieldsSchemaUpdate = yup.object().shape({

--- a/client/src/store/metadata/metadata.defaults.ts
+++ b/client/src/store/metadata/metadata.defaults.ts
@@ -176,7 +176,7 @@ export const defaultModelFields: ModelFields = {
         subtitleOption: eSubtitleOption.eNone,
         id: 0
     }],
-    skipSceneGenerate: true
+    skipSceneGenerate: false
 };
 
 export const modelFieldsSchemaUpdate = yup.object().shape({

--- a/client/src/store/metadata/metadata.types.ts
+++ b/client/src/store/metadata/metadata.types.ts
@@ -126,6 +126,7 @@ export type ModelFields = {
     idAsset?: number;
     updateNotes?: string;
     subtitles: SubtitleFields;
+    skipSceneGenerate: boolean;
 };
 
 export type SceneFields = {

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
 /**
  * Utils
  *
@@ -158,25 +160,24 @@ export function parseSubtitlesToState(titles: IngestTitle): SubtitleFields {
 export function enableSceneGenerateCheck(metadata: ModelFields, unitsEntries, purposeEntries, typeEntries ): boolean {
     const { units, purpose, modelFileType } = metadata;
     if (!units || !purpose || !modelFileType) return false;
-    
     const eVocabUnitSet = new Set([eVocabularyID.eModelUnitsMillimeter as number, eVocabularyID.eModelUnitsCentimeter, eVocabularyID.eModelUnitsMeter, eVocabularyID.eModelUnitsInch, eVocabularyID.eModelUnitsFoot, eVocabularyID.eModelUnitsYard]);
     const eVocabPurposeSet = new Set([eVocabularyID.eModelPurposeMaster]);
-    const eVocabFileTypeSet = new Set([eVocabularyID.eModelFileTypeobj, eVocabularyID.eModelFileTypestl, eVocabularyID.eModelFileTypeply, eVocabularyID.eModelFileTypefbx, eVocabularyID.eModelFileTypewrl, eVocabularyID.eModelFileTypex3d, eVocabularyID.eModelFileTypedae])
+    const eVocabFileTypeSet = new Set([eVocabularyID.eModelFileTypeobj, eVocabularyID.eModelFileTypestl, eVocabularyID.eModelFileTypeply, eVocabularyID.eModelFileTypefbx, eVocabularyID.eModelFileTypewrl, eVocabularyID.eModelFileTypex3d, eVocabularyID.eModelFileTypedae]);
     const idVUnitSet = new Set();
     const idVPurposeSet = new Set();
     const idVFileTypeSet = new Set();
 
     unitsEntries.forEach(entry => {
-        if (eVocabUnitSet.has(entry.eVocabID)) idVUnitSet.add(entry.idVocabulary)}
-    );
+        if (entry.eVocabID && eVocabUnitSet.has(entry.eVocabID)) idVUnitSet.add(entry.idVocabulary);
+    });
     purposeEntries.forEach(entry => {
-        if (eVocabPurposeSet.has(entry.eVocabID)) idVPurposeSet.add(entry.idVocabulary)}
-    );
+        if (entry.eVocabID && eVocabPurposeSet.has(entry.eVocabID)) idVPurposeSet.add(entry.idVocabulary);
+    });
     typeEntries.forEach(entry => {
-        if (eVocabFileTypeSet.has(entry.eVocabID)) idVFileTypeSet.add(entry.idVocabulary)}
-    );
+        if (entry.eVocabID && eVocabFileTypeSet.has(entry.eVocabID)) idVFileTypeSet.add(entry.idVocabulary);
+    });
 
     const result = idVUnitSet.has(units) && idVPurposeSet.has(purpose) && idVFileTypeSet.has(modelFileType);
-    
+
     return result;
 }

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -5,9 +5,10 @@
  */
 import { AssetVersion, IngestFolder, IngestIdentifier, Item, Project, SubjectUnitIdentifier, Vocabulary, IngestionItem, IngestTitle } from '../types/graphql';
 import { StateItem, StateProject } from './item';
-import { StateFolder, StateIdentifier, SubtitleFields, eSubtitleOption } from './metadata';
+import { StateFolder, StateIdentifier, SubtitleFields, eSubtitleOption, ModelFields } from './metadata';
 import { StateSubject } from './subject';
 import { FileId, FileUploadStatus, IngestionFile } from './upload';
+import { eVocabularyID } from '@dpo-packrat/common';
 
 export function parseFileId(id: FileId): number {
     return Number.parseInt(id, 10);
@@ -151,5 +152,31 @@ export function parseSubtitlesToState(titles: IngestTitle): SubtitleFields {
         }
     }
 
+    return result;
+}
+
+export function enableSceneGenerateCheck(metadata: ModelFields, unitsEntries, purposeEntries, typeEntries ): boolean {
+    const { units, purpose, modelFileType } = metadata;
+    if (!units || !purpose || !modelFileType) return false;
+    
+    const eVocabUnitSet = new Set([eVocabularyID.eModelUnitsMillimeter as number, eVocabularyID.eModelUnitsCentimeter, eVocabularyID.eModelUnitsMeter, eVocabularyID.eModelUnitsInch, eVocabularyID.eModelUnitsFoot, eVocabularyID.eModelUnitsYard]);
+    const eVocabPurposeSet = new Set([eVocabularyID.eModelPurposeMaster]);
+    const eVocabFileTypeSet = new Set([eVocabularyID.eModelFileTypeobj, eVocabularyID.eModelFileTypestl, eVocabularyID.eModelFileTypeply, eVocabularyID.eModelFileTypefbx, eVocabularyID.eModelFileTypewrl, eVocabularyID.eModelFileTypex3d, eVocabularyID.eModelFileTypedae])
+    const idVUnitSet = new Set();
+    const idVPurposeSet = new Set();
+    const idVFileTypeSet = new Set();
+
+    unitsEntries.forEach(entry => {
+        if (eVocabUnitSet.has(entry.eVocabID)) idVUnitSet.add(entry.idVocabulary)}
+    );
+    purposeEntries.forEach(entry => {
+        if (eVocabPurposeSet.has(entry.eVocabID)) idVPurposeSet.add(entry.idVocabulary)}
+    );
+    typeEntries.forEach(entry => {
+        if (eVocabFileTypeSet.has(entry.eVocabID)) idVFileTypeSet.add(entry.idVocabulary)}
+    );
+
+    const result = idVUnitSet.has(units) && idVPurposeSet.has(purpose) && idVFileTypeSet.has(modelFileType);
+    
     return result;
 }

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -156,12 +156,13 @@ export function parseSubtitlesToState(titles: IngestTitle): SubtitleFields {
     return result;
 }
 
+const eVocabUnitSet = new Set([eVocabularyID.eModelUnitsMillimeter, eVocabularyID.eModelUnitsCentimeter, eVocabularyID.eModelUnitsMeter, eVocabularyID.eModelUnitsInch, eVocabularyID.eModelUnitsFoot, eVocabularyID.eModelUnitsYard]);
+const eVocabPurposeSet = new Set([eVocabularyID.eModelPurposeMaster]);
+const eVocabFileTypeSet = new Set([eVocabularyID.eModelFileTypeobj, eVocabularyID.eModelFileTypestl, eVocabularyID.eModelFileTypeply, eVocabularyID.eModelFileTypefbx, eVocabularyID.eModelFileTypewrl, eVocabularyID.eModelFileTypex3d, eVocabularyID.eModelFileTypedae]);
+
 export function enableSceneGenerateCheck(metadata: ModelFields, unitsEntries: VocabularyOption[], purposeEntries: VocabularyOption[], typeEntries: VocabularyOption[]): boolean {
     const { units, purpose, modelFileType } = metadata;
     if (!units || !purpose || !modelFileType) return false;
-    const eVocabUnitSet = new Set([eVocabularyID.eModelUnitsMillimeter as number, eVocabularyID.eModelUnitsCentimeter, eVocabularyID.eModelUnitsMeter, eVocabularyID.eModelUnitsInch, eVocabularyID.eModelUnitsFoot, eVocabularyID.eModelUnitsYard]);
-    const eVocabPurposeSet = new Set([eVocabularyID.eModelPurposeMaster]);
-    const eVocabFileTypeSet = new Set([eVocabularyID.eModelFileTypeobj, eVocabularyID.eModelFileTypestl, eVocabularyID.eModelFileTypeply, eVocabularyID.eModelFileTypefbx, eVocabularyID.eModelFileTypewrl, eVocabularyID.eModelFileTypex3d, eVocabularyID.eModelFileTypedae]);
     const idVUnitSet = new Set();
     const idVPurposeSet = new Set();
     const idVFileTypeSet = new Set();

--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-
 /**
  * Utils
  *
@@ -11,6 +9,7 @@ import { StateFolder, StateIdentifier, SubtitleFields, eSubtitleOption, ModelFie
 import { StateSubject } from './subject';
 import { FileId, FileUploadStatus, IngestionFile } from './upload';
 import { eVocabularyID } from '@dpo-packrat/common';
+import { VocabularyOption } from './vocabulary';
 
 export function parseFileId(id: FileId): number {
     return Number.parseInt(id, 10);
@@ -157,7 +156,7 @@ export function parseSubtitlesToState(titles: IngestTitle): SubtitleFields {
     return result;
 }
 
-export function enableSceneGenerateCheck(metadata: ModelFields, unitsEntries, purposeEntries, typeEntries ): boolean {
+export function enableSceneGenerateCheck(metadata: ModelFields, unitsEntries: VocabularyOption[], purposeEntries: VocabularyOption[], typeEntries: VocabularyOption[]): boolean {
     const { units, purpose, modelFileType } = metadata;
     if (!units || !purpose || !modelFileType) return false;
     const eVocabUnitSet = new Set([eVocabularyID.eModelUnitsMillimeter as number, eVocabularyID.eModelUnitsCentimeter, eVocabularyID.eModelUnitsMeter, eVocabularyID.eModelUnitsInch, eVocabularyID.eModelUnitsFoot, eVocabularyID.eModelUnitsYard]);
@@ -166,7 +165,6 @@ export function enableSceneGenerateCheck(metadata: ModelFields, unitsEntries, pu
     const idVUnitSet = new Set();
     const idVPurposeSet = new Set();
     const idVFileTypeSet = new Set();
-
     unitsEntries.forEach(entry => {
         if (entry.eVocabID && eVocabUnitSet.has(entry.eVocabID)) idVUnitSet.add(entry.idVocabulary);
     });

--- a/client/src/store/vocabulary.ts
+++ b/client/src/store/vocabulary.ts
@@ -9,7 +9,7 @@ import { apolloClient } from '../graphql';
 import { GetVocabularyEntriesDocument, Vocabulary } from '../types/graphql';
 import { eVocabularyID, eVocabularySetID } from '@dpo-packrat/common';
 
-export type VocabularyOption = Pick<Vocabulary, 'idVocabulary' | 'Term'>;
+export type VocabularyOption = Pick<Vocabulary, 'idVocabulary' | 'Term' | 'eVocabID'>;
 export type StateVocabulary = Map<eVocabularySetID, VocabularyOption[]>;
 
 type AssetType = {

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -1007,6 +1007,7 @@ export type IngestModelInput = {
   sourceObjects: Array<RelatedObjectInput>;
   derivedObjects: Array<RelatedObjectInput>;
   updateNotes?: Maybe<Scalars['String']>;
+  skipSceneGenerate?: Maybe<Scalars['Boolean']>;
 };
 
 export type IngestSceneInput = {

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -600,6 +600,7 @@ input IngestModelInput {
   sourceObjects: [RelatedObjectInput!]!
   derivedObjects: [RelatedObjectInput!]!
   updateNotes: String
+  skipSceneGenerate: Boolean
 }
 
 input IngestSceneInput {

--- a/server/graphql/schema/ingestion/mutations.graphql
+++ b/server/graphql/schema/ingestion/mutations.graphql
@@ -82,6 +82,7 @@ input IngestModelInput {
     sourceObjects: [RelatedObjectInput!]!
     derivedObjects: [RelatedObjectInput!]!
     updateNotes: String
+    skipSceneGenerate: Boolean
 }
 
 input IngestSceneInput {

--- a/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
+++ b/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
@@ -40,7 +40,7 @@ type AssetVersionInfo = {
 };
 
 interface IngestAssetResultCook extends IngestAssetResult {
-    skipSceneGenerate?: boolean;
+    skipSceneGenerate?: boolean | null;
 }
 
 type IdentifierResults = {
@@ -1364,7 +1364,7 @@ class IngestDataWorker extends ResolverBase {
                     }
                 }
             }
-            if (typeof AVInfo.skipSceneGenerate === 'boolean') IAR.skipSceneGenerate = AVInfo.skipSceneGenerate;
+            IAR.skipSceneGenerate = AVInfo.skipSceneGenerate;
             ingestResMap.set(idAssetVersion, IAR);
         }
         if (transformUpdated)

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -1004,6 +1004,7 @@ export type IngestModelInput = {
   sourceObjects: Array<RelatedObjectInput>;
   derivedObjects: Array<RelatedObjectInput>;
   updateNotes?: Maybe<Scalars['String']>;
+  skipSceneGenerate?: Maybe<Scalars['Boolean']>;
 };
 
 export type IngestSceneInput = {

--- a/server/workflow/impl/Packrat/WorkflowEngine.ts
+++ b/server/workflow/impl/Packrat/WorkflowEngine.ts
@@ -287,24 +287,27 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
         if (CMIR.units !== undefined) {
             const parameterHelper: COOK.JobCookSIVoyagerSceneParameterHelper | null = await COOK.JobCookSIVoyagerSceneParameterHelper.compute(CMIR.idModel);
             if (parameterHelper) {
-                const jobParamSIVoyagerScene: WFP.WorkflowJobParameters =
-                    new WFP.WorkflowJobParameters(COMMON.eVocabularyID.eJobJobTypeCookSIVoyagerScene,
-                        new COOK.JobCookSIVoyagerSceneParameters(parameterHelper, CMIR.assetVersionGeometry.FileName, CMIR.units,
-                        CMIR.assetVersionDiffuse?.FileName, sceneBaseName + '.svx.json', undefined, sceneBaseName));
+                if (workflowParams.parameters.skipSceneGenerate) {
+                    LOG.info(`WorkflowEngine.eventIngestionIngestObjectModel skipping si-voyager-scene per user instruction idSO ${workflowParams.idSystemObject}`, LOG.LS.eWF);
+                } else {
+                    const jobParamSIVoyagerScene: WFP.WorkflowJobParameters =
+                        new WFP.WorkflowJobParameters(COMMON.eVocabularyID.eJobJobTypeCookSIVoyagerScene,
+                            new COOK.JobCookSIVoyagerSceneParameters(parameterHelper, CMIR.assetVersionGeometry.FileName, CMIR.units,
+                            CMIR.assetVersionDiffuse?.FileName, sceneBaseName + '.svx.json', undefined, sceneBaseName));
 
-                const wfParamSIVoyagerScene: WF.WorkflowParameters = {
-                    eWorkflowType: COMMON.eVocabularyID.eWorkflowTypeCookJob,
-                    idSystemObject,
-                    idProject: workflowParams.idProject,
-                    idUserInitiator: workflowParams.idUserInitiator,
-                    parameters: jobParamSIVoyagerScene,
-                };
-
-                const wfSIVoyagerScene: WF.IWorkflow | null = await this.create(wfParamSIVoyagerScene);
-                if (wfSIVoyagerScene)
-                    workflows.push(wfSIVoyagerScene);
-                else
-                    LOG.error(`WorkflowEngine.eventIngestionIngestObjectModel unable to create Cook si-voyager-scene workflow: ${JSON.stringify(wfParamSIVoyagerScene)}`, LOG.LS.eWF);
+                    const wfParamSIVoyagerScene: WF.WorkflowParameters = {
+                        eWorkflowType: COMMON.eVocabularyID.eWorkflowTypeCookJob,
+                        idSystemObject,
+                        idProject: workflowParams.idProject,
+                        idUserInitiator: workflowParams.idUserInitiator,
+                        parameters: jobParamSIVoyagerScene,
+                    };
+                    const wfSIVoyagerScene: WF.IWorkflow | null = await this.create(wfParamSIVoyagerScene);
+                    if (wfSIVoyagerScene)
+                        workflows.push(wfSIVoyagerScene);
+                    else
+                        LOG.error(`WorkflowEngine.eventIngestionIngestObjectModel unable to create Cook si-voyager-scene workflow: ${JSON.stringify(wfParamSIVoyagerScene)}`, LOG.LS.eWF);
+                }
             } else
                 LOG.error(`WorkflowEngine.eventIngestionIngestObjectModel unable to compute parameter info needed by Cook si-voyager-scene workflow from model: ${CMIR.idModel}`, LOG.LS.eWF);
         } else


### PR DESCRIPTION
UI
Create new component GenerateModelControl.tsx to determine when scene generation should be allowed
GenerateModelControl also has explicit instructions on how to enable scene generation during model ingestion

Client/Util
Created a helper method enableSceneGenerateCheck to determine when enable scene generation control can be enabled during model ingestion

Workflow
Added a new flag to the eventIngestionIngestObjectModel params that indicates whether to skip scene generation
