### PR TITLE
Added CPU Monitoring ...

### DIFF
--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -4,6 +4,7 @@ import { EventFactory } from '../event/interface/EventFactory';
 import { ASL, LocalStore } from '../utils/localStore';
 import { Config } from '../config';
 import * as LOG from '../utils/logger';
+import { CPUMonitor } from '../utils/osStats';
 
 import { logtest } from './routes/logtest';
 import { heartbeat } from './routes/heartbeat';
@@ -19,6 +20,8 @@ import { ApolloServer } from 'apollo-server-express';
 import cookieParser from 'cookie-parser';
 import { graphqlUploadExpress } from 'graphql-upload';
 import { v2 as webdav } from 'webdav-server';
+
+const monitorCPU: boolean = true;
 
 /**
  * Singleton instance of HttpServer is retrieved via HttpServer.getInstance()
@@ -43,6 +46,10 @@ export class HttpServer {
 
         // call to initalize the EventFactory, which in turn will initialize the AuditEventGenerator, supplying the IEventEngine
         EventFactory.getInstance();
+        if (monitorCPU) {
+            const monitor: CPUMonitor = new CPUMonitor(1000, 90, 10); // sample every second, alert if > 90% for more than 10 samples in a row
+            monitor.start();
+        }
         return res;
     }
 

--- a/server/tests/jest.config.js
+++ b/server/tests/jest.config.js
@@ -38,6 +38,7 @@ module.exports = {
         // '**/tests/storage/interface/AssetStorageAdapter.test.ts',
         // '**/tests/storage/impl/LocalStorage/OCFL.test.ts',
         // '**/tests/storage/impl/LocalStorage/LocalStorage.test.ts',
+        // '**/tests/utils/email.test.ts',
         // '**/tests/utils/helpers.test.ts',
         // '**/tests/utils/parser/bagitReader.test.ts',
         // '**/tests/utils/parser/bulkIngestReader.test.ts',

--- a/server/tests/utils/email.test.ts
+++ b/server/tests/utils/email.test.ts
@@ -1,0 +1,32 @@
+import { Email } from '../../utils/email';
+import * as H from '../../utils/helpers';
+import * as LOG from '../../utils/logger';
+
+/*
+afterAll(async done => {
+    await H.Helpers.sleep(5000);
+    done();
+});
+*/
+
+describe('Utils: Email', () => {
+    testSend('', '');
+    // testSend('tysonj@si.edu', 'tysonj@si.edu');
+    // testSend('tysonj@si.edu', 'jon.tyson@gmail.com');
+    // testSend('tysonj@si.edu', 'jon@internetshoppingclub.com');
+});
+
+async function testSend(from: string, to: string): Promise<void> {
+    const message: string = `${from} -> ${to}`;
+    test('Utils: Email.Send', async () => {
+        if (from === '' && to === '')
+            return;
+
+        const res: H.IOResults = await Email.Send(from, to, `Test ${message}`, message);
+        if (res.success)
+            LOG.info(`testSend ${message} Success`, LOG.LS.eTEST);
+        else
+            LOG.error(`testSend ${message} FAIL`, LOG.LS.eTEST);
+        expect(res.success).toBeTruthy();
+    });
+}

--- a/server/utils/osStats.ts
+++ b/server/utils/osStats.ts
@@ -1,0 +1,118 @@
+import * as LOG from './logger';
+import  * as os from 'os';
+
+/** Upon construction, computes the total MS and % CPU utilization, either compared with the pass in osStats object, or since the last reboot (if null) */
+export class osStats {
+    CPUs: os.CpuInfo[];
+
+    userTotal: number = 0;
+    niceTotal: number = 0;
+    sysTotal: number = 0;
+    idleTotal: number = 0;
+    irqTotal: number = 0;
+
+    userDelta: number = 0;
+    niceDelta: number = 0;
+    sysDelta: number = 0;
+    idleDelta: number = 0;
+    irqDelta: number = 0;
+
+    userPerc: number = 0;
+    nicePerc: number = 0;
+    sysPerc: number = 0;
+    idlePerc: number = 0;
+    irqPerc: number = 0;
+
+    busyPerc: number = 0;
+
+    constructor(prev?: osStats | undefined) {
+        this.CPUs = os.cpus();
+        for (const cpu of this.CPUs) {
+            this.userTotal += cpu.times.user;
+            this.niceTotal += cpu.times.nice;
+            this.sysTotal  += cpu.times.sys;
+            this.idleTotal += cpu.times.idle;
+            this.irqTotal  += cpu.times.irq;
+        }
+
+        // compute deltas using previous osStats object, if supplied
+        if (prev) {
+            this.userDelta = this.userTotal - prev.userTotal;
+            this.niceDelta = this.niceTotal - prev.niceTotal;
+            this.sysDelta  = this.sysTotal  - prev.sysTotal;
+            this.idleDelta = this.idleTotal - prev.idleTotal;
+            this.irqDelta  = this.irqTotal  - prev.irqTotal;
+        } else {
+            this.userDelta = this.userTotal;
+            this.niceDelta = this.niceTotal;
+            this.sysDelta  = this.sysTotal;
+            this.idleDelta = this.idleTotal;
+            this.irqDelta  = this.irqTotal;
+        }
+
+        const deltaTotal: number = this.userDelta + this.niceDelta + this.sysDelta + this.idleDelta + this.irqDelta;
+        if (deltaTotal <= 0)
+            return;
+
+        this.userPerc = this.userDelta / deltaTotal;
+        this.nicePerc = this.niceDelta / deltaTotal;
+        this.sysPerc  = this.sysDelta  / deltaTotal;
+        this.idlePerc = this.idleDelta / deltaTotal;
+        this.irqPerc  = this.irqDelta  / deltaTotal;
+        this.busyPerc = 1 - this.idlePerc;
+    }
+
+    emitInfo(): string {
+        const totalTime: number = this.userTotal + this.niceTotal + this.sysTotal + this.idleTotal + this.irqTotal;
+        const deltaTime: number = this.userDelta + this.niceDelta + this.sysDelta + this.idleDelta + this.irqDelta;
+        return `CPU Count ${this.CPUs.length}; busy percentage ${this.emitBusyPerc()}; delta time ${deltaTime}; total time ${totalTime}`;
+    }
+
+    emitBusyPerc(): string {
+        return (this.busyPerc * 100).toFixed(2) + '%';
+    }
+}
+
+export class CPUMonitor {
+    private monitorTimeout: number;
+    private alertThreshold: number;
+    private alertAlarm: number;
+
+    private alertCount: number = 0;
+    private timer: NodeJS.Timeout | null = null;
+    private OS: osStats = new osStats();
+
+    /**
+     * @monitorTimeout in milleseconds -- how often we sample CPU utilization
+     * @alertThreshold busy percentage above which we'll be alerted; 100 is the maximum
+     * @alertAlarm count of consequetive samples above alertThreshold that indicate an alarm status */
+    constructor(monitorTimeout: number, alertThreshold: number, alertAlarm: number) {
+        this.monitorTimeout = monitorTimeout;
+        this.alertThreshold = alertThreshold;
+        this.alertAlarm = alertAlarm;
+    }
+
+    start(): void {
+        this.timer = setInterval(() => this.sample(), this.monitorTimeout);
+    }
+
+    stop(): void {
+        if (this.timer)
+            clearInterval(this.timer);
+    }
+
+    sample(): void {
+        this.OS = new osStats(this.OS);
+        if ((this.OS.busyPerc * 100) >= this.alertThreshold) {
+            if (++this.alertCount >= this.alertAlarm)
+                this.alert();
+        } else
+            this.alertCount = 0;
+        // LOG.info(`CPUMonitor.sample ${this.OS.emitInfo()}; alert count ${this.alertCount};`, LOG.LS.eSYS);
+    }
+
+    alert(): void {
+        this.alertCount = 0;
+        LOG.error(`CPUMonitor exceeded ${this.alertThreshold}% CPU utilization for ${this.alertAlarm} consecutive samples: ${this.OS.emitInfo()}`, LOG.LS.eSYS);
+    }
+}


### PR DESCRIPTION
.. for use in emitting log messages when migration causes CPUs to spike to 100%.

System:
* Implemented CPU Monitoring in server/utils/osStats.ts

HTTP:
* Start CPU monitoring when configured to do so via const monitorCPU

Test:
* Add email test code, but commented out to avoid spamming an email address as automated testing is performed