### PR TITLE
Address regression failures

### DIFF
--- a/server/db/api/composite/SubjectUnitIdentifier.ts
+++ b/server/db/api/composite/SubjectUnitIdentifier.ts
@@ -25,8 +25,8 @@ export class SubjectUnitIdentifier {
             if (!SubjectUnitIdentifier.initialized) {
                 const vocabARK:             Vocabulary | undefined = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eIdentifierIdentifierTypeARK);
                 const vocabEdanRecordID:    Vocabulary | undefined = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eIdentifierIdentifierTypeEdanRecordID);
-                SubjectUnitIdentifier.idVocabARK = vocabARK ? vocabARK.idVocabulary : /* istanbul ignore next */ 76;
-                SubjectUnitIdentifier.idVocabEdanRecordID = vocabEdanRecordID ? vocabEdanRecordID.idVocabulary : /* istanbul ignore next */ 77;
+                SubjectUnitIdentifier.idVocabARK = vocabARK ? vocabARK.idVocabulary : /* istanbul ignore next */ 79;                            // SELECT idVocabulary FROM Vocabulary WHERE Term = 'ARK';
+                SubjectUnitIdentifier.idVocabEdanRecordID = vocabEdanRecordID ? vocabEdanRecordID.idVocabulary : /* istanbul ignore next */ 81; // SELECT idVocabulary FROM Vocabulary WHERE Term = 'Edan Record ID';
                 SubjectUnitIdentifier.initialized = true;
             }
 

--- a/server/tests/db/composite/SubjectUnitIdentifier.test.ts
+++ b/server/tests/db/composite/SubjectUnitIdentifier.test.ts
@@ -5,7 +5,7 @@ import * as COMMON from '@dpo-packrat/common';
 // import * as H from '../../../utils/helpers';
 
 afterAll(async done => {
-    // awaitH.Helpers.sleep(4000);
+    // await H.Helpers.sleep(4000);
     done();
 });
 
@@ -35,12 +35,12 @@ describe('DB Composite SubjectUnitIdentifier Test', () => {
     executeSearch('Armstrong', false, false, 1);
     executeSearch('65665', false, true);
     executeSearch('65665', false, false, -1);
-    executeSearch('65665', false, true, 12, 1, 100);
-    executeSearch('65665', false, true, 12, 2, 10);
-    executeSearch('65665', false, true, 12, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eDefault, true);
-    executeSearch('65665', false, true, 12, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eIdentifierValue, false);
-    executeSearch('65665', false, true, 12, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eSubjectName, true);
-    executeSearch('65665', false, true, 12, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eUnitAbbreviation, false);
+    executeSearch('65665', false, true, 17, 1, 100);
+    executeSearch('65665', false, true, 17, 2, 10);
+    executeSearch('65665', false, true, 17, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eDefault, true);
+    executeSearch('65665', false, true, 17, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eIdentifierValue, false);
+    executeSearch('65665', false, true, 17, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eSubjectName, true);
+    executeSearch('65665', false, true, 17, 2, 10, COMMON.eSubjectUnitIdentifierSortColumns.eUnitAbbreviation, false);
 });
 
 function executeQuery(query: string, expectNull: boolean, expectResults: boolean): void {


### PR DESCRIPTION
Test:
* Address regression failures caused by database ID updates.  A better fix is to load these IDs from the database, but I'm taking a shortcut to save time.