### PR TITLE
Cache: Avoid adding non-system objects to SystemObjectCache's objectIDToSystemMap

### DIFF
--- a/server/cache/SystemObjectCache.ts
+++ b/server/cache/SystemObjectCache.ts
@@ -90,9 +90,10 @@ export class SystemObjectCache {
                 this.systemIDToObjectMap.set(SO.idSystemObject, oIDCleansed);
             } else if (!isASystemObject) {
                 if (idObject) {
-                    // LOG.info(`SystemObjectCache.getSystemFromObjectIDInternal storing idSystemObject 0 for ${JSON.stringify(oIDCleansed)}`, LOG.LS.eCACHE);
                     sID = { idSystemObject: 0, Retired: false };
-                    this.objectIDToSystemMap.set(oIDCleansed, sID);
+                    // Avoid adding non-system objects to objectIDToSystemMap ... we end up with more than 2^24 entries in this map, which is the V8 limit for JS Maps
+                    // LOG.info(`SystemObjectCache.getSystemFromObjectIDInternal stored idSystemObject 0 for ${JSON.stringify(oIDCleansed)}`, LOG.LS.eCACHE);
+                    // this.objectIDToSystemMap.set(oIDCleansed, sID);
                 }
             } else
                 LOG.error(`SystemObjectCache.getSystemFromObjectIDInternal unable to lookup ${COMMON.eSystemObjectType[eObjectType]}, id ${idObject}`, LOG.LS.eCACHE );


### PR DESCRIPTION
Doing so results in us eventually exceeding the JS 2^24 entry limit for Maps ... most likely due to auditing attempting to get system objects for all sorts of DB inserts & modifications.