### PR TITLE
Regression Failure Fix

### DIFF
--- a/server/tests/utils/helpers.test.ts
+++ b/server/tests/utils/helpers.test.ts
@@ -501,15 +501,15 @@ describe('Utils: Helpers', () => {
 
         const output1: string = JSON.stringify(testData, H.Helpers.saferStringify);
         // LOG.info(`output: ${output1}`, LOG.LS.eTEST);
-        expect(output1).toEqual('{"map":[],"set":[],"bigint":"999999999999999","string":"string","number":50,"boolean":false,"null":null,"valueOrig":39}');
+        expect(output1).toEqual('{"map":[],"set":[],"bigint":999999999999999,"string":"string","number":50,"boolean":false,"null":null,"valueOrig":39}');
 
         const output2: string = JSON.stringify(testData, H.Helpers.stringifyDatabaseRow);
         // LOG.info(`output: ${output2}`, LOG.LS.eTEST);
-        expect(output2).toEqual('{"map":[],"set":[],"bigint":"999999999999999","string":"string","number":50,"boolean":false,"null":null}');
+        expect(output2).toEqual('{"map":[],"set":[],"bigint":999999999999999,"string":"string","number":50,"boolean":false,"null":null}');
 
         const output3: string = H.Helpers.JSONStringify(testData);
         // LOG.info(`output: ${output3}`, LOG.LS.eTEST);
-        expect(output3).toEqual('{"map":[],"set":[],"bigint":"999999999999999","string":"string","number":50,"boolean":false,"null":null,"valueOrig":39}');
+        expect(output3).toEqual('{"map":[],"set":[],"bigint":999999999999999,"string":"string","number":50,"boolean":false,"null":null,"valueOrig":39}');
     });
 
     test('Utils: escapeHTMLEntity', async () => {

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -12,6 +12,8 @@ import * as crypto from 'crypto';
 import * as LOG from './logger';
 import { Readable, Writable } from 'stream';
 
+require('json-bigint-patch'); // patch JSON.stringify's handling of BigInt
+
 export type IOResults = {
     success: boolean;
     error?: string;


### PR DESCRIPTION
* Require json-bigint-patch in helpers.ts, so that regression tests pick it up, too.
* Update helpers.test.ts to reflect new serialization of bigints (not as strings)