### PR TITLE
upsertContent API logging and migration si-packrat-inspect extraction

### DIFF
--- a/server/collections/impl/EdanCollection.ts
+++ b/server/collections/impl/EdanCollection.ts
@@ -236,7 +236,7 @@ export class EdanCollection implements COL.ICollection {
         // LOG.info(`EdanCollection.upsertContent: ${JSON.stringify(body)}`, LOG.LS.eCOLL);
         LOG.info('EdanCollection.upsertContent', LOG.LS.eCOLL);
         const reqResult: HttpRequestResult = await this.sendRequest(eAPIType.eEDAN3dApi, eHTTPMethod.ePost, 'api/v1.0/admin/upsertContent', '', JSON.stringify(body), 'application/json');
-        // LOG.info(`EdanCollection.upsertContent:\n${JSON.stringify(body)}\n${reqResult.output}`, LOG.LS.eCOLL);
+        LOG.info(`EdanCollection.upsertContent:\n${JSON.stringify(body)}\n${reqResult.output}`, LOG.LS.eCOLL);
         if (!reqResult.success) {
             LOG.error(`EdanCollection.${caller} failed with ${reqResult.statusText}: ${reqResult.output}`, LOG.LS.eCOLL);
             return null;

--- a/server/workflow/impl/Packrat/WorkflowUtil.ts
+++ b/server/workflow/impl/Packrat/WorkflowUtil.ts
@@ -72,6 +72,14 @@ export class WorkflowUtil {
             idSystemObject.push(idSystemObjectAssetVersion);
             if (idSystemObjectSupportFileAssetVersion)
                 idSystemObject.push(idSystemObjectSupportFileAssetVersion);
+
+            const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObjectAssetVersion);
+            if (!SO)
+                return { success: false, error: `WorkflowUtil.computeModelMetrics ${fileName} unable to fetch system object from id ${idSystemObjectAssetVersion}` };
+            if (SO.idAssetVersion)
+                idAssetVersions.push(SO.idAssetVersion);
+            else
+                LOG.error(`WorkflowUtil.computeModelMetrics ${fileName} handling system object ${idSystemObjectAssetVersion} which is not an asset version`, LOG.LS.eWF);
         } else {
             if (!idSystemObjectModel) {
                 const model: DBAPI.Model | null = await DBAPI.Model.fetch(idModel ?? 0);


### PR DESCRIPTION
Collections:
* Add logging of upsertContent API usage to provide feedback to Andrew

Workflow:
* Work harder to associate si-packrat-inspect output with the correct model asset version(s), so in turn, we can properly extract model details