### PR TITLE
Daily log rotation; mark OCFLObject move operations that fail as an error when appropriate

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -97,7 +97,8 @@
     "uuid": "9.0.0",
     "webdav": "4.11.0",
     "webdav-server": "https://github.com/Smithsonian/npm-WebDAV-Server.git",
-    "winston": "3.8.2"
+    "winston": "3.8.2",
+    "winston-daily-rotate-file": "4.7.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.12.1",

--- a/server/storage/impl/LocalStorage/OCFLObject.ts
+++ b/server/storage/impl/LocalStorage/OCFLObject.ts
@@ -184,9 +184,9 @@ export class OCFLObject {
 
     private async safeMoveFile(pathOnDisk: string, destName: string): Promise<H.IOResults> {
         let results: H.IOResults;
-        if (OCFLObject._eMoveFileType == eMoveFileType.eUnknown ||
-            OCFLObject._eMoveFileType == eMoveFileType.eMove) {
-            results = await H.Helpers.moveFile(pathOnDisk, destName);
+        if (OCFLObject._eMoveFileType === eMoveFileType.eUnknown ||
+            OCFLObject._eMoveFileType === eMoveFileType.eMove) {
+            results = await H.Helpers.moveFile(pathOnDisk, destName, (OCFLObject._eMoveFileType === eMoveFileType.eUnknown));
             if (results.success) {
                 OCFLObject._eMoveFileType = eMoveFileType.eMove;
                 return results;

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -82,11 +82,14 @@ export class Helpers {
         return { success: true };
     }
 
-    static async moveFile(nameSource: string, nameDestination: string): Promise<IOResults> {
+    static async moveFile(nameSource: string, nameDestination: string, allowedToFail?: boolean): Promise<IOResults> {
         try {
             await fsp.rename(nameSource, nameDestination);
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('Helpers.moveFile', LOG.LS.eSYS, error);
+            if (allowedToFail)
+                LOG.info(`Helpers.moveFile: ${Helpers.JSONStringify(error)}`, LOG.LS.eSYS);
+            else
+                LOG.error('Helpers.moveFile', LOG.LS.eSYS, error);
             return { success: false, error: `Unable to move ${nameSource} to ${nameDestination}: ${error}` };
         }
         return { success: true };

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as winston from 'winston';
+import 'winston-daily-rotate-file';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Config } from '../config';
@@ -103,9 +104,11 @@ function configureLogger(logPath: string | null): void {
             })
         ),
         transports: [
-            new winston.transports.File({
-                filename: path.join(logPath, 'PackratCombined.log'),
-                maxsize: 100 * 1024 * 1024 // 100 MB
+            new winston.transports.DailyRotateFile({
+                filename: 'PackratCombined.%DATE%.log',
+                dirname: logPath,
+                datePattern: 'YYYY-MM-DD',
+                maxSize: 100 * 1024 * 1024 // 100 MB
             }),
             new winston.transports.File({
                 filename: path.join(logPath, 'PackratError.log'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9494,6 +9494,13 @@ file-selector@^0.6.0:
   dependencies:
     tslib "^2.4.0"
 
+file-stream-rotator@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz#007019e735b262bb6c6f0197e58e5c87cb96cec3"
+  integrity sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==
+  dependencies:
+    moment "^2.29.1"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -13984,6 +13991,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment@^2.29.1:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -16681,7 +16693,7 @@ react-dropzone@14.2.2:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
-react-error-overlay@6.0.9, react-error-overlay@^6.0.7:
+react-error-overlay@^6.0.7:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
@@ -20094,7 +20106,17 @@ wide-align@^1.1.5:
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
 
-winston-transport@^4.5.0:
+winston-daily-rotate-file@4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz#f60a643af87f8867f23170d8cd87dbe3603a625f"
+  integrity sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==
+  dependencies:
+    file-stream-rotator "^0.6.1"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
+winston-transport@^4.4.0, winston-transport@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
   integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==


### PR DESCRIPTION
System:
* Added winston-daily-rotate-file
* Use winston-daily-rotate-file to rotate logs every day
* Allow Helpers.moveFile to fail without logging an error
* Use Helpers.moveFile without logging an error when the OCFLObject has not yet tried to move a file