### PR TITLE
Updated to Prisma v4.9.0; added DB error logging

### DIFF
--- a/server/db/api/AccessAction.ts
+++ b/server/db/api/AccessAction.ts
@@ -27,8 +27,7 @@ export class AccessAction extends DBC.DBObject<AccessActionBase> implements Acce
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessAction.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -40,8 +39,7 @@ export class AccessAction extends DBC.DBObject<AccessActionBase> implements Acce
                 data: { Name, SortOrder, },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessAction.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AccessContext.ts
+++ b/server/db/api/AccessContext.ts
@@ -29,8 +29,7 @@ export class AccessContext extends DBC.DBObject<AccessContextBase> implements Ac
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessContext.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -42,8 +41,7 @@ export class AccessContext extends DBC.DBObject<AccessContextBase> implements Ac
                 data: { Authoritative, CaptureData, Global, IntermediaryFile, Model, Scene }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessContext.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AccessContextObject.ts
+++ b/server/db/api/AccessContextObject.ts
@@ -28,8 +28,7 @@ export class AccessContextObject extends DBC.DBObject<AccessContextObjectBase> i
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessContextObject.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -44,8 +43,7 @@ export class AccessContextObject extends DBC.DBObject<AccessContextObjectBase> i
                 }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessContextObject.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AccessPolicy.ts
+++ b/server/db/api/AccessPolicy.ts
@@ -30,8 +30,7 @@ export class AccessPolicy extends DBC.DBObject<AccessPolicyBase> implements Acce
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessPolicy.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -47,8 +46,7 @@ export class AccessPolicy extends DBC.DBObject<AccessPolicyBase> implements Acce
                 }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessPolicy.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AccessRole.ts
+++ b/server/db/api/AccessRole.ts
@@ -22,8 +22,7 @@ export class AccessRole extends DBC.DBObject<AccessRoleBase> implements AccessRo
             }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessRole.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -35,8 +34,7 @@ export class AccessRole extends DBC.DBObject<AccessRoleBase> implements AccessRo
                 data: { Name, },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessRole.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AccessRoleAccessActionXref.ts
+++ b/server/db/api/AccessRoleAccessActionXref.ts
@@ -28,8 +28,7 @@ export class AccessRoleAccessActionXref extends DBC.DBObject<AccessRoleAccessAct
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessRoleAccessActionXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -44,8 +43,7 @@ export class AccessRoleAccessActionXref extends DBC.DBObject<AccessRoleAccessAct
                 }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AccessRoleAccessActionXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Actor.ts
+++ b/server/db/api/Actor.ts
@@ -31,8 +31,7 @@ export class Actor extends DBC.DBObject<ActorBase> implements ActorBase, SystemO
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Actor.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -49,8 +48,7 @@ export class Actor extends DBC.DBObject<ActorBase> implements ActorBase, SystemO
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Actor.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Asset.ts
+++ b/server/db/api/Asset.ts
@@ -49,8 +49,7 @@ export class Asset extends DBC.DBObject<AssetBase> implements AssetBase, SystemO
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Asset.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -69,8 +68,7 @@ export class Asset extends DBC.DBObject<AssetBase> implements AssetBase, SystemO
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Asset.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AssetGroup.ts
+++ b/server/db/api/AssetGroup.ts
@@ -18,8 +18,7 @@ export class AssetGroup extends DBC.DBObject<AssetGroupBase> implements AssetGro
             ({ idAssetGroup: this.idAssetGroup } = await DBC.DBConnection.prisma.assetGroup.create({ data: { } }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AssetGroup.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -31,8 +30,7 @@ export class AssetGroup extends DBC.DBObject<AssetGroupBase> implements AssetGro
                 data: { },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AssetGroup.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/AssetVersion.ts
+++ b/server/db/api/AssetVersion.ts
@@ -87,8 +87,7 @@ export class AssetVersion extends DBC.DBObject<AssetVersionBase> implements Asse
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AssetVersion.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
 
         /*
@@ -162,8 +161,7 @@ export class AssetVersion extends DBC.DBObject<AssetVersionBase> implements Asse
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AssetVersion.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 
@@ -185,7 +183,7 @@ export class AssetVersion extends DBC.DBObject<AssetVersionBase> implements Asse
             return DBC.CopyObject<AssetVersionBase, AssetVersion>(
                 await DBC.DBConnection.prisma.assetVersion.findUnique({ where: { idAssetVersion, }, }), AssetVersion);
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.AssetVersion.fetch', LOG.LS.eDB, error);
+            LOG.error(`DBAPI.AssetVersion.fetch(${idAssetVersion})`, LOG.LS.eDB, error);
             return null;
         }
     }

--- a/server/db/api/Audit.ts
+++ b/server/db/api/Audit.ts
@@ -36,8 +36,7 @@ export class Audit extends DBC.DBObject<AuditBase> implements AuditBase {
                 } }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Audit.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -54,8 +53,7 @@ export class Audit extends DBC.DBObject<AuditBase> implements AuditBase {
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Audit.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/CaptureData.ts
+++ b/server/db/api/CaptureData.ts
@@ -36,8 +36,7 @@ export class CaptureData extends DBC.DBObject<CaptureDataBase> implements Captur
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureData.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -56,8 +55,7 @@ export class CaptureData extends DBC.DBObject<CaptureDataBase> implements Captur
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureData.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/CaptureDataFile.ts
+++ b/server/db/api/CaptureDataFile.ts
@@ -34,8 +34,7 @@ export class CaptureDataFile extends DBC.DBObject<CaptureDataFileBase> implement
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataFile.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -52,8 +51,7 @@ export class CaptureDataFile extends DBC.DBObject<CaptureDataFileBase> implement
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataFile.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/CaptureDataGroup.ts
+++ b/server/db/api/CaptureDataGroup.ts
@@ -18,8 +18,7 @@ export class CaptureDataGroup extends DBC.DBObject<CaptureDataGroupBase> impleme
             ({ idCaptureDataGroup: this.idCaptureDataGroup } = await DBC.DBConnection.prisma.captureDataGroup.create({ data: { } }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataGroup.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -31,8 +30,7 @@ export class CaptureDataGroup extends DBC.DBObject<CaptureDataGroupBase> impleme
                 data: { },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataGroup.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/CaptureDataGroupCaptureDataXref.ts
+++ b/server/db/api/CaptureDataGroupCaptureDataXref.ts
@@ -28,8 +28,7 @@ export class CaptureDataGroupCaptureDataXref extends DBC.DBObject<CaptureDataGro
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataGroupCaptureDataXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -44,8 +43,7 @@ export class CaptureDataGroupCaptureDataXref extends DBC.DBObject<CaptureDataGro
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataGroupCaptureDataXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/CaptureDataPhoto.ts
+++ b/server/db/api/CaptureDataPhoto.ts
@@ -54,8 +54,7 @@ export class CaptureDataPhoto extends DBC.DBObject<CaptureDataPhotoBase> impleme
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataPhoto.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -83,8 +82,7 @@ export class CaptureDataPhoto extends DBC.DBObject<CaptureDataPhotoBase> impleme
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.CaptureDataPhoto.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/GeoLocation.ts
+++ b/server/db/api/GeoLocation.ts
@@ -33,8 +33,7 @@ export class GeoLocation extends DBC.DBObject<GeoLocationBase> implements GeoLoc
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.GeoLocation.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -46,8 +45,7 @@ export class GeoLocation extends DBC.DBObject<GeoLocationBase> implements GeoLoc
                 data: { Latitude, Longitude, Altitude, TS0, TS1, TS2, R0, R1, R2, R3 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.GeoLocation.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Identifier.ts
+++ b/server/db/api/Identifier.ts
@@ -31,8 +31,7 @@ export class Identifier extends DBC.DBObject<IdentifierBase> implements Identifi
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Identifier.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -49,8 +48,7 @@ export class Identifier extends DBC.DBObject<IdentifierBase> implements Identifi
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Identifier.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/IntermediaryFile.ts
+++ b/server/db/api/IntermediaryFile.ts
@@ -29,8 +29,7 @@ export class IntermediaryFile extends DBC.DBObject<IntermediaryFileBase> impleme
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.IntermediaryFile.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -45,8 +44,7 @@ export class IntermediaryFile extends DBC.DBObject<IntermediaryFileBase> impleme
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.IntermediaryFile.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Item.ts
+++ b/server/db/api/Item.ts
@@ -50,8 +50,7 @@ export class Item extends DBC.DBObject<ItemBase> implements ItemBase, SystemObje
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Item.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -70,8 +69,7 @@ export class Item extends DBC.DBObject<ItemBase> implements ItemBase, SystemObje
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Item.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Job.ts
+++ b/server/db/api/Job.ts
@@ -49,8 +49,7 @@ export class Job extends DBC.DBObject<JobBase> implements JobBase {
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Job.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -67,8 +66,7 @@ export class Job extends DBC.DBObject<JobBase> implements JobBase {
                 }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Job.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/JobRun.ts
+++ b/server/db/api/JobRun.ts
@@ -63,7 +63,7 @@ export class JobRun extends DBC.DBObject<JobRunBase> implements JobRunBase {
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.JobRun.create', LOG.LS.eDB, error);
+            this.logError('create', error);
             return false;
         }
     }
@@ -86,7 +86,7 @@ export class JobRun extends DBC.DBObject<JobRunBase> implements JobRunBase {
                 }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.JobRun.update', LOG.LS.eDB, error);
+            this.logError('update', error);
             return false;
         }
     }
@@ -98,7 +98,7 @@ export class JobRun extends DBC.DBObject<JobRunBase> implements JobRunBase {
             return DBC.CopyObject<JobRunBase, JobRun>(
                 await DBC.DBConnection.prisma.jobRun.findUnique({ where: { idJobRun, }, }), JobRun);
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.JobRun.fetch', LOG.LS.eDB, error);
+            LOG.error(`DBAPI.JobRun.fetch(${idJobRun})`, LOG.LS.eDB, error);
             return null;
         }
     }

--- a/server/db/api/License.ts
+++ b/server/db/api/License.ts
@@ -23,8 +23,7 @@ export class License extends DBC.DBObject<LicenseBase> implements LicenseBase {
                 await DBC.DBConnection.prisma.license.create({ data: { Name, Description, RestrictLevel }, }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.License.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -36,8 +35,7 @@ export class License extends DBC.DBObject<LicenseBase> implements LicenseBase {
                 data: { Name, Description, RestrictLevel, },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.License.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/LicenseAssignment.ts
+++ b/server/db/api/LicenseAssignment.ts
@@ -34,8 +34,7 @@ export class LicenseAssignment extends DBC.DBObject<LicenseAssignmentBase> imple
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.LicenseAssignment.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -54,8 +53,7 @@ export class LicenseAssignment extends DBC.DBObject<LicenseAssignmentBase> imple
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.LicenseAssignment.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Metadata.ts
+++ b/server/db/api/Metadata.ts
@@ -41,8 +41,7 @@ export class Metadata extends DBC.DBObject<MetadataBase> implements MetadataBase
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Metadata.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -64,8 +63,7 @@ export class Metadata extends DBC.DBObject<MetadataBase> implements MetadataBase
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Metadata.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/Model.ts
+++ b/server/db/api/Model.ts
@@ -91,8 +91,7 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Model.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -119,8 +118,7 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Model.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/ModelMaterial.ts
+++ b/server/db/api/ModelMaterial.ts
@@ -25,8 +25,7 @@ export class ModelMaterial extends DBC.DBObject<ModelMaterialBase> implements Mo
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelMaterial.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -41,8 +40,7 @@ export class ModelMaterial extends DBC.DBObject<ModelMaterialBase> implements Mo
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelMaterial.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/ModelMaterialChannel.ts
+++ b/server/db/api/ModelMaterialChannel.ts
@@ -71,8 +71,7 @@ export class ModelMaterialChannel extends DBC.DBObject<ModelMaterialChannelBase>
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelMaterialChannel.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -99,8 +98,7 @@ export class ModelMaterialChannel extends DBC.DBObject<ModelMaterialChannelBase>
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelMaterialChannel.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/ModelMaterialUVMap.ts
+++ b/server/db/api/ModelMaterialUVMap.ts
@@ -30,8 +30,7 @@ export class ModelMaterialUVMap extends DBC.DBObject<ModelMaterialUVMapBase> imp
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelMaterialUVMap.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -48,8 +47,7 @@ export class ModelMaterialUVMap extends DBC.DBObject<ModelMaterialUVMapBase> imp
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelMaterialUVMap.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/ModelObject.ts
+++ b/server/db/api/ModelObject.ts
@@ -59,8 +59,7 @@ export class ModelObject extends DBC.DBObject<ModelObjectBase> implements ModelO
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelObject.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -82,8 +81,7 @@ export class ModelObject extends DBC.DBObject<ModelObjectBase> implements ModelO
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelObject.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/ModelObjectModelMaterialXref.ts
+++ b/server/db/api/ModelObjectModelMaterialXref.ts
@@ -28,8 +28,7 @@ export class ModelObjectModelMaterialXref extends DBC.DBObject<ModelObjectModelM
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelObjectModelMaterialXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -45,8 +44,7 @@ export class ModelObjectModelMaterialXref extends DBC.DBObject<ModelObjectModelM
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelObjectModelMaterialXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/ModelProcessingAction.ts
+++ b/server/db/api/ModelProcessingAction.ts
@@ -34,8 +34,7 @@ export class ModelProcessingAction extends DBC.DBObject<ModelProcessingActionBas
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelProcessingAction.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -53,8 +52,7 @@ export class ModelProcessingAction extends DBC.DBObject<ModelProcessingActionBas
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelProcessingAction.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/ModelProcessingActionStep.ts
+++ b/server/db/api/ModelProcessingActionStep.ts
@@ -30,8 +30,7 @@ export class ModelProcessingActionStep extends DBC.DBObject<ModelProcessingActio
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelProcessingActionStep.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -47,8 +46,7 @@ export class ModelProcessingActionStep extends DBC.DBObject<ModelProcessingActio
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelProcessingActionStep.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/ModelSceneXref.ts
+++ b/server/db/api/ModelSceneXref.ts
@@ -112,8 +112,7 @@ export class ModelSceneXref extends DBC.DBObject<ModelSceneXrefBase> implements 
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelSceneXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -133,8 +132,7 @@ export class ModelSceneXref extends DBC.DBObject<ModelSceneXrefBase> implements 
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ModelSceneXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/Project.ts
+++ b/server/db/api/Project.ts
@@ -29,8 +29,7 @@ export class Project extends DBC.DBObject<ProjectBase> implements ProjectBase, S
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Project.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -42,8 +41,7 @@ export class Project extends DBC.DBObject<ProjectBase> implements ProjectBase, S
                 data: { Name, Description, },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Project.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/ProjectDocumentation.ts
+++ b/server/db/api/ProjectDocumentation.ts
@@ -32,8 +32,7 @@ export class ProjectDocumentation extends DBC.DBObject<ProjectDocumentationBase>
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ProjectDocumentation.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -49,8 +48,7 @@ export class ProjectDocumentation extends DBC.DBObject<ProjectDocumentationBase>
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.ProjectDocumentation.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -60,8 +60,7 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
                 this.audit(eEventKey.eSceneQCd); // don't await, allow this to continue asynchronously
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Scene.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -86,8 +85,7 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
                 this.audit(eEventKey.eSceneQCd); // don't await, allow this to continue asynchronously
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Scene.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Sentinel.ts
+++ b/server/db/api/Sentinel.ts
@@ -29,8 +29,7 @@ export class Sentinel extends DBC.DBObject<SentinelBase> implements SentinelBase
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Sentinel.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -46,8 +45,7 @@ export class Sentinel extends DBC.DBObject<SentinelBase> implements SentinelBase
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Sentinel.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Stakeholder.ts
+++ b/server/db/api/Stakeholder.ts
@@ -39,8 +39,7 @@ export class Stakeholder extends DBC.DBObject<StakeholderBase> implements Stakeh
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Stakeholder.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -59,8 +58,7 @@ export class Stakeholder extends DBC.DBObject<StakeholderBase> implements Stakeh
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Stakeholder.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Subject.ts
+++ b/server/db/api/Subject.ts
@@ -36,8 +36,7 @@ export class Subject extends DBC.DBObject<SubjectBase> implements SubjectBase, S
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Subject.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -56,8 +55,7 @@ export class Subject extends DBC.DBObject<SubjectBase> implements SubjectBase, S
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Subject.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/SystemObjectPairs.ts
+++ b/server/db/api/SystemObjectPairs.ts
@@ -415,7 +415,7 @@ export class SystemObjectPairs extends SystemObject implements SystemObjectPairs
                 });
             return (SOAPB ? new SystemObjectPairs(SOAPB) : null);
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectAndPairs.fetch', LOG.LS.eDB, error);
+            LOG.error(`DBAPI.SystemObjectAndPairs.fetch(${idSystemObject})`, LOG.LS.eDB, error);
             return null;
         }
     }

--- a/server/db/api/SystemObjectVersion.ts
+++ b/server/db/api/SystemObjectVersion.ts
@@ -57,8 +57,7 @@ export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> i
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectVersion.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -75,8 +74,7 @@ export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> i
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectVersion.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/SystemObjectVersionAssetVersionXref.ts
+++ b/server/db/api/SystemObjectVersionAssetVersionXref.ts
@@ -28,8 +28,7 @@ export class SystemObjectVersionAssetVersionXref extends DBC.DBObject<SystemObje
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectVersionAssetVersionXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -44,8 +43,7 @@ export class SystemObjectVersionAssetVersionXref extends DBC.DBObject<SystemObje
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectVersionAssetVersionXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/SystemObjectXref.ts
+++ b/server/db/api/SystemObjectXref.ts
@@ -30,8 +30,7 @@ export class SystemObjectXref extends DBC.DBObject<SystemObjectXrefBase> impleme
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -46,8 +45,7 @@ export class SystemObjectXref extends DBC.DBObject<SystemObjectXrefBase> impleme
                 }
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.SystemObjectXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
     /** Don't call this directly; instead, let DBObject.delete() call this. Code needing to delete a record should call this.delete(); */

--- a/server/db/api/Unit.ts
+++ b/server/db/api/Unit.ts
@@ -31,8 +31,7 @@ export class Unit extends DBC.DBObject<UnitBase> implements UnitBase, SystemObje
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Unit.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -48,8 +47,7 @@ export class Unit extends DBC.DBObject<UnitBase> implements UnitBase, SystemObje
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Unit.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/UnitEdan.ts
+++ b/server/db/api/UnitEdan.ts
@@ -29,8 +29,7 @@ export class UnitEdan extends DBC.DBObject<UnitEdanBase> implements UnitEdanBase
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.UnitEdan.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -46,8 +45,7 @@ export class UnitEdan extends DBC.DBObject<UnitEdanBase> implements UnitEdanBase
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.UnitEdan.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/User.ts
+++ b/server/db/api/User.ts
@@ -74,8 +74,7 @@ export class User extends DBC.DBObject<UserBase> implements UserBase {
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.User.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -108,8 +107,7 @@ export class User extends DBC.DBObject<UserBase> implements UserBase {
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.User.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/UserPersonalizationSystemObject.ts
+++ b/server/db/api/UserPersonalizationSystemObject.ts
@@ -30,8 +30,7 @@ export class UserPersonalizationSystemObject extends DBC.DBObject<UserPersonaliz
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.UserPersonalizationSystemObject.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -47,8 +46,7 @@ export class UserPersonalizationSystemObject extends DBC.DBObject<UserPersonaliz
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.UserPersonalizationSystemObject.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/UserPersonalizationUrl.ts
+++ b/server/db/api/UserPersonalizationUrl.ts
@@ -30,8 +30,7 @@ export class UserPersonalizationUrl extends DBC.DBObject<UserPersonalizationUrlB
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.UserPersonalizationUrl.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -47,8 +46,7 @@ export class UserPersonalizationUrl extends DBC.DBObject<UserPersonalizationUrlB
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.UserPersonalizationUrl.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Vocabulary.ts
+++ b/server/db/api/Vocabulary.ts
@@ -29,8 +29,7 @@ export class Vocabulary extends DBC.DBObject<VocabularyBase> implements Vocabula
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Vocabulary.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -46,8 +45,7 @@ export class Vocabulary extends DBC.DBObject<VocabularyBase> implements Vocabula
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Vocabulary.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/VocabularySet.ts
+++ b/server/db/api/VocabularySet.ts
@@ -27,8 +27,7 @@ export class VocabularySet extends DBC.DBObject<VocabularySetBase> implements Vo
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.VocabularySet.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -43,8 +42,7 @@ export class VocabularySet extends DBC.DBObject<VocabularySetBase> implements Vo
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.VocabularySet.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/Workflow.ts
+++ b/server/db/api/Workflow.ts
@@ -79,8 +79,7 @@ export class Workflow extends DBC.DBObject<WorkflowBase> implements WorkflowBase
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Workflow.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -102,8 +101,7 @@ export class Workflow extends DBC.DBObject<WorkflowBase> implements WorkflowBase
             }) ? true : /* istanbul ignore next */ false;
             return retValue;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.Workflow.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/WorkflowReport.ts
+++ b/server/db/api/WorkflowReport.ts
@@ -30,8 +30,7 @@ export class WorkflowReport extends DBC.DBObject<WorkflowReportBase> implements 
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowReport.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -47,8 +46,7 @@ export class WorkflowReport extends DBC.DBObject<WorkflowReportBase> implements 
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowReport.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/WorkflowSet.ts
+++ b/server/db/api/WorkflowSet.ts
@@ -18,8 +18,7 @@ export class WorkflowSet extends DBC.DBObject<WorkflowSetBase> implements Workfl
             ({ idWorkflowSet: this.idWorkflowSet } = await DBC.DBConnection.prisma.workflowSet.create({ data: { } }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowSet.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -31,8 +30,7 @@ export class WorkflowSet extends DBC.DBObject<WorkflowSetBase> implements Workfl
                 data: { },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowSet.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/WorkflowStep.ts
+++ b/server/db/api/WorkflowStep.ts
@@ -41,8 +41,7 @@ export class WorkflowStep extends DBC.DBObject<WorkflowStepBase> implements Work
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowStep.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -63,8 +62,7 @@ export class WorkflowStep extends DBC.DBObject<WorkflowStepBase> implements Work
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowStep.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/api/WorkflowStepSystemObjectXref.ts
+++ b/server/db/api/WorkflowStepSystemObjectXref.ts
@@ -30,8 +30,7 @@ export class WorkflowStepSystemObjectXref extends DBC.DBObject<WorkflowStepSyste
                 }));
             return true;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowStepSystemObjectXref.create', LOG.LS.eDB, error);
-            return false;
+            return this.logError('create', error);
         }
     }
 
@@ -47,8 +46,7 @@ export class WorkflowStepSystemObjectXref extends DBC.DBObject<WorkflowStepSyste
                 },
             }) ? true : /* istanbul ignore next */ false;
         } catch (error) /* istanbul ignore next */ {
-            LOG.error('DBAPI.WorkflowStepSystemObjectXref.update', LOG.LS.eDB, error);
-            return false;
+            return this.logError('update', error);
         }
     }
 

--- a/server/db/connection/DBObject.ts
+++ b/server/db/connection/DBObject.ts
@@ -1,6 +1,8 @@
 import { eDBObjectType, eNonSystemObjectType, ObjectIDAndType, DBObjectNameToType } from '../api/ObjectType';
 import { AuditFactory } from '../../audit/interface/AuditFactory';
 import { eEventKey } from '../../event/interface/EventEnums';
+import * as LOG from '../../utils/logger';
+import * as H from '../../utils/helpers';
 
 export abstract class DBObject<T> {
     public abstract fetchTableName(): string;
@@ -60,6 +62,11 @@ export abstract class DBObject<T> {
                 dataItem.audit(eEventKey.eDBDelete); // don't await, allow this to continue asynchronously
         }
         return retVal;
+    }
+
+    protected logError(method: string, error?: any): boolean { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+        LOG.error(`DBAPI.${this.fetchTableName()}.${method} ${H.Helpers.JSONStringify(this)}`, LOG.LS.eDB, error);
+        return false;
     }
 }
 

--- a/server/db/prisma/schema.prisma
+++ b/server/db/prisma/schema.prisma
@@ -1,8 +1,7 @@
 generator client {
-  provider        = "prisma-client-js"
-  output          = "../../../node_modules/.prisma/client"
-  previewFeatures = ["interactiveTransactions"]
-  binaryTargets   = ["native", "linux-musl"]
+  provider      = "prisma-client-js"
+  output        = "../../../node_modules/.prisma/client"
+  binaryTargets = ["native", "linux-musl"]
 }
 
 datasource mariasql {
@@ -458,9 +457,9 @@ model ModelMaterialUVMap {
   idModel              Int
   idAsset              Int
   UVMapEdgeLength      Int
+  ModelMaterialChannel ModelMaterialChannel[]
   Asset                Asset                  @relation(fields: [idAsset], references: [idAsset], onDelete: NoAction, onUpdate: NoAction, map: "fk_modelmaterialuvmap_asset1")
   Model                Model                  @relation(fields: [idModel], references: [idModel], onDelete: NoAction, onUpdate: NoAction, map: "fk_modelmaterialuvmap_model1")
-  ModelMaterialChannel ModelMaterialChannel[]
 
   @@index([idAsset], map: "ModelUVMapFile_idAsset")
   @@index([idModel], map: "ModelUVMapFile_idModel")
@@ -602,8 +601,8 @@ model Scene {
   PosedAndQCd            Boolean
   ApprovedForPublication Boolean
   Title                  String?          @mariasql.VarChar(255)
-  Asset                  Asset?           @relation(fields: [idAssetThumbnail], references: [idAsset], onDelete: NoAction, onUpdate: NoAction, map: "fk_scene_asset1")
   ModelSceneXref         ModelSceneXref[]
+  Asset                  Asset?           @relation(fields: [idAssetThumbnail], references: [idAsset], onDelete: NoAction, onUpdate: NoAction, map: "fk_scene_asset1")
   SystemObject           SystemObject?
 
   @@index([idAssetThumbnail], map: "fk_scene_asset1")
@@ -666,6 +665,14 @@ model SystemObject {
   idActor                                                               Int?                              @unique(map: "idActor")
   idStakeholder                                                         Int?                              @unique(map: "idStakeholder")
   Retired                                                               Boolean
+  AccessContextObject                                                   AccessContextObject[]
+  Asset_Asset_idSystemObjectToSystemObject                              Asset[]                           @relation("Asset_idSystemObjectToSystemObject")
+  AssetVersion_AssetVersion_idSOAttachmentToSystemObject                AssetVersion[]                    @relation("AssetVersion_idSOAttachmentToSystemObject")
+  Audit                                                                 Audit[]
+  Identifier                                                            Identifier[]
+  LicenseAssignment                                                     LicenseAssignment[]
+  Metadata_Metadata_idSystemObjectToSystemObject                        Metadata[]                        @relation("Metadata_idSystemObjectToSystemObject")
+  Metadata_Metadata_idSystemObjectParentToSystemObject                  Metadata[]                        @relation("Metadata_idSystemObjectParentToSystemObject")
   Actor                                                                 Actor?                            @relation(fields: [idActor], references: [idActor], onDelete: NoAction, onUpdate: NoAction, map: "fk_systemobject_actor1")
   Asset_AssetToSystemObject_idAsset                                     Asset?                            @relation("AssetToSystemObject_idAsset", fields: [idAsset], references: [idAsset], onDelete: NoAction, onUpdate: NoAction, map: "fk_systemobject_asset1")
   AssetVersion_AssetVersionToSystemObject_idAssetVersion                AssetVersion?                     @relation("AssetVersionToSystemObject_idAssetVersion", fields: [idAssetVersion], references: [idAssetVersion], onDelete: NoAction, onUpdate: NoAction, map: "fk_systemobject_assetversion1")
@@ -679,14 +686,6 @@ model SystemObject {
   Stakeholder                                                           Stakeholder?                      @relation(fields: [idStakeholder], references: [idStakeholder], onDelete: NoAction, onUpdate: NoAction, map: "fk_systemobject_stakeholder1")
   Subject                                                               Subject?                          @relation(fields: [idSubject], references: [idSubject], onDelete: NoAction, onUpdate: NoAction, map: "fk_systemobject_subject1")
   Unit                                                                  Unit?                             @relation(fields: [idUnit], references: [idUnit], onDelete: NoAction, onUpdate: NoAction, map: "fk_systemobject_unit1")
-  AccessContextObject                                                   AccessContextObject[]
-  Asset_Asset_idSystemObjectToSystemObject                              Asset[]                           @relation("Asset_idSystemObjectToSystemObject")
-  AssetVersion_AssetVersion_idSOAttachmentToSystemObject                AssetVersion[]                    @relation("AssetVersion_idSOAttachmentToSystemObject")
-  Audit                                                                 Audit[]
-  Identifier                                                            Identifier[]
-  LicenseAssignment                                                     LicenseAssignment[]
-  Metadata_Metadata_idSystemObjectToSystemObject                        Metadata[]                        @relation("Metadata_idSystemObjectToSystemObject")
-  Metadata_Metadata_idSystemObjectParentToSystemObject                  Metadata[]                        @relation("Metadata_idSystemObjectParentToSystemObject")
   SystemObjectVersion                                                   SystemObjectVersion[]
   SystemObjectXref_SystemObjectToSystemObjectXref_idSystemObjectMaster  SystemObjectXref[]                @relation("SystemObjectToSystemObjectXref_idSystemObjectMaster")
   SystemObjectXref_SystemObjectToSystemObjectXref_idSystemObjectDerived SystemObjectXref[]                @relation("SystemObjectToSystemObjectXref_idSystemObjectDerived")
@@ -816,7 +815,6 @@ model Vocabulary {
   idVocabularySet                                                          Int
   SortOrder                                                                Int
   Term                                                                     String                      @mariasql.VarChar(255)
-  VocabularySet                                                            VocabularySet               @relation(fields: [idVocabularySet], references: [idVocabularySet], onDelete: NoAction, onUpdate: NoAction, map: "fk_vocabulary_vocabularyset1")
   Asset                                                                    Asset[]
   CaptureData                                                              CaptureData[]
   CaptureDataFile                                                          CaptureDataFile[]
@@ -836,6 +834,7 @@ model Vocabulary {
   Model_Model_idVFileTypeToVocabulary                                      Model[]                     @relation("Model_idVFileTypeToVocabulary")
   ModelMaterialChannel                                                     ModelMaterialChannel[]
   ModelProcessingActionStep                                                ModelProcessingActionStep[]
+  VocabularySet                                                            VocabularySet               @relation(fields: [idVocabularySet], references: [idVocabularySet], onDelete: NoAction, onUpdate: NoAction, map: "fk_vocabulary_vocabularyset1")
   Workflow                                                                 Workflow[]
   WorkflowStep                                                             WorkflowStep[]
 

--- a/server/package.json
+++ b/server/package.json
@@ -106,7 +106,7 @@
     "@graphql-codegen/typescript": "2.7.3",
     "@graphql-codegen/typescript-operations": "2.5.3",
     "@graphql-codegen/typescript-react-apollo": "3.3.3",
-    "@prisma/client": "4.6.1",
+    "@prisma/client": "4.9.0",
     "@types/express": "4.17.14",
     "@types/express-serve-static-core": "4.17.18",
     "@types/fs-extra": "9.0.13",
@@ -125,7 +125,7 @@
     "@types/three": "0.144.0",
     "cross-env": "7.0.3",
     "jest": "26.6.3",
-    "prisma": "4.6.1",
+    "prisma": "4.9.0",
     "ts-jest": "26.5.4"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,22 +3604,22 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@prisma/client@4.6.1":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.6.1.tgz#e8e1d347ecbff44158d21b6591bb99650c8503a8"
-  integrity sha512-M1+NNrMzqaOIxT7PBGcTs3IZo7d1EW/+gVQd4C4gUgWBDGgD9AcIeZnUSidgWClmpMSgVUdnVORjsWWGUameYA==
+"@prisma/client@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.9.0.tgz#4a4068f3540732ea5723c008d49ed684d20f9340"
+  integrity sha512-bz6QARw54sWcbyR1lLnF2QHvRW5R/Jxnbbmwh3u+969vUKXtBkXgSgjDA85nji31ZBlf7+FrHDy5x+5ydGyQDg==
   dependencies:
-    "@prisma/engines-version" "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32"
+    "@prisma/engines-version" "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5"
 
-"@prisma/engines-version@4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32":
-  version "4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.6.1-3.694eea289a8462c80264df36757e4fdc129b1b32.tgz#90a71bbdfd5172fc674009346a6ad6b84410cc0a"
-  integrity sha512-HUCmkXAU2jqp2O1RvNtbE+seLGLyJGEABZS/R38rZjSAafAy0WzBuHq+tbZMnD+b5OSCsTVtIPVcuvx1ySxcWQ==
+"@prisma/engines-version@4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5":
+  version "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5.tgz#9d817a5779fc05b107eb02f63d197ad296d60b3c"
+  integrity sha512-M16aibbxi/FhW7z1sJCX8u+0DriyQYY5AyeTH7plQm9MLnURoiyn3CZBqAyIoQ+Z1pS77usCIibYJWSgleBMBA==
 
-"@prisma/engines@4.6.1":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.6.1.tgz#ae31309cc0f600f2da22708697b3be4eb1e46f9e"
-  integrity sha512-3u2/XxvxB+Q7cMXHnKU0CpBiUK1QWqpgiBv28YDo1zOIJE3FCF8DI2vrp6vuwjGt5h0JGXDSvmSf4D4maVjJdw==
+"@prisma/engines@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.9.0.tgz#05a1411964e047c1bc43f777c7a1c69f86a2a26c"
+  integrity sha512-t1pt0Gsp+HcgPJrHFc+d/ZSAaKKWar2G/iakrE07yeKPNavDP3iVKPpfXP22OTCHZUWf7OelwKJxQgKAm5hkgw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -16185,12 +16185,12 @@ pretty-format@^29.0.0, pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prisma@4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.6.1.tgz#6c85fb667abed006a6b849c9c1ddd81d3f071b87"
-  integrity sha512-BR4itMCuzrDV4tn3e2TF+nh1zIX/RVU0isKtKoN28ADeoJ9nYaMhiuRRkFd2TZN8+l/XfYzoRKyHzUFXLQhmBQ==
+prisma@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.9.0.tgz#295954b2a89cd35a0e6bcf66b2b036dbf80c75ee"
+  integrity sha512-bS96oZ5oDFXYgoF2l7PJ3Mp1wWWfLOo8B/jAfbA2Pn0Wm5Z/owBHzaMQKS3i1CzVBDWWPVnOohmbJmjvkcHS5w==
   dependencies:
-    "@prisma/engines" "4.6.1"
+    "@prisma/engines" "4.9.0"
 
 proc-log@^2.0.0, proc-log@^2.0.1:
   version "2.0.1"
@@ -16693,7 +16693,7 @@ react-dropzone@14.2.2:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
-react-error-overlay@^6.0.7:
+react-error-overlay@6.0.9, react-error-overlay@^6.0.7:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==


### PR DESCRIPTION
Build:
* Updated prisma to v4.9.0, in an attempt to work around issues perhaps related to the preview feature "interactiveTransactions", which is now officially released by Prisma.  We've been seeing DB operations fail (in staging logs) when a sequence of DB operations are performed, such that one depends on the previous ... and in some cases, it's as if the previous operation didn't succeed (even though it did).

DBAPI:
* Regenerated Prisma Schema
* Add logging of prisma client errors
* Add logging of ${this} in exception handling for create and update methods
* Added logging of arguments for a handful of DBAPI methods that seem to be failing.
