### PR TITLE
Test fixes: use Prisma v4.8.1 to avoid handle leak; avoid sending console to logger after log.end() is called

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -106,7 +106,7 @@
     "@graphql-codegen/typescript": "2.7.3",
     "@graphql-codegen/typescript-operations": "2.5.3",
     "@graphql-codegen/typescript-react-apollo": "3.3.3",
-    "@prisma/client": "4.9.0",
+    "@prisma/client": "4.8.1",
     "@types/express": "4.17.14",
     "@types/express-serve-static-core": "4.17.18",
     "@types/fs-extra": "9.0.13",
@@ -125,7 +125,7 @@
     "@types/three": "0.144.0",
     "cross-env": "7.0.3",
     "jest": "26.6.3",
-    "prisma": "4.9.0",
+    "prisma": "4.8.1",
     "ts-jest": "26.5.4"
   },
   "optionalDependencies": {

--- a/server/tests/teardown.ts
+++ b/server/tests/teardown.ts
@@ -1,9 +1,11 @@
 import * as LOG from '../utils/logger';
 import * as H from '../utils/helpers';
+import * as DBC from '../db/connection';
 
 export async function teardown(): Promise<void> {
+    await DBC.DBConnection.disconnect();
     LOG.end();
-    await H.Helpers.sleep(2000);
+    await H.Helpers.sleep(1000);
 }
 
 module.exports = teardown;

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -8,6 +8,7 @@ import { Config } from '../config';
 import { ASL, LocalStore } from './localStore';
 
 let logger: winston.Logger;
+let ending: boolean = false;
 export enum LS { // logger section
     eAUDIT, // audit
     eAUTH,  // authentication
@@ -44,6 +45,7 @@ export function error(message: string | undefined, eLogSection: LS, obj: any | n
 }
 
 export function end(): void {
+    ending = true;
     logger.end();
 }
 
@@ -141,27 +143,32 @@ function configureLogger(logPath: string | null): void {
     const _error = console.error;
 
     console.debug = function(...args) {
-        info(`console.debug: ${JSON.stringify(args)}`, LS.eCON);
+        if (!ending)
+            info(`console.debug: ${JSON.stringify(args)}`, LS.eCON);
         return _debug.apply(console, args);
     };
 
     console.info = function(...args) {
-        info(`console.info: ${JSON.stringify(args)}`, LS.eCON);
+        if (!ending)
+            info(`console.info: ${JSON.stringify(args)}`, LS.eCON);
         return _info.apply(console, args);
     };
 
     console.log = function(...args) {
-        info(`console.log: ${JSON.stringify(args)}`, LS.eCON);
+        if (!ending)
+            info(`console.log: ${JSON.stringify(args)}`, LS.eCON);
         return _log.apply(console, args);
     };
 
     console.warn = function(...args) {
-        info(`console.warn: ${JSON.stringify(args)}`, LS.eCON);
+        if (!ending)
+            info(`console.warn: ${JSON.stringify(args)}`, LS.eCON);
         return _warn.apply(console, args);
     };
 
     console.error = function(...args) {
-        error(`console.error: ${JSON.stringify(args)}`, LS.eCON);
+        if (!ending)
+            error(`console.error: ${JSON.stringify(args)}`, LS.eCON);
         return _error.apply(console, args);
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,22 +3604,22 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@prisma/client@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.9.0.tgz#4a4068f3540732ea5723c008d49ed684d20f9340"
-  integrity sha512-bz6QARw54sWcbyR1lLnF2QHvRW5R/Jxnbbmwh3u+969vUKXtBkXgSgjDA85nji31ZBlf7+FrHDy5x+5ydGyQDg==
+"@prisma/client@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.8.1.tgz#51c16488dfac4e74a275a2753bf20262a65f2a2b"
+  integrity sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==
   dependencies:
-    "@prisma/engines-version" "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5"
+    "@prisma/engines-version" "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
 
-"@prisma/engines-version@4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5":
-  version "4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5.tgz#9d817a5779fc05b107eb02f63d197ad296d60b3c"
-  integrity sha512-M16aibbxi/FhW7z1sJCX8u+0DriyQYY5AyeTH7plQm9MLnURoiyn3CZBqAyIoQ+Z1pS77usCIibYJWSgleBMBA==
+"@prisma/engines-version@4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe":
+  version "4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe.tgz#30401aba1029e7d32e3cb717e705a7c92ccc211e"
+  integrity sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw==
 
-"@prisma/engines@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.9.0.tgz#05a1411964e047c1bc43f777c7a1c69f86a2a26c"
-  integrity sha512-t1pt0Gsp+HcgPJrHFc+d/ZSAaKKWar2G/iakrE07yeKPNavDP3iVKPpfXP22OTCHZUWf7OelwKJxQgKAm5hkgw==
+"@prisma/engines@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.8.1.tgz#8428f7dcd7912c6073024511376595017630dc85"
+  integrity sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -16185,12 +16185,12 @@ pretty-format@^29.0.0, pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prisma@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.9.0.tgz#295954b2a89cd35a0e6bcf66b2b036dbf80c75ee"
-  integrity sha512-bS96oZ5oDFXYgoF2l7PJ3Mp1wWWfLOo8B/jAfbA2Pn0Wm5Z/owBHzaMQKS3i1CzVBDWWPVnOohmbJmjvkcHS5w==
+prisma@4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.8.1.tgz#ef93cd908809b7d02e9f4bead5eea7733ba50c68"
+  integrity sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==
   dependencies:
-    "@prisma/engines" "4.9.0"
+    "@prisma/engines" "4.8.1"
 
 proc-log@^2.0.0, proc-log@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Build:
* Roll back to Prisma v4.8.1 to avoid leading handle at test exit

Test:
* Disconnect DB at test exit

Logger:
* Avoid sending console use to logger once we have ended the log