### PR TITLE
Migration: compute asset map needed by WorkflowUtil.computeModelMetrics, etc.

### DIFF
--- a/server/db/connection/DBConnection.ts
+++ b/server/db/connection/DBConnection.ts
@@ -32,7 +32,7 @@ export class DBConnection {
                 ],
             });
 
-            prisma.$on('error', (e) => { LOG.error(`PrismaClient error ${e.message} target ${e.target}`, LOG.LS.eDB); });
+            prisma.$on('error', (e) => { LOG.error(`PrismaClient error ${e.target}`, LOG.LS.eDB); });
             // prisma.$on('query', (e) => { LOG.info(e.query, LOG.LS.eDB); });
 
             this._prisma = prisma;

--- a/server/db/connection/DBObject.ts
+++ b/server/db/connection/DBObject.ts
@@ -65,7 +65,8 @@ export abstract class DBObject<T> {
     }
 
     protected logError(method: string, error?: any): boolean { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        LOG.error(`DBAPI.${this.fetchTableName()}.${method} ${H.Helpers.JSONStringify(this)}`, LOG.LS.eDB, error);
+        const errorMessage: string = (H.Helpers.safeString(error?.message) ?? '').replace(/(\n|\r)/g, ' ');
+        LOG.error(`DBAPI.${this.fetchTableName()}.${method} ${H.Helpers.JSONStringify(this)}: ${errorMessage}`, LOG.LS.eDB);
         return false;
     }
 }

--- a/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
+++ b/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
@@ -517,6 +517,7 @@ class IngestDataWorker extends ResolverBase {
                         }
                     }
                 }
+                break; // exit retry loop
             }
         }
 

--- a/server/workflow/impl/Packrat/WorkflowUtil.ts
+++ b/server/workflow/impl/Packrat/WorkflowUtil.ts
@@ -47,7 +47,10 @@ export class WorkflowUtil {
         idSystemObjectModel: number | undefined,
         idSystemObjectAssetVersion: number | undefined,
         idSystemObjectSupportFileAssetVersion: number | undefined,
-        readStream: NodeJS.ReadableStream | undefined, idProject: number | undefined, idUserInitiator: number | undefined): Promise<H.IOResults> {
+        readStream: NodeJS.ReadableStream | undefined,
+        idProject: number | undefined,
+        idUserInitiator: number | undefined,
+        assetMap?: Map<string, number> | undefined): Promise<H.IOResults> { // map of asset filename -> idAsset, needed by WorkflowUtil.computeModelMetrics to persist ModelMaterialUVMap and ModelMaterialChannel
         LOG.info(`WorkflowUtil.computeModelMetrics (${fileName}, idModel ${idModel}, idSystemObjectModel ${idSystemObjectModel}, idSystemObjectAssetVersion ${idSystemObjectAssetVersion})`, LOG.LS.eWF);
 
         switch (path.extname(fileName).toLowerCase()) {
@@ -129,7 +132,7 @@ export class WorkflowUtil {
                 const JCOutput: JobCookSIPackratInspectOutput | null = await JobCookSIPackratInspectOutput.extractFromAssetVersion(idAssetVersion);
                 if (JCOutput) {
                     LOG.info(`WorkflowUtil.computeModelMetrics ${fileName} persisting metrics for model ${idModel}`, LOG.LS.eWF);
-                    const results: H.IOResults = await JCOutput.persist(idModel);
+                    const results: H.IOResults = await JCOutput.persist(idModel, assetMap);
                     if (!results.success)
                         return { success: false, error: `WorkflowUtil.computeModelMetrics ${fileName} post-upload workflow error: ${results.error}` };
                 }


### PR DESCRIPTION
Migration:
* Compute asset map (filename -> idAsset); pass this to WorkflowUtil.computeModelMetrics
* Don't set model title
* If no master model is supplied to scene migration, look for one among the scene children of the item parent

Workflow:
* Allow for optional assetMap to be passed into computeModelMetrics, which in turn gets passed to JobCookSIPackratInspectOutput.persist, for proper construction of ModelMaterialUVMaps and ModelMaterialChannels

DBAPI:
* Simplify DB error logging to make things easier to read

GraphQL:
* Only query EDAN once when computing identifiers for ingested subjects