### PR TITLE
Add Model Viewer (Voyager) to model details page; address migration error handling of dracoCompressed

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -584,7 +584,7 @@ function DetailsView(): React.ReactElement {
                         Update
                     </LoadingButton>
                     {(updatedIdentifiers || updatedMetadata) && <div style={{ fontStyle: 'italic', marginLeft: '5px' }}>Update needed to save your data</div>}
-                    {objectType === eSystemObjectType.eScene && <LoadingButton className={classes.updateButton} loading={false} onClick={() => document.getElementById('Voyager-Explorer')?.scrollIntoView()} style={{ marginLeft: 5 }}>View</LoadingButton>}
+                    {(objectType === eSystemObjectType.eScene || objectType === eSystemObjectType.eModel) && <LoadingButton className={classes.updateButton} loading={false} onClick={() => document.getElementById('Voyager-Explorer')?.scrollIntoView()} style={{ marginLeft: 5 }}>View</LoadingButton>}
                 </Box>
 
                 <Box display='flex'>

--- a/client/src/pages/Repository/hooks/useDetailsView.ts
+++ b/client/src/pages/Repository/hooks/useDetailsView.ts
@@ -4,6 +4,7 @@ import { useQuery, FetchResult } from '@apollo/client';
 import { apolloClient } from '../../../graphql';
 import {
     GetAssetDetailsForSystemObjectDocument,
+    GetVoyagerParamsDocument,
     GetAssetDetailsForSystemObjectQueryResult,
     GetSystemObjectDetailsDocument,
     GetSystemObjectDetailsQueryResult,
@@ -59,6 +60,18 @@ export function useObjectAssets(idSystemObject: number): GetAssetDetailsForSyste
 export async function getObjectAssets(idSystemObject: number) {
     return await apolloClient.query({
         query: GetAssetDetailsForSystemObjectDocument,
+        variables: {
+            input: {
+                idSystemObject
+            }
+        },
+        fetchPolicy: 'no-cache'
+    });
+}
+
+export async function getVoyagerParams(idSystemObject: number) {
+    return await apolloClient.query({
+        query: GetVoyagerParamsDocument,
         variables: {
             input: {
                 idSystemObject

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -988,6 +988,17 @@ export type GetVocabularyResult = {
   Vocabulary?: Maybe<Vocabulary>;
 };
 
+export type GetVoyagerParamsInput = {
+  idSystemObject: Scalars['Int'];
+};
+
+export type GetVoyagerParamsResult = {
+  __typename?: 'GetVoyagerParamsResult';
+  document?: Maybe<Scalars['String']>;
+  idSystemObjectScene?: Maybe<Scalars['Int']>;
+  path?: Maybe<Scalars['String']>;
+};
+
 export type GetWorkflowInput = {
   idWorkflow: Scalars['Int'];
 };
@@ -1844,6 +1855,7 @@ export type Query = {
   getVersionsForAsset: GetVersionsForAssetResult;
   getVocabulary: GetVocabularyResult;
   getVocabularyEntries: GetVocabularyEntriesResult;
+  getVoyagerParams: GetVoyagerParamsResult;
   getWorkflow: GetWorkflowResult;
   getWorkflowList: GetWorkflowListResult;
   searchIngestionSubjects: SearchIngestionSubjectsResult;
@@ -2042,6 +2054,11 @@ export type QueryGetVocabularyArgs = {
 
 export type QueryGetVocabularyEntriesArgs = {
   input: GetVocabularyEntriesInput;
+};
+
+
+export type QueryGetVoyagerParamsArgs = {
+  input: GetVoyagerParamsInput;
 };
 
 
@@ -3061,6 +3078,13 @@ export type GetVersionsForAssetQueryVariables = Exact<{
 
 
 export type GetVersionsForAssetQuery = { __typename?: 'Query', getVersionsForAsset: { __typename?: 'GetVersionsForAssetResult', versions: Array<{ __typename?: 'DetailVersion', idSystemObject: number, idAssetVersion: number, version: number, name: string, creator: string, dateCreated: any, size: any, hash: string, ingested: boolean, Comment?: string | null, CommentLink?: string | null }> } };
+
+export type GetVoyagerParamsQueryVariables = Exact<{
+  input: GetVoyagerParamsInput;
+}>;
+
+
+export type GetVoyagerParamsQuery = { __typename?: 'Query', getVoyagerParams: { __typename?: 'GetVoyagerParamsResult', path?: string | null, document?: string | null, idSystemObjectScene?: number | null } };
 
 export type GetEdanUnitsNamedQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -5809,6 +5833,43 @@ export function useGetVersionsForAssetLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type GetVersionsForAssetQueryHookResult = ReturnType<typeof useGetVersionsForAssetQuery>;
 export type GetVersionsForAssetLazyQueryHookResult = ReturnType<typeof useGetVersionsForAssetLazyQuery>;
 export type GetVersionsForAssetQueryResult = Apollo.QueryResult<GetVersionsForAssetQuery, GetVersionsForAssetQueryVariables>;
+export const GetVoyagerParamsDocument = gql`
+    query getVoyagerParams($input: GetVoyagerParamsInput!) {
+  getVoyagerParams(input: $input) {
+    path
+    document
+    idSystemObjectScene
+  }
+}
+    `;
+
+/**
+ * __useGetVoyagerParamsQuery__
+ *
+ * To run a query within a React component, call `useGetVoyagerParamsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetVoyagerParamsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetVoyagerParamsQuery({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useGetVoyagerParamsQuery(baseOptions: Apollo.QueryHookOptions<GetVoyagerParamsQuery, GetVoyagerParamsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetVoyagerParamsQuery, GetVoyagerParamsQueryVariables>(GetVoyagerParamsDocument, options);
+      }
+export function useGetVoyagerParamsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetVoyagerParamsQuery, GetVoyagerParamsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetVoyagerParamsQuery, GetVoyagerParamsQueryVariables>(GetVoyagerParamsDocument, options);
+        }
+export type GetVoyagerParamsQueryHookResult = ReturnType<typeof useGetVoyagerParamsQuery>;
+export type GetVoyagerParamsLazyQueryHookResult = ReturnType<typeof useGetVoyagerParamsLazyQuery>;
+export type GetVoyagerParamsQueryResult = Apollo.QueryResult<GetVoyagerParamsQuery, GetVoyagerParamsQueryVariables>;
 export const GetEdanUnitsNamedDocument = gql`
     query getEdanUnitsNamed {
   getEdanUnitsNamed {

--- a/server/db/api/Model.ts
+++ b/server/db/api/Model.ts
@@ -2,6 +2,7 @@
 import { Model as ModelBase, SystemObject as SystemObjectBase, Prisma } from '@prisma/client';
 import { SystemObject, SystemObjectBased } from '..';
 import * as DBC from '../connection';
+import * as H from '../../utils/helpers';
 import * as LOG from '../../utils/logger';
 
 export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemObjectBased {
@@ -54,7 +55,7 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
         this.CountEmbeddedTextures = model.CountEmbeddedTextures;
         this.CountLinkedTextures = model.CountLinkedTextures;
         this.FileEncoding = model.FileEncoding;
-        this.IsDracoCompressed = model.IsDracoCompressed;
+        this.IsDracoCompressed = H.Helpers.safeBoolean(model.IsDracoCompressed);
         this.AutomationTag = model.AutomationTag;
         this.CountTriangles = model.CountTriangles;
         this.Title = model.Title;
@@ -64,8 +65,8 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
         try {
             const { Name, DateCreated, idVCreationMethod, idVModality, idVUnits, idVPurpose,
                 idVFileType, idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials,
-                CountMeshes, CountVertices, CountEmbeddedTextures, CountLinkedTextures, FileEncoding, IsDracoCompressed, AutomationTag, CountTriangles,
-                Title } = this;
+                CountMeshes, CountVertices, CountEmbeddedTextures, CountLinkedTextures, FileEncoding, IsDracoCompressed,
+                AutomationTag, CountTriangles, Title } = this;
             ({ idModel: this.idModel, Name: this.Name, DateCreated: this.DateCreated, idVCreationMethod: this.idVCreationMethod,
                 idVModality: this.idVModality, idVUnits: this.idVUnits,
                 idVPurpose: this.idVPurpose, idVFileType: this.idVFileType, idAssetThumbnail: this.idAssetThumbnail,
@@ -85,7 +86,9 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
                         Vocabulary_Model_idVFileTypeToVocabulary:       idVFileType ? { connect: { idVocabulary: idVFileType }, } : undefined,
                         Asset:                                          idAssetThumbnail ? { connect: { idAsset: idAssetThumbnail }, } : undefined,
                         CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials, CountMeshes, CountVertices, CountEmbeddedTextures,
-                        CountLinkedTextures, FileEncoding, IsDracoCompressed, AutomationTag, CountTriangles, Title,
+                        CountLinkedTextures, FileEncoding,
+                        IsDracoCompressed: H.Helpers.safeBoolean(IsDracoCompressed),
+                        AutomationTag, CountTriangles, Title,
                         SystemObject:   { create: { Retired: false }, },
                     },
                 }));
@@ -98,9 +101,9 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
     protected async updateWorker(): Promise<boolean> {
         try {
             const { idModel, Name, DateCreated, idVCreationMethod, idVModality, idVUnits, idVPurpose,
-                idVFileType, idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials, CountMeshes,
-                CountVertices, CountEmbeddedTextures, CountLinkedTextures, FileEncoding, IsDracoCompressed, AutomationTag, CountTriangles,
-                Title } = this;
+                idVFileType, idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials,
+                CountMeshes, CountVertices, CountEmbeddedTextures, CountLinkedTextures, FileEncoding, IsDracoCompressed,
+                AutomationTag, CountTriangles, Title } = this;
             const retValue: boolean = await DBC.DBConnection.prisma.model.update({
                 where: { idModel, },
                 data: {
@@ -113,7 +116,9 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
                     Vocabulary_Model_idVFileTypeToVocabulary:       idVFileType ? { connect: { idVocabulary: idVFileType }, } : { disconnect: true, },
                     Asset:                                          idAssetThumbnail ? { connect: { idAsset: idAssetThumbnail }, } : { disconnect: true, },
                     CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials, CountMeshes, CountVertices, CountEmbeddedTextures,
-                    CountLinkedTextures, FileEncoding, IsDracoCompressed, AutomationTag, CountTriangles, Title,
+                    CountLinkedTextures, FileEncoding,
+                    IsDracoCompressed: H.Helpers.safeBoolean(IsDracoCompressed),
+                    AutomationTag, CountTriangles, Title,
                 },
             }) ? true : /* istanbul ignore next */ false;
             return retValue;

--- a/server/db/api/Model.ts
+++ b/server/db/api/Model.ts
@@ -63,8 +63,8 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
 
     protected async createWorker(): Promise<boolean> {
         try {
-            const { Name, DateCreated, idVCreationMethod, idVModality, idVUnits, idVPurpose,
-                idVFileType, idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials,
+            const { Name, DateCreated, idVCreationMethod, idVModality, idVUnits, idVPurpose, idVFileType,
+                idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials,
                 CountMeshes, CountVertices, CountEmbeddedTextures, CountLinkedTextures, FileEncoding, IsDracoCompressed,
                 AutomationTag, CountTriangles, Title } = this;
             ({ idModel: this.idModel, Name: this.Name, DateCreated: this.DateCreated, idVCreationMethod: this.idVCreationMethod,
@@ -100,8 +100,8 @@ export class Model extends DBC.DBObject<ModelBase> implements ModelBase, SystemO
 
     protected async updateWorker(): Promise<boolean> {
         try {
-            const { idModel, Name, DateCreated, idVCreationMethod, idVModality, idVUnits, idVPurpose,
-                idVFileType, idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials,
+            const { idModel, Name, DateCreated, idVCreationMethod, idVModality, idVUnits, idVPurpose, idVFileType,
+                idAssetThumbnail, CountAnimations, CountCameras, CountFaces, CountLights, CountMaterials,
                 CountMeshes, CountVertices, CountEmbeddedTextures, CountLinkedTextures, FileEncoding, IsDracoCompressed,
                 AutomationTag, CountTriangles, Title } = this;
             const retValue: boolean = await DBC.DBConnection.prisma.model.update({

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -170,7 +170,7 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
         }
     }
 
-    /** fetches scenes which are chilren of the specified idModelParent */
+    /** fetches scenes which are children of the specified idModelParent */
     static async fetchChildrenScenes(idModelParent: number): Promise<Scene[] | null> {
         if (!idModelParent)
             return null;
@@ -185,6 +185,25 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
                 WHERE SOM.idModel = ${idModelParent}`, Scene);
         } catch (error) /* istanbul ignore next */ {
             LOG.error('DBAPI.Model.fetchChildrenScenes', LOG.LS.eDB, error);
+            return null;
+        }
+    }
+
+    /** fetches scenes which are parent of the specified idModelParent */
+    static async fetchParentScenes(idModelChild: number): Promise<Scene[] | null> {
+        if (!idModelChild)
+            return null;
+        try {
+            return DBC.CopyArray<SceneBase, Scene>(
+                await DBC.DBConnection.prisma.$queryRaw<Scene[]>`
+                SELECT DISTINCT S.*
+                FROM Scene AS S
+                JOIN SystemObject AS SOM ON (S.idScene = SOM.idScene)
+                JOIN SystemObjectXref AS SOX ON (SOM.idSystemObject = SOX.idSystemObjectMaster)
+                JOIN SystemObject AS SOD ON (SOX.idSystemObjectDerived = SOD.idSystemObject)
+                WHERE SOD.idModel = ${idModelChild}`, Scene);
+        } catch (error) /* istanbul ignore next */ {
+            LOG.error('DBAPI.Model.fetchParentScenes', LOG.LS.eDB, error);
             return null;
         }
     }

--- a/server/graphql/api/queries/systemobject/getVoyagerParams.ts
+++ b/server/graphql/api/queries/systemobject/getVoyagerParams.ts
@@ -1,0 +1,13 @@
+import { gql } from 'apollo-server-express';
+
+const getVoyagerParams = gql`
+    query getVoyagerParams($input: GetVoyagerParamsInput!) {
+        getVoyagerParams(input: $input) {
+            path
+            document
+            idSystemObjectScene
+        }
+    }
+`;
+
+export default getVoyagerParams;

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -889,6 +889,16 @@ type GetVocabularyResult {
   Vocabulary: Vocabulary
 }
 
+input GetVoyagerParamsInput {
+  idSystemObject: Int!
+}
+
+type GetVoyagerParamsResult {
+  document: String
+  idSystemObjectScene: Int
+  path: String
+}
+
 input GetWorkflowInput {
   idWorkflow: Int!
 }
@@ -1570,6 +1580,7 @@ type Query {
   getVersionsForAsset(input: GetVersionsForAssetInput!): GetVersionsForAssetResult!
   getVocabulary(input: GetVocabularyInput!): GetVocabularyResult!
   getVocabularyEntries(input: GetVocabularyEntriesInput!): GetVocabularyEntriesResult!
+  getVoyagerParams(input: GetVoyagerParamsInput!): GetVoyagerParamsResult!
   getWorkflow(input: GetWorkflowInput!): GetWorkflowResult!
   getWorkflowList(input: GetWorkflowListInput!): GetWorkflowListResult!
   searchIngestionSubjects(input: SearchIngestionSubjectsInput!): SearchIngestionSubjectsResult!

--- a/server/graphql/schema/systemobject/queries.graphql
+++ b/server/graphql/schema/systemobject/queries.graphql
@@ -5,6 +5,7 @@ type Query {
     getSystemObjectDetails(input: GetSystemObjectDetailsInput!): GetSystemObjectDetailsResult!
     getSourceObjectIdentifer(input: GetSourceObjectIdentiferInput!): GetSourceObjectIdentiferResult!
     getAssetDetailsForSystemObject(input: GetAssetDetailsForSystemObjectInput!): GetAssetDetailsForSystemObjectResult!
+    getVoyagerParams(input: GetVoyagerParamsInput!): GetVoyagerParamsResult!
     getVersionsForAsset(input: GetVersionsForAssetInput!): GetVersionsForAssetResult!
     getDetailsTabDataForObject(input: GetDetailsTabDataForObjectInput!): GetDetailsTabDataForObjectResult!
     getProjectList(input: GetProjectListInput!): GetProjectListResult!
@@ -214,6 +215,16 @@ input GetAssetDetailsForSystemObjectInput {
 type GetAssetDetailsForSystemObjectResult {
     columns: [ColumnDefinition!]!
     assetDetailRows: [JSON!]!
+}
+
+input GetVoyagerParamsInput {
+    idSystemObject: Int!
+}
+
+type GetVoyagerParamsResult {
+    path: String
+    document: String
+    idSystemObjectScene: Int
 }
 
 type DetailVersion {

--- a/server/graphql/schema/systemobject/resolvers/index.ts
+++ b/server/graphql/schema/systemobject/resolvers/index.ts
@@ -5,6 +5,7 @@ import Metadata from './types/Metadata';
 import getSystemObjectDetails from './queries/getSystemObjectDetails';
 import getSourceObjectIdentifer from './queries/getSourceObjectIdentifer';
 import getAssetDetailsForSystemObject from './queries/getAssetDetailsForSystemObject';
+import getVoyagerParams from './queries/getVoyagerParams';
 import getVersionsForAsset from './queries/getVersionsForAsset';
 import getDetailsTabDataForObject from './queries/getDetailsTabDataForObject';
 import getProjectList from './queries/getProjectList';
@@ -24,6 +25,7 @@ const resolvers = {
         getSystemObjectDetails,
         getSourceObjectIdentifer,
         getAssetDetailsForSystemObject,
+        getVoyagerParams,
         getVersionsForAsset,
         getDetailsTabDataForObject,
         getProjectList,

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
@@ -294,7 +294,7 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
 
                 const [CD] = CaptureDataPhoto;
 
-                CD.CameraSettingsUniform = maybe<boolean>(cameraSettingUniform);
+                CD.CameraSettingsUniform = H.Helpers.safeBoolean(cameraSettingUniform);
                 if (datasetType) CD.idVCaptureDatasetType = datasetType;
                 CD.CaptureDatasetFieldID = maybe<number>(datasetFieldId);
                 CD.idVItemPositionType = maybe<number>(itemPositionType);

--- a/server/graphql/schema/systemobject/resolvers/queries/getVoyagerParams.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getVoyagerParams.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as DBAPI from '../../../../../db';
+import * as CACHE from '../../../../../cache';
+import * as LOG from '../../../../../utils/logger';
+import * as H from '../../../../../utils/helpers';
+import { GetVoyagerParamsResult, QueryGetVoyagerParamsArgs } from '../../../../../types/graphql';
+import { Parent } from '../../../../../types/resolvers';
+import * as COMMON from '@dpo-packrat/common';
+
+export default async function getVoyagerParams(_: Parent, args: QueryGetVoyagerParamsArgs): Promise<GetVoyagerParamsResult> {
+    const { input } = args;
+    const { idSystemObject } = input;
+
+    const oID: DBAPI.ObjectIDAndType | undefined = await CACHE.SystemObjectCache.getObjectFromSystem(idSystemObject);
+    if (!oID)
+        return logError(`getVoyagerParams unable to fetch object ID and type for ${idSystemObject}`);
+
+    let idSystemObjectScene: number | undefined = undefined;
+    switch (oID.eObjectType) {
+        default:
+            return logError(`getVoyagerParams called for unsupported object type ${COMMON.eSystemObjectType[oID.eObjectType]}`);
+
+        case COMMON.eSystemObjectType.eScene:
+            idSystemObjectScene = idSystemObject;
+            break;
+
+        case COMMON.eSystemObjectType.eModel: { // Determine which scene, if any, to view for a model
+            const model: DBAPI.Model | null = await DBAPI.Model.fetch(oID.idObject);
+            if (!model)
+                return logError(`getVoyagerParams unable to fetch model with id ${oID.idObject}`);
+
+            let scenesToConsider: DBAPI.Scene[] | null = null;
+            const eModelPurpose: COMMON.eVocabularyID | undefined = model.idVPurpose ?
+                await CACHE.VocabularyCache.vocabularyIdToEnum(model.idVPurpose) : undefined;
+            switch (eModelPurpose) {
+                // Master model -> find newest scene that is derived from the model
+                case COMMON.eVocabularyID.eModelPurposeMaster: {
+                    scenesToConsider = await DBAPI.Scene.fetchChildrenScenes(model.idModel);
+                    if (!scenesToConsider)
+                        return logError(`getVoyagerParams unable to fetch children scenes of model ${H.Helpers.JSONStringify(model)}`);
+                } break;
+
+                // Voyager Model -> find newest scene that is the master of the model
+                case COMMON.eVocabularyID.eModelPurposeVoyagerSceneModel: {
+                    scenesToConsider = await DBAPI.Scene.fetchParentScenes(model.idModel);
+                    if (!scenesToConsider)
+                        return logError(`getVoyagerParams unable to fetch parent scenes of model ${H.Helpers.JSONStringify(model)}`);
+
+                } break;
+
+                // Other: first look for scene that is a source for this model, then look for scene that is derived from this model
+                case COMMON.eVocabularyID.eModelPurposeDownload:
+                case COMMON.eVocabularyID.eModelPurposeIntermediateProcessingStep:
+                default:
+                    scenesToConsider = await DBAPI.Scene.fetchParentScenes(model.idModel);
+                    if (!scenesToConsider)
+                        scenesToConsider = await DBAPI.Scene.fetchChildrenScenes(model.idModel);
+                    break;
+            }
+
+            // if we have computed scenes to consider, pick the newest scene
+            let selectedScene: DBAPI.Scene | null = null;
+            if (scenesToConsider) {
+                // pick newest scene (one with highest ID)
+                for (const scene of scenesToConsider)
+                    if ((selectedScene?.idScene ?? 0) < scene.idScene)
+                        selectedScene = scene;
+            }
+
+            if (selectedScene) {
+                const SceneSO: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromScene(selectedScene);
+                if (!SceneSO)
+                    return logError(`getVoyagerParams unable to fetch system object from scene ${H.Helpers.JSONStringify(selectedScene)}`);
+                idSystemObjectScene = SceneSO.idSystemObject;
+            } else
+                return log(true, `getVoyagerParams found no scene parents or children of model ${H.Helpers.JSONStringify(model)}`);
+
+        } break;
+    }
+
+    if (!idSystemObjectScene)
+        return logError(`getVoyagerParams unable to compute scene idSystemObject from input ${idSystemObject} mapped to ${H.Helpers.JSONStringify(oID)}`);
+
+    const assetVersions: DBAPI.AssetVersion[] | null = await DBAPI.AssetVersion.fetchLatestFromSystemObject(idSystemObjectScene);
+    if (!assetVersions || assetVersions.length === 0)
+        return logError(`getVoyagerParams retrieved no asset versions for scene with id ${idSystemObjectScene}`);
+
+    // The first asset is the "preferred asset" for the scene -- namely, it's svx.json
+    return { path: assetVersions[0].FilePath, document: assetVersions[0].FileName, idSystemObjectScene };
+}
+
+function logError(error: string): GetVoyagerParamsResult {
+    return log(false, error);
+}
+
+function log(success: boolean, message: string): GetVoyagerParamsResult {
+    if (success)
+        LOG.info(`getVoyagerParams ${message}`, LOG.LS.eGQL);
+    else
+        LOG.error(`getVoyagerParams ${message}`, LOG.LS.eGQL);
+    return { };
+}

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -75,16 +75,16 @@ export class JobCookStatistics {
         JCStat.numVertices = maybe<number>(statistics?.numVertices);
         JCStat.numTexCoordChannels = maybe<number>(statistics?.numTexCoordChannels);
         JCStat.numColorChannels = maybe<number>(statistics?.numColorChannels);
-        JCStat.hasNormals = maybe<boolean>(statistics?.hasNormals);
-        JCStat.hasVertexNormals = maybe<boolean>(statistics?.hasVertexNormals);
-        JCStat.hasVertexColors = maybe<boolean>(statistics?.hasVertexColors);
-        JCStat.hasTexCoords = maybe<boolean>(statistics?.hasTexCoords);
-        JCStat.hasBones = maybe<boolean>(statistics?.hasBones);
-        JCStat.hasTangents = maybe<boolean>(statistics?.hasTangents);
-        JCStat.isTwoManifoldUnbounded = maybe<boolean>(statistics?.isTwoManifoldUnbounded);
-        JCStat.isTwoManifoldBounded = maybe<boolean>(statistics?.isTwoManifoldBounded);
-        JCStat.selfIntersecting = maybe<boolean>(statistics?.selfIntersecting);
-        JCStat.isWatertight = maybe<boolean>(statistics?.isWatertight);
+        JCStat.hasNormals = H.Helpers.safeBoolean(statistics?.hasNormals);
+        JCStat.hasVertexNormals = H.Helpers.safeBoolean(statistics?.hasVertexNormals);
+        JCStat.hasVertexColors = H.Helpers.safeBoolean(statistics?.hasVertexColors);
+        JCStat.hasTexCoords = H.Helpers.safeBoolean(statistics?.hasTexCoords);
+        JCStat.hasBones = H.Helpers.safeBoolean(statistics?.hasBones);
+        JCStat.hasTangents = H.Helpers.safeBoolean(statistics?.hasTangents);
+        JCStat.isTwoManifoldUnbounded = H.Helpers.safeBoolean(statistics?.isTwoManifoldUnbounded);
+        JCStat.isTwoManifoldBounded = H.Helpers.safeBoolean(statistics?.isTwoManifoldBounded);
+        JCStat.selfIntersecting = H.Helpers.safeBoolean(statistics?.selfIntersecting);
+        JCStat.isWatertight = H.Helpers.safeBoolean(statistics?.isWatertight);
         JCStat.materialIndex = maybe<number[]>(statistics?.materialIndex);
         return JCStat;
     }
@@ -593,6 +593,7 @@ export class JobCookSIPackratInspectOutput implements H.IOResults {
         let vFileType: DBAPI.Vocabulary | undefined = undefined;
         if (fileName)
             vFileType = await CACHE.VocabularyCache.mapModelFileByExtension(fileName);
+
         // LOG.info(`JobCookPackratInspect createModel ${fileName} -> ${JSON.stringify(vFileType)}`, LOG.LS.eJOB);
         return new DBAPI.Model({
             Name: fileName || '',
@@ -614,7 +615,7 @@ export class JobCookSIPackratInspectOutput implements H.IOResults {
             CountEmbeddedTextures: modelStats ? maybe<number>(modelStats?.numEmbeddedTextures) : null,
             CountLinkedTextures: modelStats ? maybe<number>(modelStats?.numLinkedTextures) : null,
             FileEncoding: modelStats ? maybe<string>(modelStats?.fileEncoding) : null,
-            IsDracoCompressed: modelStats ? maybe<boolean>(modelStats?.isDracoCompressed) : null,
+            IsDracoCompressed: modelStats ? H.Helpers.safeBoolean(modelStats?.isDracoCompressed) : null,
             AutomationTag: null,
             CountTriangles: modelStats ? maybe<number>(modelStats?.numTriangles) : null,
             idModel

--- a/server/tests/db/dbcreation.test.ts
+++ b/server/tests/db/dbcreation.test.ts
@@ -5604,6 +5604,16 @@ describe('DB Fetch Special Test Suite', () => {
         expect(sceneFetch).toBeTruthy();
     });
 
+    test('DB Fetch Special: Scene.fetchParentScenes', async () => {
+        let sceneFetch: DBAPI.Scene[] | null = null;
+        if (model) {
+            sceneFetch = await DBAPI.Scene.fetchParentScenes(model.idModel);
+            if (sceneFetch)
+                expect(sceneFetch.length).toEqual(0);
+        }
+        expect(sceneFetch).toBeTruthy();
+    });
+
     test('DB Fetch Special: Sentinel.fetchByURLBase', async () => {
         let sentinelFetch: DBAPI.Sentinel[] | null = null;
         if (sentinel) {
@@ -7935,6 +7945,7 @@ describe('DB Null/Zero ID Test', () => {
         expect(await DBAPI.Scene.fetchByUUID('')).toBeNull();
         expect(await DBAPI.Scene.fetchDerivedFromItems([])).toBeNull();
         expect(await DBAPI.Scene.fetchChildrenScenes(0)).toBeNull();
+        expect(await DBAPI.Scene.fetchParentScenes(0)).toBeNull();
         expect(await DBAPI.Sentinel.fetch(0)).toBeNull();
         expect(await DBAPI.Stakeholder.fetch(0)).toBeNull();
         expect(await DBAPI.Stakeholder.fetchDerivedFromProjects([])).toBeNull();

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -985,6 +985,17 @@ export type GetVocabularyResult = {
   Vocabulary?: Maybe<Vocabulary>;
 };
 
+export type GetVoyagerParamsInput = {
+  idSystemObject: Scalars['Int'];
+};
+
+export type GetVoyagerParamsResult = {
+  __typename?: 'GetVoyagerParamsResult';
+  document?: Maybe<Scalars['String']>;
+  idSystemObjectScene?: Maybe<Scalars['Int']>;
+  path?: Maybe<Scalars['String']>;
+};
+
 export type GetWorkflowInput = {
   idWorkflow: Scalars['Int'];
 };
@@ -1841,6 +1852,7 @@ export type Query = {
   getVersionsForAsset: GetVersionsForAssetResult;
   getVocabulary: GetVocabularyResult;
   getVocabularyEntries: GetVocabularyEntriesResult;
+  getVoyagerParams: GetVoyagerParamsResult;
   getWorkflow: GetWorkflowResult;
   getWorkflowList: GetWorkflowListResult;
   searchIngestionSubjects: SearchIngestionSubjectsResult;
@@ -2039,6 +2051,11 @@ export type QueryGetVocabularyArgs = {
 
 export type QueryGetVocabularyEntriesArgs = {
   input: GetVocabularyEntriesInput;
+};
+
+
+export type QueryGetVoyagerParamsArgs = {
+  input: GetVoyagerParamsInput;
 };
 
 

--- a/server/utils/migration/SceneMigration.ts
+++ b/server/utils/migration/SceneMigration.ts
@@ -647,7 +647,16 @@ export class SceneMigration {
             return this.recordError('fetchAndIngestResources', `called without required data for ${H.Helpers.JSONStringify(this.scenePackage)}`);
 
         const edanURL: string = `3d_package:${this.scenePackage.EdanUUID}`;
-        const edanRecord: COL.EdanRecord | null = await this.ICol.fetchContent(undefined, edanURL);
+        let edanRecord: COL.EdanRecord | null = null;
+
+        // try 3 times to get our content from EDAN
+        for (let retry: number = 1; retry <= 3; retry++) {
+            edanRecord = await this.ICol.fetchContent(undefined, edanURL);
+            if (edanRecord)
+                break;
+            else if (retry < 3)
+                await H.Helpers.sleep(1500);
+        }
         if (!edanRecord)
             return this.recordError('fetchAndIngestResources', `unable to fetch EDAN record for ${edanURL}`);
 


### PR DESCRIPTION
Migration:
* Handle variable Cook output for fields like "dracoCompressed" -- coerce numeric input to boolean, before attempting to write to the database
* Retry fetching content 3 times, with 1.5 seconds delay between requests, before giving up on scene migration

GraphQL:
* Implemented getVoyagerParams(), which computes the document, path, and idSystemObjectScene needed to render Voyager Story on both Scene and Model pages. For a given idSystemObject, we compute what kind of object this is. If it's a scene, use that object.  If it's a model, determine the model purpose; for master models, pick the newest child scene; for Voyager models, pick the newest parent scene; for all the rest, pick the newest scene from parents, and then from children; for non-scenes/non-models, return an error.

Client:
* Provide access to GraphQL getVoyagerParams in useDetailsView
* Replace getObjectAssets with getVoyagerParams when computing the voyager viewer parameters

DBAPI:
* Added Scene.fetchParentScenes()