### PR TITLE
(fix) all identifiers to strings & Cook2 configurations

### DIFF
--- a/client/src/store/utils.ts
+++ b/client/src/store/utils.ts
@@ -93,7 +93,7 @@ export function parseIdentifiersToState(identifiers: IngestIdentifier[], default
     const parsedIdentifiers = identifiers.map(
         ({ identifier, identifierType, idIdentifier }: IngestIdentifier, index: number): StateIdentifier => ({
             id: index,
-            identifier,
+            identifier: identifier.toString(), // ensure the identifier (even if number) is stored as a string
             identifierType,
             idIdentifier,
             preferred: false


### PR DESCRIPTION
Fixes to:
- [Ingest] identifiers with numerical digits treated as numbers instead of strings
- [System] Update to new Cook Server
