### PR TITLE
DPO3DPKRT-767/Support Multiple Cook Resources

### DIFF
--- a/server/db/api/CookResource.ts
+++ b/server/db/api/CookResource.ts
@@ -1,0 +1,79 @@
+/* eslint-disable camelcase */
+import { CookResource as CookResourceBase } from '@prisma/client';
+import * as DBC from '../connection';
+import * as LOG from '../../utils/logger';
+
+export class CookResource extends DBC.DBObject<CookResourceBase> implements CookResourceBase {
+    idCookResource!: number;
+    Name!: string;
+    Address!: string;
+    Port!: number;
+    Inspection!: number;
+    SceneGeneration!: number;
+    GenerateDownloads!: number;
+    Photogrammetry!: number;
+    LargeFiles!: number;
+    MachineType!: string;
+
+    constructor(input: CookResourceBase) {
+        super(input);
+    }
+
+    public fetchTableName(): string { return 'CookResource'; }
+    public fetchID(): number { return this.idCookResource; }
+
+    protected async createWorker(): Promise<boolean> {
+        try {
+            const { Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType } = this;
+            ({  idCookResource: this.idCookResource,
+                Name: this.Name,
+                Address: this.Address,
+                Port: this.Port,
+                Inspection: this.Inspection,
+                SceneGeneration: this.SceneGeneration,
+                GenerateDownloads: this.GenerateDownloads,
+                Photogrammetry: this.Photogrammetry,
+                LargeFiles: this.LargeFiles,
+                MachineType: this.MachineType } =
+                await DBC.DBConnection.prisma.cookResource.create({ data: { Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType }, }));
+            return true;
+        } catch (error) /* istanbul ignore next */ {
+            return this.logError('create', error);
+        }
+    }
+
+    protected async updateWorker(): Promise<boolean> {
+        try {
+            const { idCookResource, Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType } = this;
+            return await DBC.DBConnection.prisma.cookResource.update({
+                where: { idCookResource, },
+                data: { Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType },
+            }) ? true : /* istanbul ignore next */ false;
+        } catch (error) /* istanbul ignore next */ {
+            return this.logError('update', error);
+        }
+    }
+
+    static async fetch(idCookResource: number): Promise<CookResource | null> {
+        if (!idCookResource)
+            return null;
+        try {
+            return DBC.CopyObject<CookResourceBase, CookResource>(
+                await DBC.DBConnection.prisma.cookResource.findUnique({ where: { idCookResource, }, }), CookResource);
+        } catch (error) /* istanbul ignore next */ {
+            LOG.error('DBAPI.CookResource.fetch', LOG.LS.eDB, error);
+            return null;
+        }
+        return null;
+    }
+
+    static async fetchAll(): Promise<CookResource[] | null> {
+        try {
+            return DBC.CopyArray<CookResourceBase, CookResource>(
+                await DBC.DBConnection.prisma.cookResource.findMany({ orderBy: { Name: 'asc' } }), CookResource);
+        } catch (error) /* istanbul ignore next */ {
+            LOG.error('DBAPI.CookResource.fetchAll', LOG.LS.eDB, error);
+            return null;
+        }
+    }
+}

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -19,6 +19,7 @@ export * from './api/CaptureDataGroup';
 export * from './api/CaptureDataFile';
 export * from './api/CaptureDataGroupCaptureDataXref';
 export * from './api/CaptureDataPhoto';
+export * from './api/CookResource';
 export * from './api/GeoLocation';
 export * from './api/Identifier';
 export * from './api/IntermediaryFile';

--- a/server/db/prisma/schema.prisma
+++ b/server/db/prisma/schema.prisma
@@ -920,3 +920,16 @@ model WorkflowStepSystemObjectXref {
   @@index([idSystemObject, Input], map: "WorkflowStepSystemObjectXref_idSystemObject_Input")
   @@index([idWorkflowStep, Input], map: "WorkflowStepSystemObjectXref_idWorkflowStep_Input")
 }
+
+model CookResource {
+  idCookResource    Int    @id @default(autoincrement())
+  Name              String @mariasql.VarChar(256)
+  Address           String @mariasql.VarChar(256)
+  Port              Int
+  Inspection        Int
+  SceneGeneration   Int
+  GenerateDownloads Int
+  Photogrammetry    Int
+  LargeFiles        Int
+  MachineType       String @mariasql.VarChar(256)
+}

--- a/server/db/sql/scripts/Packrat.ALTER.sql
+++ b/server/db/sql/scripts/Packrat.ALTER.sql
@@ -484,3 +484,25 @@ UPDATE Unit SET ARKPrefix = 'uj5' WHERE Abbreviation = 'OCIO';
 ALTER TABLE ModelSceneXref MODIFY COLUMN `NAME` varchar(512) DEFAULT NULL;
 
 -- 2022-11-11 Deployed to Staging and Production
+
+-- 2023-10-19 Add CookResources table and default data (Eric)
+CREATE TABLE IF NOT EXISTS `CookResource` (
+    `idCookResource` int(11) NOT NULL AUTO_INCREMENT,
+	  `Name` varchar(256) NOT NULL,
+    `Address`  varchar(256) NOT NULL,
+    `Port` int(11) NOT NULL,
+    `Inspection` int(11) NOT NULL,
+    `SceneGeneration` int(11) NOT NULL,
+    `GenerateDownloads` int(11) NOT NULL,
+    `Photogrammetry` int(11) NOT NULL,
+    `LargeFiles` int(11) NOT NULL,
+    `MachineType` varchar(256) NOT NULL,
+    PRIMARY KEY (`idCookResource`)
+) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
+
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('Cook Server: 1', 'http://si-3dcook01.us.sinet.si.edu', 8000, 3, 1, 1, 0, 0, 'server');
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('Cook Server: 2', 'http://si-3dcook02.us.sinet.si.edu', 8000, 3, 3, 3, 0, 0, 'server');
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('DPO Workstation: Digitization', 'http://ocio-73qycx3.us.sinet.si.edu', 8000, 3, 3, 3, 0, 0, 'workstation');
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('DPO Workstation: #9', 'http://ocio-3ddigisi-9.us.sinet.si.edu', 8000, 3, 1, 1, 0, 0, 'workstation');
+
+------

--- a/server/db/sql/scripts/Packrat.DATA.sql
+++ b/server/db/sql/scripts/Packrat.DATA.sql
@@ -5149,3 +5149,9 @@ INSERT INTO Identifier (IdentifierValue, idVIdentifierType, idSystemObject) SELE
 INSERT INTO Identifier (IdentifierValue, idVIdentifierType, idSystemObject) SELECT 'ITEM_GUID_2', @idVocabARK, idSystemObject FROM SystemObject WHERE idItem = (SELECT idItem FROM Item WHERE NAME = 'Softshell Turtle');
 INSERT INTO Identifier (IdentifierValue, idVIdentifierType, idSystemObject) SELECT 'ITEM_GUID_3', @idVocabARK, idSystemObject FROM SystemObject WHERE idItem = (SELECT idItem FROM Item WHERE NAME = 'Softshell Turtle');
 INSERT INTO Identifier (IdentifierValue, idVIdentifierType, idSystemObject) SELECT 'ITEM_GUID_4', @idVocabARK, idSystemObject FROM SystemObject WHERE idItem = (SELECT idItem FROM Item WHERE NAME = 'bat mitzvah dress');
+
+-- Default Cook Resources
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('Cook Server: 1', 'http://si-3dcook01.us.sinet.si.edu', 8000, 3, 1, 1, 0, 0, 'server');
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('Cook Server: 2', 'http://si-3dcook02.us.sinet.si.edu', 8000, 3, 3, 3, 0, 0, 'server');
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('DPO Workstation: Digitization', 'http://ocio-73qycx3.us.sinet.si.edu', 8000, 3, 3, 3, 0, 0, 'workstation');
+INSERT INTO CookResource (Name, Address, Port, Inspection, SceneGeneration, GenerateDownloads, Photogrammetry, LargeFiles, MachineType) VALUES ('DPO Workstation: #9', 'http://ocio-3ddigisi-9.us.sinet.si.edu', 8000, 3, 1, 1, 0, 0, 'workstation');

--- a/server/db/sql/scripts/Packrat.DROP.sql
+++ b/server/db/sql/scripts/Packrat.DROP.sql
@@ -15,6 +15,7 @@ DROP TABLE IF EXISTS `CaptureDataFile`;
 DROP TABLE IF EXISTS `CaptureDataGroup`;
 DROP TABLE IF EXISTS `CaptureDataGroupCaptureDataXref`;
 DROP TABLE IF EXISTS `CaptureDataPhoto`;
+DROP TABLE IF EXISTS `CookResources`;
 DROP TABLE IF EXISTS `GeoLocation`;
 DROP TABLE IF EXISTS `Identifier`;
 DROP TABLE IF EXISTS `IntermediaryFile`;

--- a/server/db/sql/scripts/Packrat.SCHEMA.sql
+++ b/server/db/sql/scripts/Packrat.SCHEMA.sql
@@ -167,6 +167,20 @@ CREATE TABLE IF NOT EXISTS `CaptureDataPhoto` (
   PRIMARY KEY (`idCaptureDataPhoto`)
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
 
+CREATE TABLE IF NOT EXISTS `CookResource` (
+    `idCookResource` int(11) NOT NULL AUTO_INCREMENT,
+	  `Name` varchar(256) NOT NULL,
+    `Address`  varchar(256) NOT NULL,
+    `Port` int(11) NOT NULL,
+    `Inspection` int(11) NOT NULL,
+    `SceneGeneration` int(11) NOT NULL,
+    `GenerateDownloads` int(11) NOT NULL,
+    `Photogrammetry` int(11) NOT NULL,
+    `LargeFiles` int(11) NOT NULL,
+    `MachineType` varchar(256) NOT NULL,
+    PRIMARY KEY (`idCookResource`)
+) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
+
 CREATE TABLE IF NOT EXISTS `GeoLocation` (
   `idGeoLocation` int(11) NOT NULL AUTO_INCREMENT,
   `Latitude` double DEFAULT NULL,

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -13,6 +13,7 @@ import { migrate } from './routes/migrate';
 import { Downloader, download } from './routes/download';
 import { errorhandler } from './routes/errorhandler';
 import { WebDAVServer } from './routes/WebDAVServer';
+import { getCookResource } from './routes/resources';
 
 import express, { Request, Express, RequestHandler } from 'express';
 import cors from 'cors';
@@ -86,6 +87,8 @@ export class HttpServer {
         this.app.get('/migrate/*', migrate);
         this.app.get(`${Downloader.httpRoute}*`, HttpServer.idRequestMiddleware2);
         this.app.get(`${Downloader.httpRoute}*`, download);
+
+        this.app.get('/resources/cook', getCookResource);
 
         const WDSV: WebDAVServer | null = await WebDAVServer.server();
         if (WDSV) {

--- a/server/http/routes/resources.ts
+++ b/server/http/routes/resources.ts
@@ -1,76 +1,6 @@
-/* eslint-disable camelcase */
 import { Request, Response } from 'express';
-import axios, { AxiosResponse } from 'axios';
 import * as LOG from '../../utils/logger';
-import * as DBAPI from '../../db';
-
-
-// #region RESOURCES: COOK
-// TODO: move much of this functionality into a central utility function (JobCook? DBAPI?) for reuse
-type CookResourceResult = {
-    success: boolean,
-    address: string,
-    weight?: number,
-    error?: string,
-    jobsWaiting?: number,
-    jobsRunning?: number,
-};
-
-const getCookResourceStatus = async (address: string, port: number): Promise<CookResourceResult> => {
-    // example: http://si-3dcook02.us.sinet.si.edu:8000/machine
-    const endpoint = address+':'+port+'/machine';
-
-    try {
-        LOG.info(`getCookResources getting status for resource: ${endpoint}.`,LOG.LS.eHTTP);
-
-        const response: AxiosResponse | null = await axios.get(endpoint);
-        if (!response || response.status<200 || response.status>299) {
-            return {
-                success: false,
-                error: `${response?.status}: ${response?.statusText}`,
-                address };
-        }
-
-        const data = await response.data;
-        const result: CookResourceResult = {
-            success: true,
-            address,
-            weight: -1,
-            jobsWaiting: data.jobs.waiting,
-            jobsRunning: data.jobs.running,
-        };
-        return result;
-
-    } catch (error) {
-        return { success: false, error: JSON.stringify(error), address, };
-    }
-};
-
-const verifyCookResourceCapability = (job: string, resource: DBAPI.CookResource): number => {
-    // check if the resource supports the given job type
-    switch(job) {
-        case 'inspect': {
-            return resource.Inspection;
-        } break;
-
-        case 'scene_generation': {
-            return resource.SceneGeneration;
-        } break;
-
-        case 'generate_downloads': {
-            return resource.GenerateDownloads;
-        } break;
-
-        case 'photogrammetry': {
-            return resource.Photogrammetry;
-        } break;
-
-        default: {
-            LOG.error(`getCookResource failed to verify resource (${resource.Name}: ${resource.Address}). unsupported job (${job}).`,LOG.LS.eHTTP);
-            return 0;
-        }
-    }
-};
+import * as COOK from '../../job/impl/Cook/CookResource';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const extractQueryParam = (param: any): string | undefined => {
@@ -82,18 +12,6 @@ const extractQueryParam = (param: any): string | undefined => {
 };
 
 export async function getCookResource(req: Request, res: Response): Promise<void> {
-
-    // grab all resources from DB
-    const cookResources: DBAPI.CookResource[] | null = await DBAPI.CookResource.fetchAll();
-    if(!cookResources) {
-        LOG.error('getCookResources failed. no resources found in the database.',LOG.LS.eHTTP);
-        const result = {
-            success: false,
-            error: 'Cannot find a Cook resource in the database. Contact Packrat support.'
-        };
-        res.status(500).send(JSON.stringify(result));
-        return;
-    }
 
     // identify the job we're working with
     const job = extractQueryParam(req.query.job);
@@ -107,95 +25,23 @@ export async function getCookResource(req: Request, res: Response): Promise<void
         return;
     }
 
+    // figure out who called this
+    const source = (!req.ip || req.ip==='::1')?'localhost':req.ip;
+
     // cycle filter list of resources based on supported features
-    LOG.info(`getCookResources checking availability for ${job} job from: ${req.ip}`,LOG.LS.eHTTP);
-    const cookResourceResults: CookResourceResult[] = [];
-    for(let i=0; i<cookResources.length; i++) {
-
-        // make sure the resource supports the job type
-        const supportWeight: number = verifyCookResourceCapability(job,cookResources[i]);
-        if(supportWeight <= 0) {
-            LOG.info(`getCookResources skipping resource: ${cookResources[i].Name}. (address: ${cookResources[i].Address} | reason: does not support job type)`,LOG.LS.eHTTP);
-            continue;
-        }
-
-        // otherwise get its status and wait for it
-        // OPT: fire each off without waiting, but wait outside the loop for concurrency
-        const result: CookResourceResult = await getCookResourceStatus(cookResources[i].Address,cookResources[i].Port);
-        if(result.success===true) {
-            result.weight = supportWeight;
-            cookResourceResults.push(result);
-        } else {
-            LOG.info(`getCookResources skipping resource: ${cookResources[i].Name}. (address: ${cookResources[i].Address} | reason: ${result.error})`,LOG.LS.eHTTP);
-        }
-    }
+    const cookResource: COOK.CookResourceResult = await COOK.CookResource.getCookResource(job,source);
 
     // if we're empty, bail
-    if(cookResourceResults.length<=0) {
-        LOG.error(`getCookResource cannot find the best fit resource. (resources: ${cookResourceResults.length})`, LOG.LS.eHTTP);
+    if(cookResource.success===false) {
+        LOG.error(`getCookResource cannot find the best fit resource. (${cookResource.error})`, LOG.LS.eHTTP);
 
-        const result = {
-            success: false,
-            error: `Could not find a suitable resource for a ${job} job. (${cookResources.length} resources checked)`
-        };
-        res.status(204).send(JSON.stringify(result));
+        cookResource.error = `Could not find a suitable resource for a ${job} job. ${cookResource.error}`;
+        res.status(204).send(JSON.stringify(cookResource));
         return;
     }
 
-    // sort list based on capabilities
-    cookResourceResults.sort((a, b) => {
-        if(a.weight == undefined || b.weight == undefined || a.jobsWaiting == undefined || b.jobsWaiting == undefined || a.jobsRunning == undefined || b.jobsRunning == undefined) {
-            LOG.error(`getCookResources cannot sort resources. resources have undefined properties. (A: ${JSON.stringify(a)} | B: ${JSON.stringify(b)})`,LOG.LS.eHTTP);
-            return 0;
-        }
-
-        // Sort by weight in descending order
-        if (a.weight !== b.weight) {
-            return b.weight - a.weight;
-        }
-
-        // If weight is the same, sort by jobsWaiting in ascending order
-        if (a.jobsWaiting !== b.jobsWaiting) {
-            return a.jobsWaiting - b.jobsWaiting;
-        }
-
-        // If both weight and jobsWaiting are the same, sort by jobsRunning in ascending order
-        return a.jobsRunning - b.jobsRunning;
-    });
-
-    // find best match by looking at # jobs waiting
-    const bestFit: DBAPI.CookResource | undefined = cookResources.find(item => item.Address === cookResourceResults[0].address);
-    if(!bestFit) {
-        LOG.error('getCookResource cannot find a matching resource in original array.', LOG.LS.eHTTP);
-
-        const result = {
-            success: false,
-            error: `Could not find a matching resource. notify Packrat support. (${cookResources.length} resources checked)`
-        };
-        res.status(500).send(JSON.stringify(result));
-        return;
-    }
-
-    // return full info on resource
-    const result = {
-        success: true,
-        name: bestFit.Name,
-        address: bestFit.Address,
-        port: bestFit.Port,
-        machine_type: bestFit.MachineType,
-        stats: {
-            jobsWaiting: cookResourceResults[0].jobsWaiting,
-            jobsRunning: cookResourceResults[0].jobsRunning,
-        },
-        support: {
-            inspect: bestFit.Inspection,
-            scene_generation: bestFit.SceneGeneration,
-            generate_downloads: bestFit.GenerateDownloads,
-            photogrammetry: bestFit.Photogrammetry,
-            large_files: bestFit.LargeFiles,
-        }
-    };
-    res.status(200).send(JSON.stringify(result));
-    LOG.info(`getCookResources matched '${result.name}', a ${result.machine_type}, for the job. (waiting: ${result.stats.jobsWaiting} | running: ${result.stats.jobsRunning}).`,LOG.LS.eHTTP);
+    // return the result
+    res.status(200).send(JSON.stringify(cookResource));
+    LOG.info(`found matching cook resource ('${cookResource.resources[0].name} - ${cookResource.resources[0].address}:${cookResource.resources[0].port})'`,LOG.LS.eHTTP);
 }
 // #endregion

--- a/server/http/routes/resources.ts
+++ b/server/http/routes/resources.ts
@@ -35,8 +35,10 @@ export async function getCookResource(req: Request, res: Response): Promise<void
     if(cookResource.success===false) {
         LOG.error(`getCookResource cannot find the best fit resource. (${cookResource.error})`, LOG.LS.eHTTP);
 
-        cookResource.error = `Could not find a suitable resource for a ${job} job. ${cookResource.error}`;
-        res.status(204).send(JSON.stringify(cookResource));
+        // figure out the appropriate return code and send our response
+        const statusCode: number = (cookResource.error?.includes('Invalid parameter')===true)?400:200;
+        cookResource.error = `Could not find a suitable resource for a '${job}' job. ${cookResource.error}`;
+        res.status(statusCode).send(JSON.stringify(cookResource));
         return;
     }
 

--- a/server/http/routes/resources.ts
+++ b/server/http/routes/resources.ts
@@ -1,0 +1,201 @@
+/* eslint-disable camelcase */
+import { Request, Response } from 'express';
+import axios, { AxiosResponse } from 'axios';
+import * as LOG from '../../utils/logger';
+import * as DBAPI from '../../db';
+
+
+// #region RESOURCES: COOK
+// TODO: move much of this functionality into a central utility function (JobCook? DBAPI?) for reuse
+type CookResourceResult = {
+    success: boolean,
+    address: string,
+    weight?: number,
+    error?: string,
+    jobsWaiting?: number,
+    jobsRunning?: number,
+};
+
+const getCookResourceStatus = async (address: string, port: number): Promise<CookResourceResult> => {
+    // example: http://si-3dcook02.us.sinet.si.edu:8000/machine
+    const endpoint = address+':'+port+'/machine';
+
+    try {
+        LOG.info(`getCookResources getting status for resource: ${endpoint}.`,LOG.LS.eHTTP);
+
+        const response: AxiosResponse | null = await axios.get(endpoint);
+        if (!response || response.status<200 || response.status>299) {
+            return {
+                success: false,
+                error: `${response?.status}: ${response?.statusText}`,
+                address };
+        }
+
+        const data = await response.data;
+        const result: CookResourceResult = {
+            success: true,
+            address,
+            weight: -1,
+            jobsWaiting: data.jobs.waiting,
+            jobsRunning: data.jobs.running,
+        };
+        return result;
+
+    } catch (error) {
+        return { success: false, error: JSON.stringify(error), address, };
+    }
+};
+
+const verifyCookResourceCapability = (job: string, resource: DBAPI.CookResource): number => {
+    // check if the resource supports the given job type
+    switch(job) {
+        case 'inspect': {
+            return resource.Inspection;
+        } break;
+
+        case 'scene_generation': {
+            return resource.SceneGeneration;
+        } break;
+
+        case 'generate_downloads': {
+            return resource.GenerateDownloads;
+        } break;
+
+        case 'photogrammetry': {
+            return resource.Photogrammetry;
+        } break;
+
+        default: {
+            LOG.error(`getCookResource failed to verify resource (${resource.Name}: ${resource.Address}). unsupported job (${job}).`,LOG.LS.eHTTP);
+            return 0;
+        }
+    }
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const extractQueryParam = (param: any): string | undefined => {
+    if(param) {
+        return (param as string).toLocaleLowerCase().replace(/(^"|"$)/g, '');
+    }
+
+    return undefined;
+};
+
+export async function getCookResource(req: Request, res: Response): Promise<void> {
+
+    // grab all resources from DB
+    const cookResources: DBAPI.CookResource[] | null = await DBAPI.CookResource.fetchAll();
+    if(!cookResources) {
+        LOG.error('getCookResources failed. no resources found in the database.',LOG.LS.eHTTP);
+        const result = {
+            success: false,
+            error: 'Cannot find a Cook resource in the database. Contact Packrat support.'
+        };
+        res.status(500).send(JSON.stringify(result));
+        return;
+    }
+
+    // identify the job we're working with
+    const job = extractQueryParam(req.query.job);
+    if(!job) {
+        LOG.error('getCookResources failed. no job specified',LOG.LS.eHTTP);
+        const result = {
+            success: false,
+            error: 'Invalid request for Cook resources. No \'job\' parameter provided. Check your usage'
+        };
+        res.status(400).send(JSON.stringify(result));
+        return;
+    }
+
+    // cycle filter list of resources based on supported features
+    LOG.info(`getCookResources checking availability for ${job} job from: ${req.ip}`,LOG.LS.eHTTP);
+    const cookResourceResults: CookResourceResult[] = [];
+    for(let i=0; i<cookResources.length; i++) {
+
+        // make sure the resource supports the job type
+        const supportWeight: number = verifyCookResourceCapability(job,cookResources[i]);
+        if(supportWeight <= 0) {
+            LOG.info(`getCookResources skipping resource: ${cookResources[i].Name}. (address: ${cookResources[i].Address} | reason: does not support job type)`,LOG.LS.eHTTP);
+            continue;
+        }
+
+        // otherwise get its status and wait for it
+        // OPT: fire each off without waiting, but wait outside the loop for concurrency
+        const result: CookResourceResult = await getCookResourceStatus(cookResources[i].Address,cookResources[i].Port);
+        if(result.success===true) {
+            result.weight = supportWeight;
+            cookResourceResults.push(result);
+        } else {
+            LOG.info(`getCookResources skipping resource: ${cookResources[i].Name}. (address: ${cookResources[i].Address} | reason: ${result.error})`,LOG.LS.eHTTP);
+        }
+    }
+
+    // if we're empty, bail
+    if(cookResourceResults.length<=0) {
+        LOG.error(`getCookResource cannot find the best fit resource. (resources: ${cookResourceResults.length})`, LOG.LS.eHTTP);
+
+        const result = {
+            success: false,
+            error: `Could not find a suitable resource for a ${job} job. (${cookResources.length} resources checked)`
+        };
+        res.status(204).send(JSON.stringify(result));
+        return;
+    }
+
+    // sort list based on capabilities
+    cookResourceResults.sort((a, b) => {
+        if(a.weight == undefined || b.weight == undefined || a.jobsWaiting == undefined || b.jobsWaiting == undefined || a.jobsRunning == undefined || b.jobsRunning == undefined) {
+            LOG.error(`getCookResources cannot sort resources. resources have undefined properties. (A: ${JSON.stringify(a)} | B: ${JSON.stringify(b)})`,LOG.LS.eHTTP);
+            return 0;
+        }
+
+        // Sort by weight in descending order
+        if (a.weight !== b.weight) {
+            return b.weight - a.weight;
+        }
+
+        // If weight is the same, sort by jobsWaiting in ascending order
+        if (a.jobsWaiting !== b.jobsWaiting) {
+            return a.jobsWaiting - b.jobsWaiting;
+        }
+
+        // If both weight and jobsWaiting are the same, sort by jobsRunning in ascending order
+        return a.jobsRunning - b.jobsRunning;
+    });
+
+    // find best match by looking at # jobs waiting
+    const bestFit: DBAPI.CookResource | undefined = cookResources.find(item => item.Address === cookResourceResults[0].address);
+    if(!bestFit) {
+        LOG.error('getCookResource cannot find a matching resource in original array.', LOG.LS.eHTTP);
+
+        const result = {
+            success: false,
+            error: `Could not find a matching resource. notify Packrat support. (${cookResources.length} resources checked)`
+        };
+        res.status(500).send(JSON.stringify(result));
+        return;
+    }
+
+    // return full info on resource
+    const result = {
+        success: true,
+        name: bestFit.Name,
+        address: bestFit.Address,
+        port: bestFit.Port,
+        machine_type: bestFit.MachineType,
+        stats: {
+            jobsWaiting: cookResourceResults[0].jobsWaiting,
+            jobsRunning: cookResourceResults[0].jobsRunning,
+        },
+        support: {
+            inspect: bestFit.Inspection,
+            scene_generation: bestFit.SceneGeneration,
+            generate_downloads: bestFit.GenerateDownloads,
+            photogrammetry: bestFit.Photogrammetry,
+            large_files: bestFit.LargeFiles,
+        }
+    };
+    res.status(200).send(JSON.stringify(result));
+    LOG.info(`getCookResources matched '${result.name}', a ${result.machine_type}, for the job. (waiting: ${result.stats.jobsWaiting} | running: ${result.stats.jobsRunning}).`,LOG.LS.eHTTP);
+}
+// #endregion

--- a/server/job/impl/Cook/CookResource.ts
+++ b/server/job/impl/Cook/CookResource.ts
@@ -12,7 +12,7 @@ type CookResourceState = {
     jobsRunning?: number,
 };
 
-type CookResourceInfo = {
+export type CookResourceInfo = {
     name: string,
     address: string,
     port: number,

--- a/server/job/impl/Cook/CookResource.ts
+++ b/server/job/impl/Cook/CookResource.ts
@@ -168,7 +168,16 @@ export const getJobTypeFromCookJobName = (cookJobName: string): string | undefin
         }
     }
 };
+
+// utility function for formatting a cook resource into a descriptive string.
+export const getResourceInfoString = (resource: CookResourceInfo, job: string | null = null): string => {
+    const weight: number = job ? resource.support[job] : -1;
+    return `'${resource.name}', a ${resource.machine_type}, for the job. (weight: ${weight} | waiting: ${resource.stats.jobsWaiting} | running: ${resource.stats.jobsRunning}).`;
+};
+
 export class CookResource {
+
+    // TODO: improved combined weighting of different fields vs. current sequential approach
 
     static async getCookResource(job: string, source?: string, includeAll: boolean = false): Promise<CookResourceResult> {
 
@@ -243,7 +252,7 @@ export class CookResource {
         // cycle through all gathered resources building our returned list
         for(let i=0; i<cookResourceResults.length; i++) {
 
-            // find match of resource asnd its results
+            // find match of resource and its results
             const resource: DBAPI.CookResource | undefined = cookResources.find(item => item.Address === cookResourceResults[i].address);
             if(!resource) {
                 LOG.info(`getCookResource cannot find a matching resource in original array. skipping (${cookResourceResults[i].address})`, LOG.LS.eSYS);
@@ -265,7 +274,7 @@ export class CookResource {
         }
 
         // status messgae
-        LOG.info(`getCookResources matched ${result.resources.length} resources. The best fit is '${result.resources[0].name}', a ${result.resources[0].machine_type}, for the job. (waiting: ${result.resources[0].stats.jobsWaiting} | running: ${result.resources[0].stats.jobsRunning}).`,LOG.LS.eSYS);
+        LOG.info(`getCookResources matched ${result.resources.length} resources. The best fit is ${getResourceInfoString(result.resources[0])}`,LOG.LS.eSYS);
         return result;
     }
 }

--- a/server/job/impl/Cook/CookResource.ts
+++ b/server/job/impl/Cook/CookResource.ts
@@ -1,0 +1,225 @@
+/* eslint-disable camelcase */
+import axios, { AxiosResponse } from 'axios';
+import * as LOG from '../../../utils/logger';
+import * as DBAPI from '../../../db';
+
+type CookResourceState = {
+    success: boolean,
+    address: string,
+    weight?: number,
+    error?: string,
+    jobsWaiting?: number,
+    jobsRunning?: number,
+};
+
+type CookResourceInfo = {
+    name: string,
+    address: string,
+    port: number,
+    machine_type: string,
+    stats: {
+        jobsWaiting: number | undefined,
+        jobsRunning: number | undefined,
+    },
+    support: {
+        inspect: number
+        scene_generation: number
+        generate_downloads: number
+        photogrammetry: number,
+        large_files: number,
+    }
+};
+
+export type CookResourceResult = {
+    success: boolean,
+    error?: string,
+    resources: CookResourceInfo[],
+};
+
+const getCookResourceStatus = async (address: string, port: number): Promise<CookResourceState> => {
+    // example: http://si-3dcook02.us.sinet.si.edu:8000/machine
+    const endpoint = address+':'+port+'/machine';
+
+    try {
+        LOG.info(`getCookResources getting status for resource: ${endpoint}.`,LOG.LS.eSYS);
+
+        const response: AxiosResponse | null = await axios.get(endpoint);
+        if (!response || response.status<200 || response.status>299) {
+            return {
+                success: false,
+                error: `${response?.status}: ${response?.statusText}`,
+                address };
+        }
+
+        const data = await response.data;
+        const result: CookResourceState = {
+            success: true,
+            address,
+            weight: -1,
+            jobsWaiting: data.jobs.waiting,
+            jobsRunning: data.jobs.running,
+        };
+        return result;
+
+    } catch (error) {
+        return { success: false, error: JSON.stringify(error), address, };
+    }
+};
+const verifyCookResourceCapability = (job: string, resource: DBAPI.CookResource): number => {
+    // check if the resource supports the given job type
+    switch(job) {
+        case 'inspect': {
+            return resource.Inspection;
+        } break;
+
+        case 'scene_generation': {
+            return resource.SceneGeneration;
+        } break;
+
+        case 'generate_downloads': {
+            return resource.GenerateDownloads;
+        } break;
+
+        case 'photogrammetry': {
+            return resource.Photogrammetry;
+        } break;
+
+        default: {
+            LOG.error(`getCookResource failed to verify resource (${resource.Name}: ${resource.Address}). unsupported job (${job}).`,LOG.LS.eSYS);
+            return 0;
+        }
+    }
+};
+const createResult = (dbResource: DBAPI.CookResource, resourceState: CookResourceState): CookResourceResult => {
+    return {
+        success: true,
+        resources: [{
+            name: dbResource.Name,
+            address: dbResource.Address,
+            port: dbResource.Port,
+            machine_type: dbResource.MachineType,
+            stats: {
+                jobsWaiting: resourceState.jobsWaiting,
+                jobsRunning: resourceState.jobsRunning,
+            },
+            support: {
+                inspect: dbResource.Inspection,
+                scene_generation: dbResource.SceneGeneration,
+                generate_downloads: dbResource.GenerateDownloads,
+                photogrammetry: dbResource.Photogrammetry,
+                large_files: dbResource.LargeFiles,
+            },
+        }],
+    };
+};
+const createResultError = (message: string, dbResource?: DBAPI.CookResource | undefined, resourceState?: CookResourceState | undefined): CookResourceResult => {
+
+    const result: CookResourceResult = {
+        success: false,
+        error: message,
+        resources: []
+    };
+
+    // if we have a resource
+    if(dbResource) {
+        const resource: CookResourceInfo = {
+            name: dbResource.Name,
+            address: dbResource.Address,
+            port: dbResource.Port,
+            machine_type: dbResource.MachineType,
+            stats: {
+                jobsWaiting: resourceState?.jobsWaiting,
+                jobsRunning: resourceState?.jobsRunning,
+            },
+            support: {
+                inspect: dbResource.Inspection,
+                scene_generation: dbResource.SceneGeneration,
+                generate_downloads: dbResource.GenerateDownloads,
+                photogrammetry: dbResource.Photogrammetry,
+                large_files: dbResource.LargeFiles,
+            },
+        };
+        result.resources.push(resource);
+    }
+    return result;
+};
+
+export class CookResource {
+
+    static async getCookResource(job: string, source?: string): Promise<CookResourceResult> {
+
+        // grab all resources from DB
+        const cookResources: DBAPI.CookResource[] | null = await DBAPI.CookResource.fetchAll();
+        if(!cookResources) {
+            LOG.error('getCookResources failed. no resources found in the database.',LOG.LS.eSYS);
+            return createResultError('Cannot find a Cook resource in the database. Contact Packrat support.');
+        }
+
+        // cycle filter list of resources based on supported features
+        // TODO: add user id, or 'internal'
+        LOG.info(`getCookResources checking availability for '${job}' job from '${(!source)?'internal':source}'`,LOG.LS.eSYS);
+        const cookResourceResults: CookResourceState[] = [];
+        for(let i=0; i<cookResources.length; i++) {
+
+            // make sure the resource supports the job type
+            const supportWeight: number = verifyCookResourceCapability(job,cookResources[i]);
+            if(supportWeight <= 0) {
+                LOG.info(`getCookResources skipping resource: ${cookResources[i].Name}. (address: ${cookResources[i].Address} | reason: does not support job type)`,LOG.LS.eSYS);
+                continue;
+            }
+
+            // otherwise get its status and wait for it
+            // OPT: fire each off without waiting, but wait outside the loop for concurrency
+            const result: CookResourceState = await getCookResourceStatus(cookResources[i].Address,cookResources[i].Port);
+            if(result.success===true) {
+                result.weight = supportWeight;
+                cookResourceResults.push(result);
+            } else {
+                LOG.info(`getCookResources skipping resource: ${cookResources[i].Name}. (address: ${cookResources[i].Address} | reason: ${result.error})`,LOG.LS.eSYS);
+            }
+        }
+
+        // if we're empty, bail
+        if(cookResourceResults.length<=0) {
+            LOG.error(`getCookResource cannot find the best fit resource. (resources: ${cookResourceResults.length})`, LOG.LS.eSYS);
+            return createResultError(`Could not find a suitable resource for a ${job} job. (${cookResources.length} resources checked)`);
+        }
+
+        // sort list based on capabilities
+        cookResourceResults.sort((a, b) => {
+            if(a.weight == undefined || b.weight == undefined || a.jobsWaiting == undefined || b.jobsWaiting == undefined || a.jobsRunning == undefined || b.jobsRunning == undefined) {
+                LOG.error(`getCookResources cannot sort resources. resources have undefined properties. (A: ${JSON.stringify(a)} | B: ${JSON.stringify(b)})`,LOG.LS.eSYS);
+                return 0;
+            }
+
+            // Sort by weight in descending order
+            if (a.weight !== b.weight) {
+                return b.weight - a.weight;
+            }
+
+            // If weight is the same, sort by jobsWaiting in ascending order
+            if (a.jobsWaiting !== b.jobsWaiting) {
+                return a.jobsWaiting - b.jobsWaiting;
+            }
+
+            // If both weight and jobsWaiting are the same, sort by jobsRunning in ascending order
+            return a.jobsRunning - b.jobsRunning;
+        });
+
+        // find best match by looking at # jobs waiting
+        const bestFit: DBAPI.CookResource | undefined = cookResources.find(item => item.Address === cookResourceResults[0].address);
+        if(!bestFit) {
+            LOG.error('getCookResource cannot find a matching resource in original array.', LOG.LS.eSYS);
+            return createResultError(`Could not find a matching resource. notify Packrat support. (${cookResources.length} resources checked)`);
+        }
+
+        // return full info on resource
+        const result: CookResourceResult = createResult(bestFit, cookResourceResults[0]);
+        LOG.info(`getCookResources matched '${result.resources[0].name}', a ${result.resources[0].machine_type}, for the job. (waiting: ${result.resources[0].stats.jobsWaiting} | running: ${result.resources[0].stats.jobsRunning}).`,LOG.LS.eSYS);
+        return result;
+    }
+}
+
+// TODO:
+// 2. update where inspection is called to use this
+// 3. if works, do same for scene generation

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -145,13 +145,14 @@ export abstract class JobCook<T> extends JobPackrat {
         for(let i=0; i<cookResources.resources.length; i++) {
             const endpoint = `${cookResources.resources[i].address}:${cookResources.resources[i].port}/`;
             this._configuration.cookServerURLs.push(endpoint);
+            // LOG.info(COOKRES.getResourceInfoString(cookResources.resources[i],job),LOG.LS.eJOB);
         }
         this._configuration.cookServerURLIndex = 0;
 
         // add to our report so we know what resource was chosen
         // TODO: debug mode outputting all considered resources and the one chosen
         const bestFit: COOKRES.CookResourceInfo = cookResources.resources[this._configuration.cookServerURLIndex];
-        const reportMsg: string = `Matched ${cookResources.resources.length} Cook resources. The best fit is '${bestFit.name}', a ${bestFit.machine_type}, for the job. (weight: ${bestFit.support[job]??-1} | waiting: ${bestFit.stats.jobsWaiting} | running: ${bestFit.stats.jobsRunning}).`;
+        const reportMsg: string = `Matched ${cookResources.resources.length} Cook resources. The best fit is ${COOKRES.getResourceInfoString(bestFit,job)}`;
         this.appendToReportAndLog(reportMsg,false);
 
         // return success

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -556,4 +556,6 @@ export abstract class JobCook<T> extends JobPackrat {
             LOG.info(error, LOG.LS.eJOB);
         return res;
     }
+
+    // TODO: add helper that wraps CookResource
 }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -8,6 +8,7 @@ import * as REP from '../../../report/interface';
 import { Config } from '../../../config';
 import * as H from '../../../utils/helpers';
 import { Email } from '../../../utils/email';
+import * as COOKRES from '../../../job/impl/Cook/CookResource';
 
 import { v4 as uuidv4 } from 'uuid';
 import { AuthType, createClient, WebDAVClient, CreateWriteStreamOptions, CreateReadStreamOptions } from 'webdav';
@@ -36,12 +37,16 @@ class JobCookConfiguration {
     jobName: string;
     recipeId: string;
     jobId: string;
+    cookServerURLs: string[];
+    cookServerURLIndex: number;
 
-    constructor(clientId: string, jobName: string, recipeId: string, jobId: string | null, dbJobRun: DBAPI.JobRun) {
+    constructor(clientId: string, jobName: string, recipeId: string, jobId: string | null, dbJobRun: DBAPI.JobRun, serverURL: string[] | null) {
         this.clientId = clientId;
         this.jobName = `${jobName}: ${dbJobRun.idJobRun}`;
         this.recipeId = recipeId;
         this.jobId = jobId || uuidv4(); // create a new JobID if we haven't provided one
+        this.cookServerURLs = serverURL || Config.job.cookServerUrls; // assign our environment defined URL as default
+        this.cookServerURLIndex = 0;
     }
 }
 
@@ -86,8 +91,8 @@ export abstract class JobCook<T> extends JobPackrat {
     private static _stagingSempaphoreWrite = new Semaphore(CookWebDAVSimultaneousTransfers);
     private static _stagingSempaphoreRead = new Semaphore(CookWebDAVSimultaneousTransfers);
     private static _cookJobSempaphore = new Semaphore(CookSimultaneousJobs);
-    private static _cookServerURLs: string[] = [];
-    private static _cookServerURLIndex: number = 0;
+    // private static _cookServerURLs: string[] = [];
+    // private static _cookServerURLIndex: number = 0;
     private static _cookServerFailureNotificationDate: Date | null = null;
     private static _cookServerFailureNotificationList: Set<string> = new Set<string>();
     private static _cookConnectFailures: number = 0;
@@ -99,20 +104,64 @@ export abstract class JobCook<T> extends JobPackrat {
         recipeId: string, jobId: string | null, idAssetVersions: number[] | null,
         report: REP.IReport | null, dbJobRun: DBAPI.JobRun) {
         super(jobEngine, dbJobRun, report);
-        JobCook.initialize();
-        this._configuration = new JobCookConfiguration(clientId, jobName, recipeId, jobId, dbJobRun);
+        // JobCook.initialize();
+        this._configuration = new JobCookConfiguration(clientId, jobName, recipeId, jobId, dbJobRun, null);
         this._idAssetVersions = idAssetVersions;
+
+        // NOTE: any JobCook implementations MUST call initialize() before createWorker.
     }
 
-    static initialize() {
-        if (JobCook._cookServerURLs.length === 0) {
-            JobCook._cookServerURLs = Config.job.cookServerUrls;
-            JobCook._cookServerURLIndex = 0;
+    async initialize(): Promise<H.IOResults> {
+        // if (JobCook._cookServerURLs.length === 0) {
+        //     JobCook._cookServerURLs = Config.job.cookServerUrls;
+        //     JobCook._cookServerURLIndex = 0;
+        // }
+
+        if(this._initialized===true)
+            return { success: true };
+
+        // convert recipe to job type
+        const job: string | undefined = COOKRES.getJobTypeFromCookJobName(this._configuration.jobName); //'inspect';
+        if(!job) {
+            const error = `getCookResource cannot determine Cook job type. (${this._configuration.jobName})`;
+            LOG.error(error, LOG.LS.eJOB);
+            return { success: false, error };
         }
+
+        // cycle filter list of resources based on supported features
+        const cookResources: COOKRES.CookResourceResult = await COOKRES.CookResource.getCookResource(job,this._configuration.jobId,true);
+
+        // if we're empty, bail
+        if(cookResources.success===false || cookResources.resources.length<=0) {
+            const error = `getCookResource cannot find the best fit resource. (${cookResources.error})`;
+            LOG.error(error, LOG.LS.eJOB);
+            return { success: false, error };
+        }
+
+        // rebuild list of resources
+        this._configuration.cookServerURLs = [];
+        for(let i=0; i<cookResources.resources.length; i++) {
+            const endpoint = `${cookResources.resources[i].address}:${cookResources.resources[i].port}/`;
+            this._configuration.cookServerURLs.push(endpoint);
+        }
+        this._configuration.cookServerURLIndex = 0;
+
+        // return success
+        this._initialized = true;
+        return { success: true };
     }
 
-    static CookServerURL(): string {
-        return JobCook._cookServerURLs[JobCook._cookServerURLIndex];
+    CookServerURL(): string {
+        // return JobCook._cookServerURLs[JobCook._cookServerURLIndex];
+        // if we don't have a server yet, throw error
+        if(this._initialized === false) {
+            LOG.error(`JobCook:${this.name} is not initialized. providing default Cook server endpoint (${this._configuration.cookServerURLs[0]}).`,LOG.LS.eJOB);
+            return this._configuration.cookServerURLs[0];
+        }
+
+        // return whatever resource we're currently on
+        // LOG.info(`JobCook.CookServerURL returning ${this._configuration.cookServerURLs[this._configuration.cookServerURLIndex]} as best fit out of ${this._configuration.cookServerURLs.length} available resources.`,LOG.LS.eJOB);
+        return this._configuration.cookServerURLs[this._configuration.cookServerURLIndex];
     }
 
     // #region IJob interface
@@ -212,7 +261,7 @@ export abstract class JobCook<T> extends JobPackrat {
 
         try {
             // Create job via POST to /job
-            let requestUrl: string = JobCook.CookServerURL() + 'job';
+            let requestUrl: string = this.CookServerURL() + 'job';
             const jobCookPostBody: JobCookPostBody<T> = new JobCookPostBody<T>(this._configuration, await this.getParameters(), eJobCookPriority.eNormal);
 
             while (true) {
@@ -248,7 +297,7 @@ export abstract class JobCook<T> extends JobPackrat {
             // Initiate job via PATCH to /clients/<CLIENTID>/jobs/<JOBID>/run
             requestCount = 0;
             res = { success: false, allowRetry: true };
-            requestUrl = JobCook.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/run`;
+            requestUrl = this.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/run`;
             while (true) {
                 try {
                     LOG.info(`JobCook [${this.name()}] running job: ${requestUrl}`, LOG.LS.eJOB);
@@ -284,7 +333,7 @@ export abstract class JobCook<T> extends JobPackrat {
         // Cancel job via PATCH to /clients/<CLIENTID>/jobs/<JOBID>/cancel
         let requestCount: number = 0;
         let res: H.IOResults = { success: false };
-        const requestUrl: string = JobCook.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/cancel`;
+        const requestUrl: string = this.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/cancel`;
         LOG.info(`JobCook [${this.name()}] cancelling job: ${requestUrl}`, LOG.LS.eJOB);
         while (true) {
             try {
@@ -313,7 +362,7 @@ export abstract class JobCook<T> extends JobPackrat {
         // LOG.info(`JobCook [${this.name()}] polling [${pollNumber}]`, LOG.LS.eJOB);
         // poll server for status update
         // Get job report via GET to /clients/<CLIENTID>/jobs/<JOBID>/report
-        const requestUrl: string = JobCook.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/report`;
+        const requestUrl: string = this.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/report`;
         try {
             const axiosResponse = await axios.get(requestUrl);
             if (axiosResponse.status !== 200) {
@@ -345,11 +394,14 @@ export abstract class JobCook<T> extends JobPackrat {
     protected async fetchFile(fileName: string): Promise<STORE.ReadStreamResult> {
         const res: STORE.ReadStreamResult = await JobCook._stagingSempaphoreRead.runExclusive(async (value) => {
             try {
+                // grab our endpoint
+                const cookEndpoint: string = this.CookServerURL();
+
                 // transmit file to Cook work folder via WebDAV
                 const destination: string = `/${this._configuration.jobId}/${fileName}`;
-                LOG.info(`JobCook [${this.name()}] JobCook.fetchFile via WebDAV from ${JobCook.CookServerURL()}${destination.substring(1)}; semaphore count ${value}`, LOG.LS.eJOB);
+                LOG.info(`JobCook [${this.name()}] JobCook.fetchFile via WebDAV from ${cookEndpoint}${destination.substring(1)}; semaphore count ${value}`, LOG.LS.eJOB);
 
-                const webdavClient: WebDAVClient = createClient(JobCook.CookServerURL(), {
+                const webdavClient: WebDAVClient = createClient(cookEndpoint, {
                     authType: AuthType.None,
                     maxBodyLength: 10 * 1024 * 1024 * 1024,
                     withCredentials: false
@@ -361,7 +413,7 @@ export abstract class JobCook<T> extends JobPackrat {
                 RS.on('error', error => { LOG.error(`JobCook [${this.name()}] JobCook.fetchFile stream error`, LOG.LS.eJOB, error); });
                 return { readStream: RS, fileName, storageHash: null, success: true };
             } catch (error) {
-                LOG.error('JobCook [${this.name()}] JobCook.fetchFile', LOG.LS.eJOB, error);
+                LOG.error(`JobCook [${this.name()}] JobCook.fetchFile`, LOG.LS.eJOB, error);
                 return { readStream: null, fileName, storageHash: null, success: false, error: JSON.stringify(error) };
             }
         });
@@ -380,7 +432,7 @@ export abstract class JobCook<T> extends JobPackrat {
                     // in this case, the override stream is for the model geometry file
                     let RSRs: STORE.ReadStreamResult[] | undefined = this._streamOverrideMap.get(idAssetVersion);
                     if (!RSRs) {
-                        // LOG.info(`JobCook [${this.name()}] JobCook.stageFiles found no stream override for idAssetVersion ${idAssetVersion} among ${this._streamOverrideMap.size} overrides`, LOG.LS.eJOB);
+                        LOG.info(`JobCook [${this.name()}] JobCook.stageFiles found no stream override for idAssetVersion ${idAssetVersion} among ${this._streamOverrideMap.size} overrides`, LOG.LS.eJOB);
                         RSRs = [];
                         RSRs.push(await STORE.AssetStorageAdapter.readAssetVersionByID(idAssetVersion));
                     }
@@ -396,9 +448,9 @@ export abstract class JobCook<T> extends JobPackrat {
 
                         // transmit file to Cook work folder via WebDAV
                         const destination: string = `/${this._configuration.jobId}/${fileName}`;
-                        LOG.info(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${JobCook.CookServerURL()}${destination.substring(1)}; semaphore count ${value}`, LOG.LS.eJOB);
+                        LOG.info(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${this.CookServerURL()}${destination.substring(1)}; semaphore count ${value}`, LOG.LS.eJOB);
 
-                        const webdavClient: WebDAVClient = createClient(JobCook.CookServerURL(), {
+                        const webdavClient: WebDAVClient = createClient(this.CookServerURL(), {
                             authType: AuthType.None,
                             maxBodyLength: 100 * 1024 * 1024 * 1024,
                             withCredentials: false
@@ -430,7 +482,7 @@ export abstract class JobCook<T> extends JobPackrat {
                             return { success: false, error };
                         }
 
-                        LOG.info(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${JobCook.CookServerURL()}${destination.substring(1)}: transmitted ${res.size} bytes`, LOG.LS.eJOB);
+                        LOG.info(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${this.CookServerURL()}${destination.substring(1)}: transmitted ${res.size} bytes`, LOG.LS.eJOB);
 
                         // use WebDAV client's stat to detect when file is fully staged and available on the server
                         // poll for filesize of remote file.  Continue polling:
@@ -439,7 +491,7 @@ export abstract class JobCook<T> extends JobPackrat {
                         // - pause CookRetryDelay ms between stat polls
                         let stagingSuccess: boolean = false;
                         for (let statCount: number = 0; statCount < CookWebDAVStatRetryCount; statCount++) {
-                            const pollingLocation: string = `${JobCook.CookServerURL()}${destination.substring(1)} [${statCount + 1}/${CookWebDAVStatRetryCount}]`;
+                            const pollingLocation: string = `${this.CookServerURL()}${destination.substring(1)} [${statCount + 1}/${CookWebDAVStatRetryCount}]`;
                             try {
                                 const stat: any = await webdavClient.stat(destination);
                                 const baseName: string | undefined = (stat.data) ? stat.data.basename : stat.basename;
@@ -460,10 +512,10 @@ export abstract class JobCook<T> extends JobPackrat {
                             await H.Helpers.sleep(CookRetryDelay); // sleep for an additional CookRetryDelay ms before exiting, to allow for file writing to complete
                         }
                         if (stagingSuccess) {
-                            LOG.info(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${JobCook.CookServerURL()}${destination.substring(1)}: success`, LOG.LS.eJOB);
+                            LOG.info(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${this.CookServerURL()}${destination.substring(1)}: success`, LOG.LS.eJOB);
                         } else {
                             error = `Unable to verify existence of staged file ${fileName}`;
-                            LOG.error(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${JobCook.CookServerURL()}${destination.substring(1)}: ${error}`, LOG.LS.eJOB);
+                            LOG.error(`JobCook [${this.name()}] JobCook.stageFiles staging via WebDAV at ${this.CookServerURL()}${destination.substring(1)}: ${error}`, LOG.LS.eJOB);
                             success = false;
                             break;
                         }
@@ -482,10 +534,10 @@ export abstract class JobCook<T> extends JobPackrat {
 
     private async handleCookConnectionFailure(): Promise<void> {
         // inform IT-OPS email alias and attempt to switch to "next" Cook server, if any
-        const cookServerURL: string = JobCook._cookServerURLs[JobCook._cookServerURLIndex];
-        if (++JobCook._cookServerURLIndex >= JobCook._cookServerURLs.length)
-            JobCook._cookServerURLIndex = 0;
-        LOG.info(`JobCook.handleCookConnectionFailure switching from ${cookServerURL} to ${JobCook._cookServerURLs[JobCook._cookServerURLIndex]}`, LOG.LS.eJOB);
+        const cookServerURL: string = this._configuration.cookServerURLs[this._configuration.cookServerURLIndex];
+        if (++this._configuration.cookServerURLIndex >= this._configuration.cookServerURLs.length)
+            this._configuration.cookServerURLIndex = 0;
+        LOG.info(`JobCook.handleCookConnectionFailure switching from ${cookServerURL} to ${this._configuration.cookServerURLs[this._configuration.cookServerURLIndex]}`, LOG.LS.eJOB);
 
         // only notify once about a specific server
         if (JobCook._cookServerFailureNotificationList.has(cookServerURL))
@@ -556,6 +608,4 @@ export abstract class JobCook<T> extends JobPackrat {
             LOG.info(error, LOG.LS.eJOB);
         return res;
     }
-
-    // TODO: add helper that wraps CookResource
 }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -124,7 +124,8 @@ export abstract class JobCook<T> extends JobPackrat {
         const job: string | undefined = COOKRES.getJobTypeFromCookJobName(this._configuration.jobName); //'inspect';
         if(!job) {
             const error = `getCookResource cannot determine Cook job type. (${this._configuration.jobName})`;
-            LOG.error(error, LOG.LS.eJOB);
+            this.appendToReportAndLog(error, true);
+            // LOG.error(error, LOG.LS.eJOB);
             return { success: false, error };
         }
 
@@ -134,7 +135,8 @@ export abstract class JobCook<T> extends JobPackrat {
         // if we're empty, bail
         if(cookResources.success===false || cookResources.resources.length<=0) {
             const error = `getCookResource cannot find the best fit resource. (${cookResources.error})`;
-            LOG.error(error, LOG.LS.eJOB);
+            this.appendToReportAndLog(error,true);
+            // LOG.error(error, LOG.LS.eJOB);
             return { success: false, error };
         }
 
@@ -145,6 +147,12 @@ export abstract class JobCook<T> extends JobPackrat {
             this._configuration.cookServerURLs.push(endpoint);
         }
         this._configuration.cookServerURLIndex = 0;
+
+        // add to our report so we know what resource was chosen
+        // TODO: debug mode outputting all considered resources and the one chosen
+        const bestFit: COOKRES.CookResourceInfo = cookResources.resources[this._configuration.cookServerURLIndex];
+        const reportMsg: string = `Matched ${cookResources.resources.length} Cook resources. The best fit is '${bestFit.name}', a ${bestFit.machine_type}, for the job. (weight: ${bestFit.support[job]??-1} | waiting: ${bestFit.stats.jobsWaiting} | running: ${bestFit.stats.jobsRunning}).`;
+        this.appendToReportAndLog(reportMsg,false);
 
         // return success
         this._initialized = true;

--- a/server/job/impl/Cook/index.ts
+++ b/server/job/impl/Cook/index.ts
@@ -3,3 +3,4 @@ export * from './JobCookSIGenerateDownloads';
 export * from './JobCookSIPackratInspect';
 export * from './JobCookSIVoyagerScene';
 export * from './CookRecipe';
+export * from './CookResource';

--- a/server/job/interface/IJob.ts
+++ b/server/job/interface/IJob.ts
@@ -5,6 +5,7 @@ import * as H from '../../utils/helpers';
 export interface IJob {
     name(): string;
     configuration(): any;
+    initialize(): any;
 
     executeJob(fireDate: Date): Promise<H.IOResults>;
     cancelJob(): Promise<H.IOResults>;

--- a/server/package.json
+++ b/server/package.json
@@ -76,6 +76,7 @@
     "husky": "8.0.1",
     "image-size": "1.0.2",
     "json-bigint-patch": "0.0.8",
+    "jsonfile": "6.1.0",
     "jszip": "3.10.1",
     "ldapjs": "2.3.3",
     "lodash": "4.17.21",

--- a/server/storage/impl/LocalStorage/OCFLInventory.ts
+++ b/server/storage/impl/LocalStorage/OCFLInventory.ts
@@ -254,10 +254,17 @@ export class OCFLInventoryVersions {
 
     getHashForFilename(version: string, fileName: string): string {
         const inventoryVersion: OCFLInventoryVersion | null = this.getInventoryVersion(version);
+
         /* istanbul ignore if */
-        if (!inventoryVersion || !inventoryVersion.state)
+        if (!inventoryVersion || !inventoryVersion.state) {
+            LOG.info(`OCFLInventory.getHashForFilename could not get inventory version or state. (${fileName}:${version})`,LOG.LS.eSTR);
             return '';
-        return inventoryVersion.state.getHashForFilename(fileName);
+        }
+
+        const result: string = inventoryVersion.state.getHashForFilename(fileName);
+        if(result.length<=0)
+            LOG.info(`OCFLInventory.getHashForFilename could not get hash for filename. (${fileName}:${version})`,LOG.LS.eSTR);
+        return result;
     }
 
     private getInventoryVersion(version: string): OCFLInventoryVersion | null {
@@ -341,11 +348,13 @@ export class OCFLInventory implements OCFLInventoryType {
 
     /** version == -1 -> most recent version */
     getContentPathAndHash(fileName: string, version: number = -1): OCFLPathAndHash {
+
         if (version == -1)
             return this.manifest.getLatestContentPathAndHash(fileName);
 
         const versionString: string = OCFLObject.versionFolderName(version);
         const hash: string = this.versions.getHashForFilename(versionString, fileName);
+
         if (hash)
             return {
                 path: path.join(OCFLObject.versionContentPartialPath(version), fileName),

--- a/server/storage/impl/LocalStorage/OCFLObject.ts
+++ b/server/storage/impl/LocalStorage/OCFLObject.ts
@@ -567,12 +567,19 @@ export class OCFLObject {
 
     /** version == -1 -> most recent version */
     fileLocationAndHash(fileName: string, version: number): OCFLPathAndHash | null {
+
         /* istanbul ignore next */
-        if (!this._ocflInventory)
+        if (!this._ocflInventory) {
+            LOG.error(`OCFLInventory.fileLocationAndHash does not have OCFL inventory (${fileName}:${version})`,LOG.LS.eSTR);
             return null;
+        }
+
         const pathAndHash: OCFLPathAndHash = this._ocflInventory.getContentPathAndHash(fileName, version);
-        if (!pathAndHash.hash && !pathAndHash.path)
+        if (!pathAndHash.hash && !pathAndHash.path) {
+            LOG.error(`OCFLInventory.fileLocationAndHash cannot get path (${pathAndHash.path}) or hash (${pathAndHash.hash})`,LOG.LS.eSTR);
             return null;
+        }
+
         pathAndHash.path = path.join(this._objectRoot, pathAndHash.path);   // prepend object root to content path
         return pathAndHash;
     }

--- a/server/tests/graphql/queries/asset/getAssetVersionsDetails.test.ts
+++ b/server/tests/graphql/queries/asset/getAssetVersionsDetails.test.ts
@@ -49,8 +49,7 @@ const getAssetVersionDetailsTest = (utils: TestSuiteUtils): void => {
                             const getContentsInput: GetAssetVersionsDetailsInput = {
                                 idAssetVersions: [assetVersion.idAssetVersion]
                             };
-                            console.log('getContentsInput', JSON.stringify(getContentsInput));
-                            console.log('User', JSON.stringify(User));
+
                             const { valid, Details } = await graphQLApi.getAssetVersionsDetails(getContentsInput, { user: User, isAuthenticated: true });
                             expect(valid).toBeTruthy();
                             expect(Details.length).toBeGreaterThan(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13301,19 +13301,19 @@ jsonc-parser@3.2.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-jsonfile@^6.0.1:
+jsonfile@6.1.0, jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
   integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
   dependencies:
     universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
   optionalDependencies:
     graceful-fs "^4.1.6"
 


### PR DESCRIPTION
Added support for dynamic Cook resource assignment in CookJobs. When a job is created, available Cook resources are queried to find the best fit for the current job type looking at the resource's configuration and # of jobs running/waiting. This allows for better utilization of Cook resources and load balancing for concurrent jobs.

Currently supports the following jobs:
- inspection
- scene_generation
- generate_downloads
- photogrammetry

Additionally, a public endpoint was created allowing other services (i.e. Cook, Voyager, etc.) to query Packrat to get the best fit Cook resource. This is useful for various automations including Photogrammetry.

Example:
```
https://packrat.si.edu/resources/cook?job=inspection
``` 

Developers need to add the CookResource table to their local DB. See 'Packrat.ALTER.sql' for details and default data.