### PR TITLE
DPO3DPKRT-776/non ascii characters for derivatives

### DIFF
--- a/server/utils/nameHelpers.ts
+++ b/server/utils/nameHelpers.ts
@@ -4,7 +4,7 @@ import * as CACHE from '../cache';
 import * as H from './helpers';
 import * as LOG from './logger';
 import * as COMMON from '@dpo-packrat/common';
-import sanitize from 'sanitize-filename';
+// import sanitize from 'sanitize-filename';
 
 export const UNKNOWN_NAME: string = '<UNKNOWN>';
 
@@ -47,10 +47,17 @@ export class NameHelpers {
         return scene.Name;
     }
 
+    /* eslint-disable no-control-regex */
     static sanitizeFileName(fileName: string): string {
-        return sanitize(fileName.replace(/[\s,]/g, '_').replace(/[^a-zA-Z0-9\-_.]/g, '-'));
+        //basic_clean: return sanitize(fileName.replace(/[\s,]/g, '_').replace(/[^a-zA-Z0-9\-_.]/g, '-'));
         //legacy: return sanitize(fileName.replace(/:/g, '-').replace(/ /g, '_'), { replacement: '_' });
+
+        return fileName.replace(/[\s,]/g, '_')  // replace spaces and commas
+            .replace(/[^\x00-\x7F]/g, '')       // remove non-ascii characters
+            .replace(/['`]/g, '')               // remove all apostrophes and single quotes
+            .replace(/[^a-zA-Z0-9\-_.]/g, '-'); // replace special characters except for certain ones
     }
+    /* eslint-enable no-control-regex */
 
     static computeBaseTitle(name: string, subtitle: string | undefined | null): string {
         return (subtitle) ? name.replace(`: ${subtitle}`, '') : name; // base title is the display name, with its subtitle removed, if any


### PR DESCRIPTION
EDAN titles containing non-ASCII characters were causing issues with scene generation recipes. Updated sanitization regex.  