### PR TITLE
[DPO3DPKRT-788] Updating assets from Cook with diff names fails

### DIFF
--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -35,7 +35,7 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
     public fetchTableName(): string { return 'Scene'; }
     public fetchID(): number { return this.idScene; }
     public fetchLogInfo(): string {
-        return `scene: ${this.idScene}:${this.Name} | EDAN: ${this.EdanUUID}`;
+        return `scene: ${this.Name}[id:${this.idScene}] | EDAN: ${this.EdanUUID}`;
     }
 
     protected async createWorker(): Promise<boolean> {

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -34,6 +34,9 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
 
     public fetchTableName(): string { return 'Scene'; }
     public fetchID(): number { return this.idScene; }
+    public fetchLogInfo(): string {
+        return `scene: ${this.idScene}:${this.Name} | EDAN: ${this.EdanUUID}`;
+    }
 
     protected async createWorker(): Promise<boolean> {
         try {
@@ -208,4 +211,5 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
             return null;
         }
     }
+
 }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -681,6 +681,8 @@ export abstract class JobCook<T> extends JobPackrat {
         if(!sceneAssets || sceneAssets.length == 0)
             return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData cannot find any assets for the Packrat scene. (${sceneSource.fetchLogInfo()})`);
 
+        LOG.info(`JobCookSIGenerateDownloads.verifyIncomingCookData\n\t${H.Helpers.JSONStringify(sceneAssets)}\n\t${H.Helpers.JSONStringify(fileMap)}`,LOG.LS.eDEBUG);
+
         // determine baseName from existing assets in the Packrat scene (error on diff)
         const sceneBaseName: string | null = this.extractBaseName(sceneAssets.map(asset => asset.FileName));
         if(!sceneBaseName)
@@ -694,7 +696,7 @@ export abstract class JobCook<T> extends JobPackrat {
             return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData invalid incoming basename. (${sceneSource.fetchLogInfo()} | ${sceneBaseName}:${incomingBaseName})`);
 
         // TODO: cycle through incoming assets, compare against what Packrat is expecting for
-        // this recipe and make sure it's present.
+        // this recipe and make sure it's present. (use overridden methods)
         // ...
 
         LOG.info(`JobCookSIGenerateDownloads incoming Cook data verified. (scene: ${sceneSource.idScene}:${sceneSource.Name} | EDAN: ${sceneSource.EdanUUID}  | svx: ${filteredScenes[0][1]})`,LOG.LS.eJOB);

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -396,9 +396,16 @@ export abstract class JobCook<T> extends JobPackrat {
             }
 
             // look for completion in 'state' member, via value of 'done', 'error', or 'cancelled'; update eJobRunStatus and terminate polling job
+            // write to the log for the first 10 polling cycles, then every 5th one after that
             const cookJobReport = axiosResponse.data;
             if (pollNumber <= 10 || ((pollNumber % 5) == 0))
                 LOG.info(`JobCook [${this.name()}] polling [${pollNumber}], state: ${cookJobReport['state']}: ${requestUrl}`, LOG.LS.eJOB);
+
+            // if we finished (i.e. not running or waiting) then we push out an additional log statement
+            // to ensure it's caught
+            if(cookJobReport['state']!=='waiting' && cookJobReport['state']!=='running')
+                LOG.info(`JobCook [${this.name()}] polling [exited], state: ${cookJobReport['state']}: ${requestUrl}`, LOG.LS.eJOB);
+
             switch (cookJobReport['state']) {
                 case 'created':     await this.recordCreated();                                                         break;
                 case 'waiting':     await this.recordWaiting();                                                         break;
@@ -667,47 +674,15 @@ export abstract class JobCook<T> extends JobPackrat {
         return res;
     }
 
-    protected async verifyIncomingCookData(sceneSource: DBAPI.Scene, fileMap: Map<string,string>): Promise<H.IOResults> {
-
-        // simple check on download map making sure we have an SVX file in the mix
-        const filteredScenes = Array.from(fileMap.entries()).filter(([key, value]) => {
-            return key === 'scene' && value.includes('.svx');
-        });
-        if(filteredScenes.length!==1)
-            return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData invalid svx files. found ${filteredScenes.length} svx scenes. (${sceneSource.fetchLogInfo()})`);
-
-        // get assets in Packrat Scene
-        const sceneAssets: DBAPI.Asset[] | null = await DBAPI.Asset.fetchFromScene(sceneSource.idScene);
-        if(!sceneAssets || sceneAssets.length == 0)
-            return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData cannot find any assets for the Packrat scene. (${sceneSource.fetchLogInfo()})`);
-
-        LOG.info(`JobCookSIGenerateDownloads.verifyIncomingCookData\n\t${H.Helpers.JSONStringify(sceneAssets)}\n\t${H.Helpers.JSONStringify(fileMap)}`,LOG.LS.eDEBUG);
-
-        // determine baseName from existing assets in the Packrat scene (error on diff)
-        const sceneBaseName: string | null = this.extractBaseName(sceneAssets.map(asset => asset.FileName));
-        if(!sceneBaseName)
-            return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData cannot extract base name. (${sceneSource.fetchLogInfo()})`);
-
-        // determine baseName from incoming assets from Cook (error on diff)
-        const incomingBaseName: string | null = this.extractBaseName([...fileMap.values()]);
-        if(!incomingBaseName)
-            return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData invalid incoming basename. (${sceneSource.fetchLogInfo()})`);
-        else if(sceneBaseName != incomingBaseName)
-            return await this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData invalid incoming basename. (${sceneSource.fetchLogInfo()} | ${sceneBaseName}:${incomingBaseName})`);
-
-        // TODO: cycle through incoming assets, compare against what Packrat is expecting for
-        // this recipe and make sure it's present. (use overridden methods)
-        // ...
-
-        LOG.info(`JobCookSIGenerateDownloads incoming Cook data verified. (scene: ${sceneSource.idScene}:${sceneSource.Name} | EDAN: ${sceneSource.EdanUUID}  | svx: ${filteredScenes[0][1]})`,LOG.LS.eJOB);
+    protected async verifyIncomingCookData(_sceneSource: DBAPI.Scene, _fileMap: Map<string,string>): Promise<H.IOResults> {
         return { success: true };
     }
 
-    private extractBaseName(filenames: string[]): string | null {
+    protected extractBaseName(filenames: string[]): string | null {
         // extract the base name from the list of incoming filenames and make sure they all share
         // the same values. input (currently) requires an SVX file in the list
         // TODO: broader support for other 'groups' of filenames that may not have an SVX
-        const svxFilename: string | null = 'yup.svx';
+        const svxFilename: string | undefined = filenames.find(filename => filename.includes('.svx.json'));
         if(!svxFilename || svxFilename.length == 0) {
             this.logError('JobCookSIGenerateDownloads cannot extract basename. SVX file not found');
             return null;
@@ -727,11 +702,13 @@ export abstract class JobCook<T> extends JobPackrat {
         return baseName;
     }
 
-    protected async logError(errorMessage: string): Promise<H.IOResults> {
-        // const error: string = `JobCookSIGenerateDownloads.${errorMessage}`;
-        // TODO: prepend with recipe type/info/jobId. overriden by each derived class
-        const error = `${this.name} - ${errorMessage}`;
-        await this.appendToReportAndLog(error, true);
-        return { success: false, error };
-    }
+    // private getSceneFilenamesFromMap(fileMap: Map<string, string>): string[] {
+    //     const result: string[] = [];
+    //     fileMap.forEach((value, _key) => {
+    //         if (value.includes('svx.json')) {
+    //             result.push(value);
+    //         }
+    //     });
+    //     return result;
+    // }
 }

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -531,10 +531,10 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
         return JobCookSIVoyagerScene.vocabAssetTypeModelGeometryFile;
     }
 
-    private async logError(errorBase: string): Promise<H.IOResults> {
-        const error: string = `${this.name()} ${errorBase}`;
-        await this.appendToReportAndLog(error, true);
-        return { success: false, error };
-    }
+    // private async logError(errorBase: string): Promise<H.IOResults> {
+    //     const error: string = `${this.name()} ${errorBase}`;
+    //     await this.appendToReportAndLog(error, true);
+    //     return { success: false, error };
+    // }
 }
 

--- a/server/job/impl/NS/JobPackrat.ts
+++ b/server/job/impl/NS/JobPackrat.ts
@@ -50,6 +50,8 @@ export abstract class JobPackrat implements JOB.IJob {
         for (let attempt: number = 0; attempt < JOB_RETRY_COUNT; attempt++) {
             await this.recordCreated();
             this._results = await this.startJobWorker(fireDate);
+            LOG.info(`JobPackrat.executeJob start job worker results (${H.Helpers.JSONStringify(this._results)})`,LOG.LS.eDEBUG);
+
             if (!this._results.success)
                 await this.recordFailure(null, this._results.error);
 
@@ -203,6 +205,15 @@ export abstract class JobPackrat implements JOB.IJob {
             await this._dbJobRun.update();
             this.updateEngines(true, true); // don't block
         }
+    }
+
+    protected async logError(errorMessage: string, addToReport: boolean = true): Promise<H.IOResults> {
+        // const error: string = `JobCookSIGenerateDownloads.${errorMessage}`;
+        // TODO: prepend with recipe type/info/jobId. overriden by each derived class
+        const error = `[${this.name()}] ${errorMessage}`;
+        if(addToReport == true)
+            await this.appendToReportAndLog(error, true);
+        return { success: false, error: errorMessage };
     }
     // #endregion
 }


### PR DESCRIPTION
Generate downloads now verifies assets returning from Cook meet basic requirements (e.g. naming) before accepting them for ingestion.