### PR TITLE
[DPO3DPKRT-799] Cook reports reports not added to workflow

### DIFF
--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -34,6 +34,9 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
 
     public fetchTableName(): string { return 'Scene'; }
     public fetchID(): number { return this.idScene; }
+    public fetchLogInfo(): string {
+        return `scene: ${this.Name}[id:${this.idScene}] | EDAN: ${this.EdanUUID}`;
+    }
 
     protected async createWorker(): Promise<boolean> {
         try {
@@ -208,4 +211,5 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
             return null;
         }
     }
+
 }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -396,9 +396,16 @@ export abstract class JobCook<T> extends JobPackrat {
             }
 
             // look for completion in 'state' member, via value of 'done', 'error', or 'cancelled'; update eJobRunStatus and terminate polling job
+            // write to the log for the first 10 polling cycles, then every 5th one after that
             const cookJobReport = axiosResponse.data;
             if (pollNumber <= 10 || ((pollNumber % 5) == 0))
                 LOG.info(`JobCook [${this.name()}] polling [${pollNumber}], state: ${cookJobReport['state']}: ${requestUrl}`, LOG.LS.eJOB);
+
+            // if we finished (i.e. not running or waiting) then we push out an additional log statement
+            // to ensure it's caught
+            if(cookJobReport['state']!=='waiting' && cookJobReport['state']!=='running')
+                LOG.info(`JobCook [${this.name()}] polling [exited], state: ${cookJobReport['state']}: ${requestUrl}`, LOG.LS.eJOB);
+
             switch (cookJobReport['state']) {
                 case 'created':     await this.recordCreated();                                                         break;
                 case 'waiting':     await this.recordWaiting();                                                         break;
@@ -666,4 +673,42 @@ export abstract class JobCook<T> extends JobPackrat {
             LOG.info(error, LOG.LS.eJOB);
         return res;
     }
+
+    protected async verifyIncomingCookData(_sceneSource: DBAPI.Scene, _fileMap: Map<string,string>): Promise<H.IOResults> {
+        return { success: true };
+    }
+
+    protected extractBaseName(filenames: string[]): string | null {
+        // extract the base name from the list of incoming filenames and make sure they all share
+        // the same values. input (currently) requires an SVX file in the list
+        // TODO: broader support for other 'groups' of filenames that may not have an SVX
+        const svxFilename: string | undefined = filenames.find(filename => filename.includes('.svx.json'));
+        if(!svxFilename || svxFilename.length == 0) {
+            this.logError('JobCookSIGenerateDownloads cannot extract basename. SVX file not found');
+            return null;
+        }
+
+        // get the baseName from the SVX file
+        const baseName: string = svxFilename.replace(/\.svx\.json$/, '');
+
+        // compare with others in the list to make sure they match
+        const errorNames: string[] = filenames.filter(filename => !filename.startsWith(baseName));
+        if(errorNames.length>0) {
+            this.logError(`JobCookSIGenerateDownloads filenames don't share base name. (${errorNames.join(' | ')})`);
+            return null;
+        }
+
+        // return success
+        return baseName;
+    }
+
+    // private getSceneFilenamesFromMap(fileMap: Map<string, string>): string[] {
+    //     const result: string[] = [];
+    //     fileMap.forEach((value, _key) => {
+    //         if (value.includes('svx.json')) {
+    //             result.push(value);
+    //         }
+    //     });
+    //     return result;
+    // }
 }

--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -169,7 +169,10 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
             this.cleanupCalled = true;
 
             const results: H.IOResults = await this.createSystemObjects();
-            await this.appendToReportAndLog(`${this.name()} ${results.success ? 'succeeded' : 'failed: ' + results.error}`, !results.success);
+            if(results.success==false)
+                this.recordFailure(null,results.error);
+            else
+                await this.appendToReportAndLog(`${this.name()} succeeded`, false);
             return results;
         } catch (error) {
             LOG.error('JobCookSIGenerateDownloads.cleanupJob', LOG.LS.eJOB, error);
@@ -184,17 +187,17 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // grab our Packrat Scene from the database. idScene is a parameter passed in when creating this object
         const sceneSource: DBAPI.Scene | null = this.idScene ? await DBAPI.Scene.fetch(this.idScene) : null;
         if (!sceneSource)
-            return this.logError(`createSystemObjects unable to compute source scene from id ${this.idScene}`);
+            return this.logError(`unable to compute source scene from id ${this.idScene}`);
 
         // grab the scene's SystemObject.
         const sceneSystemObject: DBAPI.SystemObject | null = await sceneSource.fetchSystemObject();
         if (!sceneSystemObject)
-            return this.logError(`createSystemObjects unable to fetch scene system object from ${H.Helpers.JSONStringify(sceneSource)}`);
+            return this.logError(`unable to fetch scene system object from ${H.Helpers.JSONStringify(sceneSource)}`);
 
         // grab our master model's source info
         const modelSource: DBAPI.Model | null = this.idModel ? await DBAPI.Model.fetch(this.idModel) : null;
         if (!modelSource)
-            return this.logError(`createSystemObjects unable to compute source model from id ${this.idModel}`);
+            return this.logError(`unable to compute source model from id ${this.idModel}`);
 
         // Retrieve generated files from Cook. Cook may return multiple types of objects (models, scenes, etc.)
         // map from download type -> download filename
@@ -212,6 +215,12 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         if(downloadMap.size<=0)
             return this.logError('JobCookSIGenerateDownloads did not receive any files to process. Cook error?');
 
+        // verify the downloads/files we received from Cook are compatible with the current Packrat representation.
+        // we do this to avoid issues where incoming Cook assets differ causing a new object be created.
+        const verifyDataResult: H.IOResults = await this.verifyIncomingCookData(sceneSource, downloadMap);
+        if(verifyDataResult.success == false)
+            return this.logError('incoming Cook data is not valid. Cannot generate downloads.',false);
+
         // array to handle accumulated errors/warning while processing files
         // returned as a string for further processing or display to user. (Q?)
         let svxSceneFile: FileProcessItem | null = null;
@@ -224,8 +233,6 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
         // cycle through retrieved downloads, processing them
         LOG.info(`JobCookSIGenerateDownloads processing ${downloadMap.size} generated downloads (idScene:${sceneSource.idScene})`,LOG.LS.eJOB);
-        // cycle through retrieved downloads, processing them
-        LOG.info(`JobCookSIGenerateDownloads processing ${downloadMap.size} generated downloads (idScene:${sceneSource.idScene})`,LOG.LS.eJOB);
         for (const [downloadType, downloadFile] of downloadMap) {
 
             // fetch the file from WebDav shared space with Cook
@@ -236,7 +243,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
             LOG.info(`JobCookSIGenerateDownloads processing download ${downloadFile} of type ${downloadType}`, LOG.LS.eJOB);
             const RSR: STORE.ReadStreamResult = await this.fetchFile(downloadFile);
             if (!RSR.success || !RSR.readStream)
-                return this.logError(`createSystemObjects unable to fetch stream for generated download ${downloadFile}: ${RSR.error}`);
+                return this.logError(`JobCookSIGenerateDownloads.createSystemObjects unable to fetch stream for generated download ${downloadFile}: ${RSR.error}`);
 
             // build our item for tracking the file and push into our queue
             const currentItemResult: FileProcessItem = {
@@ -259,7 +266,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
                     // store the results. skip additional scenes if any
                     currentItemResult.data = svx.SvxExtraction;
                     if(svxSceneFile != null)
-                        this.logError(`JobCookSIGenerateDownloads.createSystemObjects detected multiple scene files in Cook response (idScene: ${sceneSource.idScene} | file: ${downloadFile})`);
+                        await this.logError(`JobCookSIGenerateDownloads.createSystemObjects detected multiple scene files in Cook response (idScene: ${sceneSource.idScene} | file: ${downloadFile})`);
                     svxSceneFile = currentItemResult;
                     continue;
                 }
@@ -292,7 +299,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // if we don't have a scene file, then we bail
         // TODO: cleanup ingested models on failure
         if(!svxSceneFile || svxSceneFile.success===false)
-            return await this.appendToReportAndLog(`JobCookSIGenerateDownloads failed processing of returned download files (${H.Helpers.JSONStringify(svxSceneFile)})`,true);
+            return this.logError(`JobCookSIGenerateDownloads failed processing of returned download files (${H.Helpers.JSONStringify(svxSceneFile)})`);
 
         // if we had errors processing models, then we bail
         // TODO: rollback to previous versions of all models that were successful on failure (i.e. cleanup)
@@ -301,7 +308,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
             const errors = `["${
                 modelFiles.filter(obj => obj.success === false).map(obj => obj.error).join('","')
             }"]`;
-            return await this.appendToReportAndLog(`JobCookSIGenerateDownloads failed processing of returned download model files (name: ${sceneSource.Name} | idScene: ${sceneSource.idScene} | errors: ${errors})`,true);
+            return this.logError(`JobCookSIGenerateDownloads failed processing of returned download model files (name: ${sceneSource.Name} | idScene: ${sceneSource.idScene} | errors: ${errors})`);
         }
 
         // update all ModelSceneXrefs transforms for generated models in the svx scene with what's in the
@@ -352,7 +359,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // process the scene file, ingesting it
         const result = await this.processSceneFile(modelSource, svxSceneFile, idUserCreator);
         if(result.success===false)
-            await this.appendToReportAndLog(`JobCookSIGenerateDownloads failed to process svx scene (${result.error})`);
+            return this.logError(`JobCookSIGenerateDownloads failed to process svx scene (${result.error})`);
         else
             await this.appendToReportAndLog(`JobCookSIGenerateDownloads successful processing of svx scene: ${svxSceneFile.fileName}`);
 
@@ -435,12 +442,6 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         }
     }
 
-    private logError(errorMessage: string): H.IOResults {
-        // const error: string = `JobCookSIGenerateDownloads.${errorMessage}`;
-        LOG.error(errorMessage, LOG.LS.eJOB);
-        return { success: false, error: errorMessage };
-    }
-
     //------------------------------------------------------------------------------
     // MODEL
     //------------------------------------------------------------------------------
@@ -449,7 +450,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
         // verify input
         if(!sceneSource || fileItem.fileName.length<=0 || idUserCreator < 0 || RSR == null) {
-            this.logError(`JobCookSIGenerateDownloads.processModelFile invalid parameters passed for ${fileItem.fileName}`);
+            await this.logError(`JobCookSIGenerateDownloads.processModelFile invalid parameters passed for ${fileItem.fileName}`);
             return null;
         }
 
@@ -457,7 +458,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // This is used for defaults linking the model to a Scene in the even that one doesn't already exist
         const MSXSources: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromModelAndScene(modelSource.idModel, sceneSource.idScene);
         if (!MSXSources) {
-            this.logError(`JobCookSIGenerateDownloads.processModelFile createSystemObjects unable to compute ModelSceneXrefs from idModel ${this.idModel}, idScene ${this.idScene}`);
+            await this.logError(`JobCookSIGenerateDownloads.processModelFile createSystemObjects unable to compute ModelSceneXrefs from idModel ${this.idModel}, idScene ${this.idScene}`);
             return null;
         }
         const MSXSource: DBAPI.ModelSceneXref | null = MSXSources.length > 0 ? MSXSources[0] : null;
@@ -466,7 +467,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // determine the vocabulary needed for ingestion. vocabulary is used for...
         const vModelGeometryFile: DBAPI.Vocabulary | undefined = await this.computeVocabModelGeometryFile();
         if (!vModelGeometryFile) {
-            this.logError('JobCookSIGenerateDownloads.processModelFile createSystemObjects unable to calculate vocabulary needed to ingest generated downloads');
+            await this.logError('JobCookSIGenerateDownloads.processModelFile createSystemObjects unable to calculate vocabulary needed to ingest generated downloads');
             return null;
         }
 
@@ -490,12 +491,12 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
                     }
                 } else {
                     const name = H.Helpers.JSONStringify(modelSO);
-                    this.logError(`unable to fetch assets for model system object ${name}`);
+                    await this.logError(`unable to fetch assets for model system object ${name}`);
                     return null;
                 }
             } else {
                 const name = H.Helpers.JSONStringify(modelSource);
-                this.logError(`unable to fetch system object ${name}`);
+                await this.logError(`unable to fetch system object ${name}`);
                 return null;
             }
         } else {
@@ -503,21 +504,21 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
             model = await this.createModel(fileItem.fileName, fileItem.downloadType, modelSource);
             if (!await model.create()) {
                 const name = H.Helpers.JSONStringify(model);
-                this.logError(`JobCookSIGenerateDownloads.processModelFile unable to create model: ${name}`);
+                await this.logError(`JobCookSIGenerateDownloads.processModelFile unable to create model: ${name}`);
                 return null;
             }
 
             // link model as derived from the scene
             const SOX1: DBAPI.SystemObjectXref | null = await DBAPI.SystemObjectXref.wireObjectsIfNeeded(sceneSource, model);
             if (!SOX1) {
-                this.logError(`JobCookSIGenerateDownloads.processModelFile unable to wire model to scene: ${H.Helpers.JSONStringify(sceneSource)} and Model ${H.Helpers.JSONStringify(model)} together`);
+                await this.logError(`JobCookSIGenerateDownloads.processModelFile unable to wire model to scene: ${H.Helpers.JSONStringify(sceneSource)} and Model ${H.Helpers.JSONStringify(model)} together`);
                 return null;
             }
 
             // link model as derived from the master model
             const SOX2: DBAPI.SystemObjectXref | null = await DBAPI.SystemObjectXref.wireObjectsIfNeeded(modelSource, model);
             if (!SOX2) {
-                this.logError(`JobCookSIGenerateDownloads.processModelFile unable to wire model to master model source: ${H.Helpers.JSONStringify(modelSource)} and Model ${H.Helpers.JSONStringify(model)} together`);
+                await this.logError(`JobCookSIGenerateDownloads.processModelFile unable to wire model to master model source: ${H.Helpers.JSONStringify(modelSource)} and Model ${H.Helpers.JSONStringify(model)} together`);
                 return null;
             }
         }
@@ -549,7 +550,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // check for multiple asset versions
         // Q: what problem(s) does this cause?
         if (IAR.assetVersions && IAR.assetVersions.length > 1)
-            this.logError(`JobCookSIGenerateDownloads.processModelFile created multiple asset versions, unexpectedly, ingesting ${fileItem.fileName}`);
+            await this.logError(`JobCookSIGenerateDownloads.processModelFile created multiple asset versions, unexpectedly, ingesting ${fileItem.fileName}`);
 
         // if no SysObj exists for this model then we check our cache for one
         let idSystemObjectModel: number | null = modelSO ? modelSO.idSystemObject : null;
@@ -623,7 +624,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
         // TODO: if failed cleanup prior ingestion?
         if (MSXResult === false) {
-            this.logError(`JobCookSIGenerateDownloads.processModelFile cannot create/update ModelSceneXref ${H.Helpers.JSONStringify(MSX)}`);
+            await this.logError(`JobCookSIGenerateDownloads.processModelFile cannot create/update ModelSceneXref ${H.Helpers.JSONStringify(MSX)}`);
             return null;
         }
 
@@ -636,7 +637,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
                 await this.appendToReportAndLog(`JobCookSIGenerateDownloads extracted model metrics for ${model.Name}`);
             else if (results.error) {
                 // TODO: cleanup ingestion
-                this.logError(`JobCookSIGenerateDownloads.processModelFile failed inspecting the model: ${model.Name} (${results.error})`);
+                await this.logError(`JobCookSIGenerateDownloads.processModelFile failed inspecting the model: ${model.Name} (${results.error})`);
                 return null;
             }
         }
@@ -740,20 +741,20 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
     // #endregion
 
     //------------------------------------------------------------------------------
-    // SCENE
+    // VOYAGER SCENE
     //------------------------------------------------------------------------------
     // #region scene
     private async processSceneFile(modelSource: DBAPI.Model, fileItem: FileProcessItem, idUserCreator: number): Promise<H.IOResults> {
 
         if (!this.sceneParameterHelper)
-            return this.logError('JobCookSIGenerateDownloads.processSceneFile called without needed parameters');
+            return await this.logError('JobCookSIGenerateDownloads.processSceneFile called without needed parameters');
 
         const svxFile: string = fileItem.fileName; //this.parameters.svxFile ?? 'scene.svx.json';
         const svxData = fileItem.data;
         const vScene: DBAPI.Vocabulary | undefined = await this.computeVocabAssetTypeScene();
         const vModel: DBAPI.Vocabulary | undefined = await this.computeVocabAssetTypeModelGeometryFile();
         if (!vScene || !vModel)
-            return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to calculate vocabulary needed to ingest scene file ${svxFile}`);
+            return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to calculate vocabulary needed to ingest scene file ${svxFile}`);
 
         LOG.info(`JobCookSIGenerateDownloads.processSceneFile[${svxFile}] parse scene`, LOG.LS.eJOB);
         // LOG.info(`JobCookSIGenerateDownloads.processSceneFile fetched scene:${H.Helpers.JSONStringify(svxData)}`, LOG.LS.eJOB);
@@ -762,7 +763,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // TODO: what if there are multiple?
         const scenes: DBAPI.Scene[] | null = await DBAPI.Scene.fetchChildrenScenes(modelSource.idModel);
         if (!scenes)
-            return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to fetch children scenes of master model ${modelSource.idModel}`);
+            return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to fetch children scenes of master model ${modelSource.idModel}`);
 
         // if we have more than one scene see if there is a clear path to selecting one (i.e. one has EDAN id)
         // TODO: investigate why the system sometimes creates additional scenes
@@ -795,7 +796,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
         // if we have multiple valid scenes, bail
         if(scenes.length>1)
-            return this.logError(`multiple valid scenes found (${scenes.length}). cannot find asset to update (idScene: ${fileItem.fileName})`);
+            return await this.logError(`multiple valid scenes found (${scenes.length}). cannot find asset to update (idScene: ${fileItem.fileName})`);
 
         // If needed, create a new scene (if we have no scenes, or if we have multiple scenes, then create a new one);
         // If we have just one scene, before reusing it, see if the model names all match up
@@ -829,19 +830,19 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
             if (this.sceneParameterHelper.sceneTitle)
                 scene.Title = this.sceneParameterHelper.sceneTitle;
             if (!await scene.create())
-                return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to create Scene file ${svxFile}: database error`);
+                return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to create Scene file ${svxFile}: database error`);
 
             // wire ModelSource to Scene
             const SOX: DBAPI.SystemObjectXref | null = await DBAPI.SystemObjectXref.wireObjectsIfNeeded(modelSource, scene);
             if (!SOX)
-                return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to wire Model Source ${H.Helpers.JSONStringify(modelSource)} to Scene ${H.Helpers.JSONStringify(scene)}: database error`);
+                return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to wire Model Source ${H.Helpers.JSONStringify(modelSource)} to Scene ${H.Helpers.JSONStringify(scene)}: database error`);
 
             // wire ItemParent to Scene
             const OG: DBAPI.ObjectGraph = this.sceneParameterHelper.OG;
             if (OG.item && OG.item.length > 0) {
                 const SOX2: DBAPI.SystemObjectXref | null = await DBAPI.SystemObjectXref.wireObjectsIfNeeded(OG.item[0], scene);
                 if (!SOX2)
-                    return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to wire item ${H.Helpers.JSONStringify(OG.item[0])} to Scene ${H.Helpers.JSONStringify(scene)}: database error`);
+                    return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to wire item ${H.Helpers.JSONStringify(OG.item[0])} to Scene ${H.Helpers.JSONStringify(scene)}: database error`);
             }
             // LOG.info(`JobCookSIGenerateDownloads.processSceneFile[${svxFile}] wire ModelSource to Scene: ${H.Helpers.JSONStringify(SOX)}`, LOG.LS.eJOB);
         } else {
@@ -868,7 +869,7 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         // Read file a second time ... cloneStream isn't available
         const RSR = await this.fetchFile(svxFile);
         if (!RSR.success || !RSR.readStream)
-            return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to fetch stream for scene file ${svxFile}: ${RSR.error}`);
+            return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to fetch stream for scene file ${svxFile}: ${RSR.error}`);
 
         // create our configuration for ingesting this svx scene
         const ISI: STORE.IngestStreamOrFileInput = {
@@ -886,9 +887,9 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         };
         const IAR: STORE.IngestAssetResult = await STORE.AssetStorageAdapter.ingestStreamOrFile(ISI);
         if (!IAR.success)
-            return this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to ingest scene file ${svxFile}: ${IAR.error}`);
+            return await this.logError(`JobCookSIGenerateDownloads.processSceneFile unable to ingest scene file ${svxFile}: ${IAR.error}`);
         if (IAR.assetVersions && IAR.assetVersions.length > 1)
-            LOG.error(`JobCookSIGenerateDownloads.processSceneFile created multiple asset versions, unexpectedly, ingesting ${svxFile}`, LOG.LS.eJOB);
+            await this.logError(`JobCookSIGenerateDownloads.processSceneFile created multiple asset versions, unexpectedly, ingesting ${svxFile}`);
 
         const SOI: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromScene(scene);
         const assetVersion: DBAPI.AssetVersion | null = (IAR.assetVersions && IAR.assetVersions.length > 0) ? IAR.assetVersions[0] : null;
@@ -997,6 +998,68 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
                 LOG.error('JobCookSIGenerateDownloads unable to fetch vocabulary for Asset Type Model Geometry File', LOG.LS.eGQL);
         }
         return JobCookSIGenerateDownloads.vocabAssetTypeModelGeometryFile;
+    }
+
+    protected async verifyIncomingCookData(sceneSource: DBAPI.Scene, fileMap: Map<string,string>): Promise<H.IOResults> {
+
+        const result: H.IOResults = await super.verifyIncomingCookData(sceneSource, fileMap);
+        if(result.success == false)
+            return this.logError('verifyIncomingCookData base failed');
+
+        // get assets in Packrat Scene
+        const sceneAssets: DBAPI.Asset[] | null = await DBAPI.Asset.fetchFromScene(sceneSource.idScene);
+        if(!sceneAssets || sceneAssets.length == 0)
+            return this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData cannot find any assets for the Packrat scene. (${sceneSource.fetchLogInfo()})`);
+        const sceneAssetFilenames: string[] = sceneAssets.map(asset => asset.FileName);
+        LOG.info(`JobCookSIGenerateDownloads.verifyIncomingCookData\n\t${H.Helpers.JSONStringify(sceneAssetFilenames)}\n\t${H.Helpers.JSONStringify(fileMap)}`,LOG.LS.eDEBUG);
+
+        // determine baseName from existing assets in the Packrat scene (error on diff)
+        const sceneBaseName: string | null = this.extractBaseName(sceneAssets.map(asset => asset.FileName));
+        if(!sceneBaseName)
+            return this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData cannot extract base name. (${sceneSource.fetchLogInfo()})`);
+
+        // get list of filenames from the incoming fileMap
+        const incomingAssetFilenames: string[] = [...fileMap.values()];
+
+        // define expected suffixes to look for in the system
+        // NOTE: need to update this list if si-generate-downloads returns new/different assets
+        const suffixes: string[] = ['-150k-4096_std.glb','-100k-2048_std_draco.glb','.svx.json','-100k-2048_std.usdz','-full_resolution-obj_std.zip','-150k-4096-gltf_std.zip','-150k-4096-obj_std.zip'];
+        const mismatches: string[] = [];
+
+        // cycle through Scene assets comparing with incoming.
+        // if we have a file with the provided suffix in the Scene then check for a full name match with the incoming map
+        for(let i=0; i<suffixes.length; i++) {
+            // Only check for the filenames in the system already. If not in the system, assuming
+            // it's a new file or first run of the recipe.
+            // NOTE: if scene file has the correct name but generated downloads do not then this will succeed because
+            //       it cannot find the files in the scene and assumes them to be new.
+            const filename: string = sceneBaseName + suffixes[i];
+            if(sceneAssetFilenames.includes(filename)==true) {
+                // see if the same filename exists with the Cook response
+                // if not, then we assume there is a name difference and is not valid
+                if(incomingAssetFilenames.includes(filename)==false) {
+                    this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData couldn't find match in Cook map for: ${filename}`,false);
+                    mismatches.push(filename);
+                } else {
+                    LOG.info(`JobCookSIGenerateDownloads.verifyIncomingCookData found match for ${filename}.`,LOG.LS.eDEBUG);
+                }
+            } else {
+                // if it's not in the scene then we check just the suffix in case we have a mismatch in the system (critical)
+                const found: string|undefined = sceneAssetFilenames.find(filename => filename.endsWith(suffixes[i]));
+                if(found)
+                    return this.logError(`CRITICAL: JobCookSIGenerateDownloads.verifyIncomingCookData found an incoming asset (${found}) that doesn't share the scene (id: ${sceneSource.idScene}) base name (${sceneBaseName}).`);
+                else {
+                    LOG.info(`JobCookSIGenerateDownloads.verifyIncomingCookData didn't find ${filename}. Assuming it's new...`,LOG.LS.eDEBUG);
+                }
+            }
+        }
+
+        // if we have mismatches throw an error and dump out specifics
+        if(mismatches.length > 0)
+            return this.logError(`JobCookSIGenerateDownloads.verifyIncomingCookData couldn't find matching assets with '${sceneBaseName}' base name. (${mismatches.length}: ${incomingAssetFilenames.join('|')}`);
+
+        LOG.info(`JobCookSIGenerateDownloads incoming Cook data verified. (${sceneSource.fetchLogInfo()}  | baseName: ${sceneBaseName})`,LOG.LS.eJOB);
+        return { success: true };
     }
 
     // private async getModelDetailsFromVoyagerScene(svxFile): Promise<DBAPI.ModelSceneXref[] | null> {

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -531,10 +531,10 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
         return JobCookSIVoyagerScene.vocabAssetTypeModelGeometryFile;
     }
 
-    private async logError(errorBase: string): Promise<H.IOResults> {
-        const error: string = `${this.name()} ${errorBase}`;
-        await this.appendToReportAndLog(error, true);
-        return { success: false, error };
-    }
+    // private async logError(errorBase: string): Promise<H.IOResults> {
+    //     const error: string = `${this.name()} ${errorBase}`;
+    //     await this.appendToReportAndLog(error, true);
+    //     return { success: false, error };
+    // }
 }
 

--- a/server/job/impl/NS/JobPackrat.ts
+++ b/server/job/impl/NS/JobPackrat.ts
@@ -50,6 +50,8 @@ export abstract class JobPackrat implements JOB.IJob {
         for (let attempt: number = 0; attempt < JOB_RETRY_COUNT; attempt++) {
             await this.recordCreated();
             this._results = await this.startJobWorker(fireDate);
+            LOG.info(`JobPackrat.executeJob start job worker results (${H.Helpers.JSONStringify(this._results)})`,LOG.LS.eDEBUG);
+
             if (!this._results.success)
                 await this.recordFailure(null, this._results.error);
 
@@ -203,6 +205,15 @@ export abstract class JobPackrat implements JOB.IJob {
             await this._dbJobRun.update();
             this.updateEngines(true, true); // don't block
         }
+    }
+
+    protected async logError(errorMessage: string, addToReport: boolean = true): Promise<H.IOResults> {
+        // const error: string = `JobCookSIGenerateDownloads.${errorMessage}`;
+        // TODO: prepend with recipe type/info/jobId. overriden by each derived class
+        const error = `[${this.name()}] ${errorMessage}`;
+        if(addToReport == true)
+            await this.appendToReportAndLog(error, true);
+        return { success: false, error: errorMessage };
     }
     // #endregion
 }

--- a/server/types/voyager/json/meta.schema.json
+++ b/server/types/voyager/json/meta.schema.json
@@ -31,6 +31,10 @@
                 "height": {
                     "type": "integer",
                     "minimum": 1
+                },
+                "usage": {
+                    "type": "string",
+                    "enum": [ "Render", "ARCode" ]
                 }
             },
             "required": [
@@ -112,6 +116,14 @@
                 },
                 "uris": {
                     "description": "Location of the audio resource, absolute URL or path relative to this document with language key",
+                    "type": "object"
+                },
+                "captionUris": {
+                    "description": "Location of the caption resource, absolute URL or path relative to this document with language key",
+                    "type": "object"
+                },
+                "durations": {
+                    "description": "Length of the audio resource with language key",
                     "type": "object"
                 }
             },

--- a/server/types/voyager/json/model.schema.json
+++ b/server/types/voyager/json/model.schema.json
@@ -65,6 +65,11 @@
                     "type": "string",
                     "minLength": 1
                 },
+                "viewId": {
+                    "description": "Id of a snapshot resource with camera view information for this annotation.",
+                    "type": "string",
+                    "minLength": 1
+                },
                 "style": {
                     "type": "string"
                 },

--- a/server/types/voyager/json/setup.schema.json
+++ b/server/types/voyager/json/setup.schema.json
@@ -15,11 +15,20 @@
                 "exposure": {
                     "type": "number"
                 },
+                "toneMapping": {
+                    "type": "boolean"
+                },
                 "gamma": {
                     "type": "number"
                 },
                 "annotationsVisible": {
                     "type": "boolean"
+                },
+                "isWallMountAR": {
+                    "type": "boolean"
+                },
+                "arScale": {
+                    "type": "number"
                 },
                 "activeTags": {
                     "type": "string"
@@ -83,6 +92,12 @@
                     "type": "boolean"
                 },
                 "autoZoom": {
+                    "type": "boolean"
+                },
+                "autoRotation": {
+                    "type": "boolean"
+                },
+                "lightsFollowCamera": {
                     "type": "boolean"
                 },
                 "orbit": {
@@ -188,6 +203,28 @@
                 },
                 "position": {
                     "type": "number"
+                },
+                "color": {
+                    "$ref": "./common.schema.json#/definitions/vector3"
+                }
+            }
+        },
+        "audio": {
+            "type": "object",
+            "properties": {
+                "narrationId": {
+                    "type": "string"
+                }
+            }
+        },
+        "language": {
+            "type": "object",
+            "properties": {
+                "language": {
+                    "type": "string",
+                    "enum": [
+                        "EN", "ES", "DE", "NL", "JA", "FR", "HAW"
+                    ]
                 }
             }
         },
@@ -303,6 +340,12 @@
         },
         "tours": {
             "$ref": "#/definitions/tours"
+        },
+        "language": {
+            "$ref": "#/definitions/language"
+        },
+        "audio": {
+            "$ref": "#/definitions/audio"
         }
     }
 }

--- a/server/types/voyager/meta.ts
+++ b/server/types/voyager/meta.ts
@@ -1,7 +1,7 @@
-/* eslint-disable quotes, @typescript-eslint/brace-style */
+/* eslint-disable quotes, @typescript-eslint/brace-style, @typescript-eslint/no-explicit-any */
 /**
  * NOTE: this file is part of the definition of a Voyager scene, found in a .svx.json file.
- * This was imported from Voyager's source/client/schema on 1/24/2024. It was then modified,
+ * This was imported from Voyager's source/client/schema on 3/5/2024. It was then modified,
  * minimally, to allow for use by Packrat. Ideally, in the future, we will extract out the
  * definition of this shared file format for use by both projects.
  */
@@ -49,9 +49,11 @@ export interface IImage
     byteSize: number;
     width: number;
     height: number;
+    usage?: TImageUsage;
 }
 
 export type TImageQuality = "Thumb" | "Low" | "Medium" | "High";
+export type TImageUsage = "Render" | "ARCode";
 
 /**
  * Refers to an external document or a media file (audio, video, image).

--- a/server/types/voyager/model.ts
+++ b/server/types/voyager/model.ts
@@ -1,7 +1,7 @@
 /* eslint-disable quotes, @typescript-eslint/brace-style */
 /**
  * NOTE: this file is part of the definition of a Voyager scene, found in a .svx.json file.
- * This was imported from Voyager's source/client/schema on 1/24/2024. It was then modified,
+ * This was imported from Voyager's source/client/schema on 3/5/2024. It was then modified,
  * minimally, to allow for use by Packrat. Ideally, in the future, we will extract out the
  * definition of this shared file format for use by both projects.
  */
@@ -25,7 +25,7 @@
 // import { Dictionary } from "@ff/core/types";
 // import { ColorRGBA, EUnitType, TUnitType, Vector3, Vector4 } from "./common";
 type Dictionary<T> = Record<string, T>;
-import { ColorRGBA, TUnitType, Vector3, Vector4 } from "./common";
+import { ColorRGBA, /*EUnitType,*/ TUnitType, Vector3, Vector4 } from "./common";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -86,6 +86,7 @@ export interface IAnnotation
     imageCredit?: Dictionary<string>;
     imageAltText?: Dictionary<string>;
     audioId?: string;
+    viewId?: string;
 
     style?: string;
     visible?: boolean;

--- a/server/types/voyager/setup.ts
+++ b/server/types/voyager/setup.ts
@@ -1,7 +1,7 @@
-/* eslint-disable quotes, @typescript-eslint/brace-style */
+/* eslint-disable quotes, @typescript-eslint/brace-style, @typescript-eslint/no-explicit-any */
 /**
  * NOTE: this file is part of the definition of a Voyager scene, found in a .svx.json file.
- * This was imported from Voyager's source/client/schema on 1/24/2024. It was then modified,
+ * This was imported from Voyager's source/client/schema on 3/5/2024. It was then modified,
  * minimally, to allow for use by Packrat. Ideally, in the future, we will extract out the
  * definition of this shared file format for use by both projects.
  */
@@ -25,7 +25,6 @@ import { ELanguageType, TLanguageType } from "./common";
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 export type TShaderMode = "Default" | "Clay" | "XRay" | "Normals" | "Wireframe";
 export enum EShaderMode { Default, Clay, XRay, Normals, Wireframe }
@@ -57,6 +56,7 @@ export interface ISetup
     slicer?: ISlicer;
     tours?: ITours;
     snapshots?: ISnapshots;
+    audio?: IAudio;
 }
 
 export interface IInterface


### PR DESCRIPTION
The 'Workflow' view in Packrat now provides access to Cook Job reports from when the job first starts and continues to update it while the job is running. 

Additional QoL additions added as well: 
- Cook Job Id now listed in reports
- all errors appended to reports, etc.