### PR TITLE
DPO3DPKRT-798/manual execution generate downloads

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -556,6 +556,9 @@ function DetailsView(): React.ReactElement {
             return false;
         } finally {
             setIsUpdatingData(false);
+
+            // check our generate downloads button
+            await verifyGenerateDownloads();
         }
     };
 

--- a/server/collections/impl/PublishScene.ts
+++ b/server/collections/impl/PublishScene.ts
@@ -301,7 +301,7 @@ export class PublishScene {
         return DownloadMSXMap;
     }
 
-    static async handleSceneUpdates(idScene: number, idSystemObject: number, _idUser: number | undefined,
+    static async handleSceneUpdates(idScene: number, _idSystemObject: number, _idUser: number | undefined,
         oldPosedAndQCd: boolean, newPosedAndQCd: boolean,
         LicenseOld: DBAPI.License | undefined, LicenseNew: DBAPI.License | undefined): Promise<SceneUpdateResult> {
         // if we've changed Posed and QC'd, and/or we've updated our license, create or remove downloads
@@ -319,8 +319,9 @@ export class PublishScene {
                 return PublishScene.sendResult(false, `Unable to fetch workflow engine for download generation for scene ${idScene}`);
 
             // trigger the workflow/recipe
-            workflowEngine.generateSceneDownloads(idScene, { idUserInitiator: _idUser }); // don't await
-            return { success: true, downloadsGenerated: true, downloadsRemoved: false };
+            // HACK: disable automatic download generation for the moment
+            // workflowEngine.generateSceneDownloads(idScene, { idUserInitiator: _idUser }); // don't await
+            return { success: true, downloadsGenerated: false, downloadsRemoved: false };
         } else { // Remove downloads
             LOG.info(`PublishScene.handleSceneUpdates removing downloads for scene ${idScene}`, LOG.LS.eGQL);
             // Compute downloads
@@ -338,9 +339,11 @@ export class PublishScene {
                     assetVersionOverrideMap.set(asset.idAsset, 0);
             }
 
-            const SOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.cloneObjectAndXrefs(idSystemObject, null, 'Removing Downloads', assetVersionOverrideMap);
-            if (!SOV)
-                return PublishScene.sendResult(false, `Unable to clone system object version for idSystemObject ${idSystemObject} for scene ${idScene}`);
+            // HACK: preventing modifying downloads in the Scene.
+            //       Publishing should not add/remove assets but select what is included when sent to EDAN
+            // const SOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.cloneObjectAndXrefs(idSystemObject, null, 'Removing Downloads', assetVersionOverrideMap);
+            // if (!SOV)
+            //     return PublishScene.sendResult(false, `Unable to clone system object version for idSystemObject ${idSystemObject} for scene ${idScene}`);
             return { success: true, downloadsGenerated: false, downloadsRemoved: true };
         }
     }

--- a/server/db/api/Asset.ts
+++ b/server/db/api/Asset.ts
@@ -160,6 +160,31 @@ export class Asset extends DBC.DBObject<AssetBase> implements AssetBase, SystemO
             `,Asset);
     }
 
+    static async fetchFromModel(idModel: number): Promise<Asset[] | null> {
+        // get any assets associated with the given Model. Can include meshes, textures, and materials
+        return DBC.CopyArray<AssetBase, Asset>(
+            await DBC.DBConnection.prisma.$queryRaw<Asset[]>`
+                SELECT * FROM Model AS mdl
+                JOIN SystemObject AS mdlSO ON mdl.idModel = mdlSO.idModel
+                JOIN Asset AS a ON a.idSystemObject = mdlSO.idSystemObject
+                WHERE mdl.idModel = ${idModel};
+            `,Asset);
+    }
+
+    static async fetchVoyagerSceneFromScene(idScene: number): Promise<Asset[] | null> {
+        // get the voyager scene asset associated with the Packrat scene (if any)
+        // TODO: get asset type id from VocabularyID
+        const idvAssetType: number = 137;
+
+        return DBC.CopyArray<AssetBase, Asset>(
+            await DBC.DBConnection.prisma.$queryRaw<Asset[]>`
+                SELECT a.* FROM Scene AS scn
+                JOIN SystemObject AS scnSO ON scn.idScene = scnSO.idScene
+                JOIN Asset AS a ON a.idSystemObject = scnSO.idSystemObject
+                WHERE scn.idScene = ${idScene} AND a.idVAssetType = ${idvAssetType};
+            `,Asset);
+    }
+
     /** Fetches assets that are connected to the specified idSystemObject (via that object's last SystemObjectVersion,
      * and that SystemObjectVersionAssetVersionXref's records). For those assets, we look for a match on FileName, idVAssetType */
     static async fetchMatching(idSystemObject: number, FileName: string, idVAssetType: number): Promise<Asset | null> {

--- a/server/db/api/JobRun.ts
+++ b/server/db/api/JobRun.ts
@@ -51,10 +51,14 @@ export class JobRun extends DBC.DBObject<JobRunBase> implements JobRunBase {
         // grab our parameters, parse them and see if we have the scene
         try {
             const json = JSON.parse(this.Parameters);
-            if(!json.idScene)
-                return false;
 
-            return (json.idScene == idScene);
+            if(json.idScene)
+                return (json.idScene == idScene);
+
+            if(!json.model && !json.model.idScene)
+                return (json.model.idScene == idScene);
+
+            return false;
         } catch(error) {
             LOG.error(`JobRun.usesScene failed. (${error})`,LOG.LS.eDB);
             return false;
@@ -68,10 +72,14 @@ export class JobRun extends DBC.DBObject<JobRunBase> implements JobRunBase {
         // grab our parameters, parse them and see if we have the model
         try {
             const json = JSON.parse(this.Parameters);
-            if(!json.idModel)
-                return false;
 
-            return (json.idModel == idModel);
+            if(json.idModel)
+                return (json.idModel == idModel);
+
+            if(!json.model && !json.model.idModel)
+                return (json.model.idModel == idModel);
+
+            return false;
         } catch(error) {
             LOG.error(`JobRun.usesModel failed. (${error})`,LOG.LS.eDB);
             return false;

--- a/server/db/api/JobRun.ts
+++ b/server/db/api/JobRun.ts
@@ -248,6 +248,24 @@ export class JobRun extends DBC.DBObject<JobRunBase> implements JobRunBase {
         }
     }
 
+    static async fetchActiveByScene(idJob: number, idScene: number): Promise<JobRun[] | null> {
+        const jobs: JobRun[] = [];
+        const activeJobs: JobRun[] | null = await JobRun.fetchByJobFiltered(idJob,true);
+        if(!activeJobs) {
+            LOG.error('DBAPI.JobRun.fetchActiveByScene failed to get filtered jobs',LOG.LS.eDB);
+            return null;
+        }
+
+        // see if it's ours and if so, store the job's id
+        for(let i=0; i< activeJobs.length; i++){
+            if(activeJobs[i].usesScene(idScene)) {
+                jobs.push(activeJobs[i]);
+            }
+        }
+
+        return jobs;
+    }
+
     static async fetchFromWorkflow(idWorkflow: number): Promise<JobRun[] | null> {
         // direct get of JubRun(s) from a specific workflow
         try {

--- a/server/db/api/Project.ts
+++ b/server/db/api/Project.ts
@@ -161,4 +161,19 @@ export class Project extends DBC.DBObject<ProjectBase> implements ProjectBase, S
             return null;
         }
     }
+
+    static async fetchFromScene(idScene: number): Promise<Project[] | null> {
+        // return the project(s) associated with a particular scene
+        return DBC.CopyArray<ProjectBase, Project>(
+            await DBC.DBConnection.prisma.$queryRaw<Project[]>`
+                SELECT proj.* FROM Scene AS scn
+                JOIN SystemObject AS scnSO ON scn.idScene = scnSO.idScene
+                JOIN SystemObjectXref AS scnSOX ON scnSO.idSystemObject = scnSOX.idSystemObjectDerived
+                JOIN SystemObject AS itemSO ON scnSOX.idSystemObjectMaster = itemSO.idSystemObject AND itemSO.idItem IS NOT NULL
+                JOIN SystemObjectXref AS itemSOX ON itemSO.idSystemObject = itemSOX.idSystemObjectDerived
+                JOIN SystemObject AS projSO ON itemSOX.idSystemObjectMaster = projSO.idSystemObject AND projSO.idProject IS NOT NULL
+                JOIN Project AS proj ON projSO.idProject = proj.idProject
+                WHERE scn.idScene = ${idScene};
+            `,Project);
+    }
 }

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -149,6 +149,27 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
         }
     }
 
+    static async fetchBySystemObject(idSystemObject: number): Promise<Scene | null> {
+        if (!idSystemObject)
+            return null;
+        try {
+            const scenes: Scene[] | null =  DBC.CopyArray<SceneBase, Scene>(
+                await DBC.DBConnection.prisma.$queryRaw<Scene[]>`
+                SELECT * FROM Scene AS scn
+                JOIN SystemObject AS so ON (scn.idScene = so.idScene)
+                WHERE so.idSystemObject = ${idSystemObject};`, Scene);
+
+            // if we have scenes just return the first one, else null
+            if(scenes)
+                return scenes[0];
+
+            return null;
+        } catch (error) /* istanbul ignore next */ {
+            LOG.error('DBAPI.Scene.fetchBySystemObject', LOG.LS.eDB, error);
+            return null;
+        }
+    }
+
     /**
      * Computes the array of Scenes that are connected to any of the specified items.
      * Scenes are connected to system objects; we examine those system objects which are in a *derived* relationship

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -37,14 +37,6 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
     public fetchLogInfo(): string {
         return `scene: ${this.Name}[id:${this.idScene}] | EDAN: ${this.EdanUUID}`;
     }
-    public canGenerateDownloads(): boolean {
-        // determine if this scene is valid for generating downloads
-        // TODO: do a check to make sure it has a valid master model attached
-        if(!this.PosedAndQCd)
-            return false;
-
-        return true;
-    }
 
     protected async createWorker(): Promise<boolean> {
         try {

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -37,6 +37,14 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
     public fetchLogInfo(): string {
         return `scene: ${this.Name}[id:${this.idScene}] | EDAN: ${this.EdanUUID}`;
     }
+    public canGenerateDownloads(): boolean {
+        // determine if this scene is valid for generating downloads
+        // TODO: do a check to make sure it has a valid master model attached
+        if(!this.PosedAndQCd)
+            return false;
+
+        return true;
+    }
 
     protected async createWorker(): Promise<boolean> {
         try {

--- a/server/db/api/SystemObjectVersion.ts
+++ b/server/db/api/SystemObjectVersion.ts
@@ -143,6 +143,10 @@ export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> i
             if (!DBC.DBConnection.isFullPrismaClient(prismaClient))
                 return SystemObjectVersion.cloneObjectAndXrefsTrans(idSystemObject, idSystemObjectVersion, Comment, assetVersionOverrideMap, assetsUnzipped);
 
+            // set our options for all transactions. these timeout values help with situations
+            // where concurrent requests to the DB take longer than expected. (in seconds)
+            const transactionOptions = { maxWait: 5000, timeout: 10000 };
+
             // otherwise, start a new transaction:
             // LOG.info('DBAPI.SystemObjectVersion.cloneObjectAndXrefs starting a new DB transaction', LOG.LS.eDB);
             return await prismaClient.$transaction(async (prisma) => {
@@ -150,7 +154,7 @@ export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> i
                 const retValue: SystemObjectVersion | null = await SystemObjectVersion.cloneObjectAndXrefsTrans(idSystemObject, idSystemObjectVersion, Comment, assetVersionOverrideMap, assetsUnzipped);
                 DBC.DBConnection.clearPrismaTransaction(transactionNumber);
                 return retValue;
-            });
+            },transactionOptions);
         } catch (error) /* istanbul ignore next */ {
             LOG.error('DBAPI.SystemObjectVersion.cloneObjectAndXrefs', LOG.LS.eDB, error);
             return null;

--- a/server/db/api/SystemObjectVersion.ts
+++ b/server/db/api/SystemObjectVersion.ts
@@ -144,8 +144,12 @@ export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> i
                 return SystemObjectVersion.cloneObjectAndXrefsTrans(idSystemObject, idSystemObjectVersion, Comment, assetVersionOverrideMap, assetsUnzipped);
 
             // set our options for all transactions. these timeout values help with situations
-            // where concurrent requests to the DB take longer than expected. (in seconds)
-            const transactionOptions = { maxWait: 5000, timeout: 10000 };
+            // where concurrent requests to the DB take longer than expected. (in ms)
+            const transactionOptions = {
+                maxWait: 10000, // how long Prisma will wait to get a connection (default: 2000)
+                timeout: 20000  // how long an interactive transaction can take (default: 5000)
+                // isolationLevel: Prisma.TransactionIsolationLevel.Serializable, // how much concurrency is allowed 'serializable' is most strict (default: RepeatableRead)
+            };
 
             // otherwise, start a new transaction:
             // LOG.info('DBAPI.SystemObjectVersion.cloneObjectAndXrefs starting a new DB transaction', LOG.LS.eDB);

--- a/server/event/interface/EventEnums.ts
+++ b/server/event/interface/EventEnums.ts
@@ -3,6 +3,7 @@ export enum eEventTopic {
     eDB = 2,
     ePublish = 3,
     eHTTP = 4,
+    eScene = 5
 }
 
 export enum eEventKey {
@@ -14,4 +15,5 @@ export enum eEventKey {
     eHTTPDownload = 6,
     eHTTPUpload = 7,
     eAuthFailed = 8,
+    eGenDownloads = 9
 }

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -140,7 +140,6 @@ export class HttpServer {
         ASL.run(new LocalStore(true, idUser), () => {
             LOG.info(`HTTP.idRequestMiddleware creating new LocalStore (url: ${req.originalUrl} | idUser: ${idUser})`,LOG.LS.eHTTP);
             next();
-            LOG.info(`HTTP.idRequestMiddleware POST store run (${ASL.getStore()?.idRequest})`,LOG.LS.eDEBUG);
         });
     }
 
@@ -164,18 +163,18 @@ export class HttpServer {
                 query = queryGQL;
                 queryParams = H.Helpers.JSONStringify(req.body.variables);
             } else
-                query = 'Unknown GraphQL';
+                query = `Unknown GraphQL: ${query}|${req.path}`;
         }
         LOG.info(`New ${method} request [${query}] made by user ${idUser}. (${queryParams})`,LOG.LS.eHTTP);
         next();
     }
-    private static checkLocalStore(label: string) {
-        return function (_req, _res, next) {
-            //LOG.info(`HTTP.checkLocalStore [${label}]. (url: ${req.originalUrl} | ${H.Helpers.JSONStringify(ASL.getStore())})`,LOG.LS.eDEBUG);
-            ASL.checkLocalStore(label);
-            next();
-        };
-    }
+    // private static checkLocalStore(label: string) {
+    //     return function (_req, _res, next) {
+    //         //LOG.info(`HTTP.checkLocalStore [${label}]. (url: ${req.originalUrl} | ${H.Helpers.JSONStringify(ASL.getStore())})`,LOG.LS.eDEBUG);
+    //         ASL.checkLocalStore(label);
+    //         next();
+    //     };
+    // }
     // private static printRequest(req: Request, label: string = 'Request'): void {
     //     if(!req) {
     //         console.log('nothing');

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -81,10 +81,6 @@ export class HttpServer {
         await server.start();
         server.applyMiddleware({ app: this.app, cors: false });
 
-        // Packrat API endpoints (WIP)
-        this.app.post('/api/scene/gen-downloads', generateDownloads);
-        this.app.get('/api/scene/gen-downloads', generateDownloads);
-
         // utility endpoints
         this.app.get('/logtest', logtest);
         this.app.get('/heartbeat', heartbeat);
@@ -96,6 +92,10 @@ export class HttpServer {
         this.app.get(`${Downloader.httpRoute}*`, download);
 
         this.app.get('/resources/cook', getCookResource);
+
+        // Packrat API endpoints (WIP)
+        this.app.post('/api/scene/gen-downloads', generateDownloads);
+        this.app.get('/api/scene/gen-downloads', generateDownloads);
 
         const WDSV: WebDAVServer | null = await WebDAVServer.server();
         if (WDSV) {

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -97,18 +97,15 @@ export class HttpServer {
             this.app.use(webdav.extensions.express(WebDAVServer.httpRoute, this.WDSV.webdav()));
 
         // authentication and graphQL endpoints
-        this.app.use(HttpServer.checkLocalStore('0:Auth/GraphQL'));
         this.app.use('/auth', AuthRouter);
         this.app.use('/graphql', graphqlUploadExpress());
 
         // start our ApolloServer
-        this.app.use(HttpServer.checkLocalStore('1:Apollo'));
         const server = new ApolloServer(ApolloServerOptions);
         await server.start();
         server.applyMiddleware({ app: this.app, cors: false });
 
         // utility endpoints
-        this.app.use(HttpServer.checkLocalStore('2:Utility'));
         this.app.get('/logtest', logtest);
         this.app.get('/heartbeat', heartbeat);
         this.app.get('/solrindex', solrindex);
@@ -118,19 +115,9 @@ export class HttpServer {
         this.app.get(`${Downloader.httpRoute}*`, download);
 
         // Packrat API endpoints (WIP)
-        this.app.use(HttpServer.checkLocalStore('3:API'));
         this.app.get('/resources/cook', getCookResource);
         this.app.get('/api/scene/gen-downloads', generateDownloads);
         this.app.post('/api/scene/gen-downloads', generateDownloads);
-
-        // // WebDAV storage (used for staging to Voyager/Cook)
-        // this.app.use(HttpServer.checkLocalStore('4:WebDAV'));
-        // const WDSV: WebDAVServer | null = await WebDAVServer.server();
-        // if (WDSV) {
-        //     this.app.use(webdav.extensions.express(WebDAVServer.httpRoute, WDSV.webdav()));
-        //     this.app.use(HttpServer.checkLocalStore('4b:WebDAV'));
-        // } else
-        //     LOG.error('HttpServer.configureMiddlewareAndRoutes failed to initialize WebDAV server', LOG.LS.eHTTP);
 
         // if we're here then we handle any errors that may have surfaced
         this.app.use(errorhandler); // keep last
@@ -143,7 +130,6 @@ export class HttpServer {
         }
 
         // only gets here if no other route is satisfied
-        this.app.use(HttpServer.checkLocalStore('5:Exit'));
         return true;
     }
 

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -15,6 +15,8 @@ import { errorhandler } from './routes/errorhandler';
 import { WebDAVServer } from './routes/WebDAVServer';
 import { getCookResource } from './routes/resources';
 
+import { generateDownloads } from './routes/api/generateDownloads';
+
 import express, { Request, Express, RequestHandler } from 'express';
 import cors from 'cors';
 import { ApolloServer } from 'apollo-server-express';
@@ -79,6 +81,11 @@ export class HttpServer {
         await server.start();
         server.applyMiddleware({ app: this.app, cors: false });
 
+        // Packrat API endpoints (WIP)
+        this.app.post('/api/scene/gen-downloads', generateDownloads);
+        this.app.get('/api/scene/gen-downloads', generateDownloads);
+
+        // utility endpoints
         this.app.get('/logtest', logtest);
         this.app.get('/heartbeat', heartbeat);
         this.app.get('/solrindex', solrindex);

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -4,6 +4,7 @@ import { EventFactory } from '../event/interface/EventFactory';
 import { ASL, LocalStore } from '../utils/localStore';
 import { Config } from '../config';
 import * as LOG from '../utils/logger';
+import * as H from '../utils/helpers';
 import { UsageMonitor } from '../utils/osStats';
 
 import { logtest } from './routes/logtest';
@@ -14,7 +15,6 @@ import { Downloader, download } from './routes/download';
 import { errorhandler } from './routes/errorhandler';
 import { WebDAVServer } from './routes/WebDAVServer';
 import { getCookResource } from './routes/resources';
-
 import { generateDownloads } from './routes/api/generateDownloads';
 
 import express, { Request, Express, RequestHandler } from 'express';
@@ -49,7 +49,11 @@ export class HttpServer {
     private async initializeServer(): Promise<boolean> {
         LOG.info('**************************', LOG.LS.eSYS);
         LOG.info('Packrat Server Initialized', LOG.LS.eSYS);
-        const res: boolean = await this.configureMiddlewareAndRoutes();
+
+        let res: boolean = false;
+        // await ASL.run(new LocalStore(true, undefined), async () => {
+        res = await this.configureMiddlewareAndRoutes();
+        // });
 
         // call to initalize the EventFactory, which in turn will initialize the AuditEventGenerator, supplying the IEventEngine
         EventFactory.getInstance();
@@ -60,26 +64,64 @@ export class HttpServer {
         return res;
     }
 
+    // private static printRequest(req: Request, label: string = 'Request'): void {
+    //     if(!req) {
+    //         console.log('nothing');
+    //     }
+    //     LOG.info(`${label}: ${H.Helpers.JSONStringify({
+    //         // headers: req.headers,
+    //         // body: req.body,
+    //         query: req.query,
+    //         params: req.params,
+    //         url: req.url,
+    //         method: req.method,
+    //         ip: req.ip,
+    //         path: req.path,
+    //         sid: req.cookies?.connect?.sid ?? undefined,
+    //         // cookies: req.cookies,
+    //         user: req.user
+    //     })}`,LOG.LS.eDEBUG);
+    // }
+
     static bodyProcessorExclusions: RegExp = /^\/(?!webdav).*$/;
     private async configureMiddlewareAndRoutes(): Promise<boolean> {
-        this.app.use(HttpServer.idRequestMiddleware);
-        this.app.use(cors(authCorsConfig));
+        // First step is to modify the request body as needed. We do this first
+        // because the express.json() 3rd party library breaks any context created
+        // by the AsyncLocalStore as it waits for the request/body to arrive.
         this.app.use(HttpServer.bodyProcessorExclusions, express.json() as RequestHandler); // do not extract webdav PUT bodies into request.body element
         this.app.use(HttpServer.bodyProcessorExclusions, express.urlencoded({ extended: true }) as RequestHandler);
+
+        // get our cookie and auth system rolling. We do this here so we can extract
+        // our user information (if present) and have it for creating the LocalStore.
+        // this.app.use((req,_res,next)=>{ HttpServer.printRequest(req,'[Pre-Auth]'); next(); });
+        this.app.use(cors(authCorsConfig));
         this.app.use(cookieParser());
         this.app.use(authSession);
         this.app.use(passport.initialize());
         this.app.use(passport.session());
+        // this.app.use((req,_res,next)=>{ HttpServer.printRequest(req,'[Post-Auth]'); next(); });
 
-        this.app.use('/auth', HttpServer.idRequestMiddleware2);
+        // create our LocalStore for all future interactions
+        // this.app.use(HttpServer.checkLocalStore('[Pre-LocalStore]'));
+        this.app.use(HttpServer.logRequest);
+        this.app.use(HttpServer.idRequestMiddleware);
+        this.app.use(HttpServer.checkLocalStore('0:Create'));
+
+        // this.app.use('/auth', HttpServer.idRequestMiddleware2);
         this.app.use('/auth', AuthRouter);
-        this.app.use('/graphql', HttpServer.idRequestMiddleware2);
-        this.app.use('/graphql', HttpServer.graphqlLoggingMiddleware);
+        // this.app.use(HttpServer.checkLocalStore('h'));
+        // this.app.use('/graphql', HttpServer.idRequestMiddleware2);
+        // this.app.use('/graphql', HttpServer.graphqlLoggingMiddleware);
+        // this.app.use(HttpServer.checkLocalStore('i'));
         this.app.use('/graphql', graphqlUploadExpress());
+        // this.app.use(HttpServer.checkLocalStore('d'));
 
+        // start our ApolloServer
+        this.app.use(HttpServer.checkLocalStore('1:Auth/GraphQL'));
         const server = new ApolloServer(ApolloServerOptions);
         await server.start();
         server.applyMiddleware({ app: this.app, cors: false });
+        this.app.use(HttpServer.checkLocalStore('2:Utility'));
 
         // utility endpoints
         this.app.get('/logtest', logtest);
@@ -88,63 +130,120 @@ export class HttpServer {
         this.app.get('/solrindexprofiled', solrindexprofiled);
         this.app.get('/migrate', migrate);
         this.app.get('/migrate/*', migrate);
-        this.app.get(`${Downloader.httpRoute}*`, HttpServer.idRequestMiddleware2);
+        // this.app.get(`${Downloader.httpRoute}*`, HttpServer.idRequestMiddleware2);
         this.app.get(`${Downloader.httpRoute}*`, download);
-
-        this.app.get('/resources/cook', getCookResource);
+        this.app.use(HttpServer.checkLocalStore('3:API'));
 
         // Packrat API endpoints (WIP)
-        this.app.post('/api/scene/gen-downloads', generateDownloads);
+        this.app.get('/resources/cook', getCookResource);
         this.app.get('/api/scene/gen-downloads', generateDownloads);
+        this.app.post('/api/scene/gen-downloads', generateDownloads);
+        this.app.use(HttpServer.checkLocalStore('4:WebDAV'));
 
+        // WebDAV storage (used for staging to Voyager/Cook)
         const WDSV: WebDAVServer | null = await WebDAVServer.server();
         if (WDSV) {
-            this.app.use(WebDAVServer.httpRoute, HttpServer.idRequestMiddleware2);
+            this.app.use(HttpServer.checkLocalStore('g-WebDAV'));
+            // this.app.use(WebDAVServer.httpRoute, HttpServer.idRequestMiddleware2);
             this.app.use(webdav.extensions.express(WebDAVServer.httpRoute, WDSV.webdav()));
+            this.app.use(HttpServer.checkLocalStore('h-WebDAV'));
         } else
             LOG.error('HttpServer.configureMiddlewareAndRoutes failed to initialize WebDAV server', LOG.LS.eHTTP);
 
+        // if we're here then we handle any errors that may have surfaced
         this.app.use(errorhandler); // keep last
 
+        // if we're not testing then open up server on the correct port
         if (process.env.NODE_ENV !== 'test') {
             this.app.listen(Config.http.port, () => {
                 LOG.info(`Server is running on port ${Config.http.port}`, LOG.LS.eSYS);
             });
         }
+
+        this.app.use(HttpServer.checkLocalStore('5:Exit'));
         return true;
     }
 
     // creates a LocalStore populated with the next requestID
     private static idRequestMiddleware(req: Request, _res, next): void {
-        if (!req.originalUrl.startsWith('/auth/') &&
-            !req.originalUrl.startsWith('/graphql') &&
-            !req.originalUrl.startsWith(Downloader.httpRoute) &&
-            !req.originalUrl.startsWith(WebDAVServer.httpRoute)) {
-            const user = req['user'];
-            const idUser = user ? user['idUser'] : undefined;
-            ASL.run(new LocalStore(true, idUser), () => {
-                LOG.info(req.originalUrl, LOG.LS.eHTTP);
-                next();
-            });
-        } else
-            next();
-    }
+        // const user = req['user'];
+        // const idUser = user ? user['idUser'] : undefined;
+        // const LS: LocalStore | undefined = ASL.getStore();
+        // if(!LS) {
+        //     LOG.info(`HTTP.idRequestMiddleware no LocalStore found. creating new LocalStore (url: ${req.originalUrl} | user: ${H.Helpers.JSONStringify(req['user'])})`,LOG.LS.eDEBUG);
+        //     ASL.run(new LocalStore(true, idUser), () => {
+        //         LOG.info(`request: ${req.originalUrl}`, LOG.LS.eHTTP);
+        //     });
+        // } else if(!LS.idUser) {
+        //     LOG.error(`HTTP.idRequestMiddleware warning. LocalStore is missing idUser. (${idUser})`,LOG.LS.eHTTP);
+        //     LS.idUser = idUser;
+        // }
+        // next();
 
-    private static idRequestMiddleware2(req: Request, _res, next): void {
+        // if (!req.originalUrl.startsWith('/auth/') &&
+        //     !req.originalUrl.startsWith('/graphql') &&
+        //     !req.originalUrl.startsWith(Downloader.httpRoute) &&
+        //     !req.originalUrl.startsWith(WebDAVServer.httpRoute)) {
+        // HttpServer.printRequest(req, `idRequestMiddleware [${req.originalUrl}]`);
         const user = req['user'];
         const idUser = user ? user['idUser'] : undefined;
         ASL.run(new LocalStore(true, idUser), () => {
-            if (!req.originalUrl.startsWith('/graphql'))
-                LOG.info(`HTTP request for: ${req.originalUrl}`, LOG.LS.eHTTP);
+            LOG.info(`HTTP.idRequestMiddleware creating new LocalStore (url: ${req.originalUrl} | idUser: ${idUser})`,LOG.LS.eHTTP);
             next();
         });
+        // } else
+        //     next();
     }
 
-    private static graphqlLoggingMiddleware(req: Request, _res, next): void {
-        const query: string | null = computeGQLQuery(req);
-        if (query && query !== '__schema') // silence __schema logging, issued by GraphQL playground
-            LOG.info(`${query} ${JSON.stringify(req.body.variables)}`, LOG.LS.eGQL);
-        return next();
+    // private static idRequestMiddleware2(req: Request, _res, next): void {
+    //     const user = req['user'];
+    //     const idUser = user ? user['idUser'] : undefined;
+    //     ASL.run(new LocalStore(true, idUser), () => {
+    //         if (!req.originalUrl.startsWith('/graphql'))
+    //             LOG.info(`HTTP request for: ${req.originalUrl}`, LOG.LS.eHTTP);
+    //         next();
+    //     });
+    // }
+
+    // logging middleware routines
+    private static logRequest(req: Request, _res, next): void {
+        // TODO: more detailed information about the request
+        // figure out who is calling this
+        const user = req['user'];
+        const idUser = user ? user['idUser'] : undefined;
+
+        // our method (GET, POST, ...)
+        let method = req.method.toUpperCase();
+
+        // get our query
+        let query = req.originalUrl;
+        let queryParams = H.Helpers.JSONStringify(req.query);
+        if(req.originalUrl.includes('/graphql')) {
+            method = 'GQL';
+            const queryGQL = computeGQLQuery(req);
+            if(queryGQL && queryGQL !== '__schema') {
+                query = queryGQL;
+                queryParams = H.Helpers.JSONStringify(req.body.variables);
+            } else
+                query = 'Unknown GraphQL';
+        }
+        LOG.info(`New ${method} request [${query}] made by user ${idUser}. (${queryParams})`,LOG.LS.eHTTP);
+        next();
+    }
+    // private static graphqlLoggingMiddleware(req: Request, _res, next): void {
+    //     const query: string | null = computeGQLQuery(req);
+    //     if (query && query !== '__schema') // silence __schema logging, issued by GraphQL playground
+    //         LOG.info(`${query} ${JSON.stringify(req.body.variables)}`, LOG.LS.eGQL);
+    //     return next();
+    // }
+
+    // private static idCheck = 0;
+    // private static lblCheck = '';
+    private static checkLocalStore(label: string) {
+        return function (req, _res, next) {
+            LOG.info(`HTTP.checkLocalStore [${label}]. (url: ${req.originalUrl} | ${H.Helpers.JSONStringify(ASL.getStore())})`,LOG.LS.eDEBUG);
+            next();
+        };
     }
 }
 

--- a/server/http/routes/WebDAVServer.ts
+++ b/server/http/routes/WebDAVServer.ts
@@ -4,7 +4,6 @@ import * as STORE from '../../storage/interface';
 import * as DBAPI from '../../db';
 import * as CACHE from '../../cache';
 import * as COMMON from '@dpo-packrat/common';
-import * as H from '../../utils/helpers';
 import { BufferStream } from '../../utils/bufferStream';
 import { AuditFactory } from '../../audit/interface/AuditFactory';
 import { eEventKey } from '../../event/interface/EventEnums';
@@ -71,12 +70,12 @@ export class WebDAVServer {
             // port: webDAVPort
         });
         this.server.beforeRequest((ctx, next) => {
-            // LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} START`, LOG.LS.eDEBUG);
+            LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} START`, LOG.LS.eHTTP);
             next();
         });
         this.server.afterRequest((ctx, next) => {
             // Display the method, the URI, the returned status code and the returned message
-            // LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} END ${ctx.response.statusCode} ${ctx.response.statusMessage}`, LOG.LS.eDEBUG);
+            LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} END ${ctx.response.statusCode} ${ctx.response.statusMessage}`, LOG.LS.eHTTP);
             next();
         });
     }
@@ -424,8 +423,6 @@ class WebDAVFileSystem extends webdav.FileSystem {
             if (lockUUID === undefined)
                 return;
             */
-
-            const cacheStore: LocalStore | undefined = ASL.getStore();
 
             const pathS: string = pathWD.toString();
             const DP: DownloaderParser = new DownloaderParser('', pathS);

--- a/server/http/routes/WebDAVServer.ts
+++ b/server/http/routes/WebDAVServer.ts
@@ -71,14 +71,12 @@ export class WebDAVServer {
             // port: webDAVPort
         });
         this.server.beforeRequest((ctx, next) => {
-            ASL.checkLocalStore(`WebDAV:After - ${ctx.request.method} ${ctx.request.url}`);
-            LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} START`, LOG.LS.eHTTP);
+            // LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} START`, LOG.LS.eDEBUG);
             next();
         });
         this.server.afterRequest((ctx, next) => {
             // Display the method, the URI, the returned status code and the returned message
-            ASL.checkLocalStore(`WebDAV:After - ${ctx.request.method} ${ctx.request.url}`);
-            LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} END ${ctx.response.statusCode} ${ctx.response.statusMessage}`, LOG.LS.eHTTP);
+            // LOG.info(`WEBDAV ${ctx.request.method} ${ctx.request.url} END ${ctx.response.statusCode} ${ctx.response.statusMessage}`, LOG.LS.eDEBUG);
             next();
         });
     }
@@ -417,16 +415,8 @@ class WebDAVFileSystem extends webdav.FileSystem {
         releaser();
     }
 
-    // _openWriteStream?(path: webdav.Path, ctx: webdav.OpenWriteStreamInfo, callback: webdav.ReturnCallback<Writable>, callbackComplete: webdav.SimpleCallback): void {
-    //     ASL.checkLocalStore('WRAP:1');
-    //     ASL.clone(ASL.getStore(),async () => {
-    //         await this.__openWriteStream(path,ctx,callback,callbackComplete);
-    //     });
-    // }
-
     async _openWriteStream(pathWD: webdav.Path, _info: webdav.OpenWriteStreamInfo,
         callback: webdav.ReturnCallback<Writable>, callbackComplete: webdav.SimpleCallback): Promise<void> {
-        // console.trace('_openWriteStream');
 
         try {
             /*
@@ -435,7 +425,6 @@ class WebDAVFileSystem extends webdav.FileSystem {
                 return;
             */
 
-            ASL.checkLocalStore('WebDAV:1b');
             const cacheStore: LocalStore | undefined = ASL.getStore();
 
             const pathS: string = pathWD.toString();
@@ -449,13 +438,11 @@ class WebDAVFileSystem extends webdav.FileSystem {
                 return;
             }
 
-            ASL.checkLocalStore('WebDAV:2');
             // Audit upload
             const auditData = { url: `${WebDAVServer.httpRoute}${DP.requestURLV}`, auth: true };
             const auditOID: DBAPI.ObjectIDAndType = { eObjectType: DP.eObjectTypeV, idObject: DP.idObjectV };
             AuditFactory.audit(auditData, auditOID, eEventKey.eHTTPUpload);
 
-            ASL.checkLocalStore('WebDAV:3');
             const SOP: DBAPI.SystemObjectPairs | null = (DP.idSystemObjectV) ? await DBAPI.SystemObjectPairs.fetch(DP.idSystemObjectV) : null;
             const SOBased: DBAPI.SystemObjectBased | null = SOP ? SOP.SystemObjectBased : null;
             if (!SOBased) {
@@ -466,7 +453,6 @@ class WebDAVFileSystem extends webdav.FileSystem {
                 return;
             }
 
-            ASL.checkLocalStore('WebDAV:4');
             const assetVersion: DBAPI.AssetVersion | undefined = DPResults.assetVersion;
             const asset: DBAPI.Asset | null = assetVersion ? await DBAPI.Asset.fetch(assetVersion.idAsset) : null;
 
@@ -487,8 +473,7 @@ class WebDAVFileSystem extends webdav.FileSystem {
                 // await this.removeLock(pathWD, info.context, lockUUID);
                 return;
             }
-            ASL.checkLocalStore('WebDAV:5');
-            LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}), FileName ${FileName}, FilePath ${FilePath}, asset type ${COMMON.eVocabularyID[eVocab]}, SOBased ${JSON.stringify(SOBased, H.Helpers.saferStringify)}`, LOG.LS.eHTTP);
+            // LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}), FileName ${FileName}, FilePath ${FilePath}, asset type ${COMMON.eVocabularyID[eVocab]}, SOBased ${JSON.stringify(SOBased, H.Helpers.saferStringify)}`, LOG.LS.eHTTP);
 
             const LS: LocalStore = await ASL.getOrCreateStore();
             const idUserCreator: number = LS?.idUser ?? 0;
@@ -502,10 +487,8 @@ class WebDAVFileSystem extends webdav.FileSystem {
             // BS.on('drain', async () => { LOG.info(`WebDAVFileSystem._openWriteStream: (W) onDrain for ${asset ? JSON.stringify(asset, H.Helpers.saferStringify) : 'new asset'}`, LOG.LS.eHTTP); });
             // BS.on('close', async () => { LOG.info(`WebDAVFileSystem._openWriteStream: (W) onClose for ${asset ? JSON.stringify(asset, H.Helpers.saferStringify) : 'new asset'}`, LOG.LS.eHTTP); });
             BS.on('finish', async () => {
-                console.trace('WebDAV: BufferStream');
-                ASL.checkLocalStore(`WebDAV:Fin:1 - ${cacheStore?.idRequest}`);
                 try {
-                    LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}): (W) onFinish for ${asset ? JSON.stringify(asset, H.Helpers.saferStringify) : 'new asset'}`, LOG.LS.eHTTP);
+                    // LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}): (W) onFinish for ${asset ? JSON.stringify(asset, H.Helpers.saferStringify) : 'new asset'}`, LOG.LS.eDEBUG);
                     const ISI: STORE.IngestStreamOrFileInput = {
                         readStream: BS,
                         localFilePath: null,
@@ -522,22 +505,18 @@ class WebDAVFileSystem extends webdav.FileSystem {
 
                     // Serialize access per DP.idSystemObjectV via Semaphore, allowing only 1 ingestion at a time per system object
                     const writeLock: SemaphoreInterface | undefined = await this.computeWriteLock(DP.idSystemObjectV, pathS);
-                    ASL.checkLocalStore(`WebDAV:Fin:2 - ${cacheStore?.idRequest}`);
                     if (writeLock) {
                         for (let lockAttempt = 1; lockAttempt <= 5; lockAttempt++) {
                             try {
-                                ASL.checkLocalStore('WebDAV:Fin:3');
                                 await writeLock.runExclusive(async (_value) => {
                                     try {
-                                        LOG.info(`WebDAVFileSystem._openWriteStream cached store: ${cacheStore}`,LOG.LS.eDEBUG);
-                                        LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}): (W) onFinish ingestStream START`, LOG.LS.eHTTP);
+                                        // LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}): (W) onFinish ingestStream START`, LOG.LS.DEBUG);
                                         return await this.ingestStream(ISI, pathS);
                                     } finally {
                                         await this.releaseWriteLock(DP.idSystemObjectV, pathS);
-                                        LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}): (W) onFinish ingestStream END`, LOG.LS.eHTTP);
+                                        // LOG.info(`WebDAVFileSystem._openWriteStream(${pathS}): (W) onFinish ingestStream END`, LOG.LS.eDEBUG);
                                     }
                                 });
-                                ASL.checkLocalStore('WebDAV:Fin:4');
                                 return;
                             } catch (error) {
                                 if (error === E_TIMEOUT) {
@@ -552,22 +531,17 @@ class WebDAVFileSystem extends webdav.FileSystem {
                             }
                         }
                     } else {
-                        ASL.checkLocalStore('WebDAV:Fin:3b');
                         return await this.ingestStream(ISI, pathS);
                     }
                 } catch (error) {
                     LOG.error(`WebDAVFileSystem._openWriteStream(${pathWD}) (W) onFinish`, LOG.LS.eHTTP, error);
                 } finally {
-                    ASL.checkLocalStore(`WebDAV:Fin:10 - ${cacheStore?.idRequest}`);
                     callbackComplete(undefined);
-                    ASL.checkLocalStore(`WebDAV:Fin:10b - ${cacheStore?.idRequest}`);
                 }
             });
 
             // LOG.info('WebDAVFileSystem._openWriteStream callback()', LOG.LS.eHTTP);
-            ASL.checkLocalStore(`WebDAV:11 - ${cacheStore?.idRequest}`);
             callback(undefined, BS);
-            ASL.checkLocalStore(`WebDAV:11b - ${cacheStore?.idRequest}`);
         } catch (error) {
             LOG.error(`WebDAVFileSystem._openWriteStream(${pathWD})`, LOG.LS.eHTTP, error);
         }

--- a/server/http/routes/api/generateDownloads.ts
+++ b/server/http/routes/api/generateDownloads.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as LOG from '../../../utils/logger';
+import * as DBAPI from '../../../db';
+
+import { Request, Response } from 'express';
+
+type GenDownloadsStatus = {
+    idWorkflow?: number,        // do we have a workflow/report so we can (later) jump to its status page
+    isSceneValid: boolean,      // if the referenced scene is QC'd and has basic requirements met
+    isRunning: boolean,         // is there a job already running
+    message?: string
+};
+
+type GenDownloadsResponse = {
+    success: boolean,           // was the request successful
+    message?: string,           // errors from the request|workflow to put in console or display to user
+    data?: GenDownloadsStatus
+};
+
+const generateResponse = (success: boolean, message?: string | undefined, data?: any | undefined): GenDownloadsResponse => {
+    return {
+        success,
+        message,
+        data
+    };
+};
+
+export async function generateDownloads(req: Request, res: Response): Promise<void> {
+    LOG.info('Generating Downloads from API request...', LOG.LS.eHTTP);
+
+    console.log(req.method);
+
+    // get our method to see what we should do
+    let statusOnly: boolean = true;
+    switch(req.method) {
+        case 'get': statusOnly = true; break;
+        case 'post': statusOnly = false; break;
+        default: {
+            LOG.error('API.generateDownloads failed. unsupported HTTP method',LOG.LS.eHTTP);
+            res.status(400).send(JSON.stringify(generateResponse(false,'invalid HTTP method')));
+            return;
+        }
+    }
+
+    // #region verify the status of the scene/workflow
+    // extract query param for idSystemObject
+    const idSystemObject: number = parseInt((req.query.id as string) ?? '0');
+    console.log(idSystemObject);
+    if(idSystemObject === 0) {
+        LOG.error(`API.generateDownloads failed. invalid id: ${idSystemObject}`,LOG.LS.eHTTP);
+        res.status(400).send(JSON.stringify(generateResponse(false,`invalid id parameter: ${req.query.id ?? -1}`)));
+        return;
+    }
+
+    // grab it and make sure it's a scene
+    const scene: DBAPI.Scene | null = await DBAPI.Scene.fetchBySystemObject(idSystemObject);
+    console.log(scene);
+    if(!scene) {
+        LOG.error(`API.generateDownloads failed. cannot find Scene. (id:${idSystemObject})`,LOG.LS.eHTTP);
+        res.status(400).send(JSON.stringify(generateResponse(false,`cannot find scene: ${idSystemObject}`)));
+        return;
+    }
+
+    // see if scene is valid
+    // TODO: add more checks to ensure it's safe to run generate downloads (e.g. master model good, names good, etc.)
+    const isSceneValid: boolean = (scene.PosedAndQCd)?false:true;
+    console.log(isSceneValid);
+    if(isSceneValid === false) {
+        LOG.error(`API.generateDownloads failed. scene is not QC'd. (id:${idSystemObject} | scene:${scene.idScene})`,LOG.LS.eHTTP);
+        res.status(400).send(JSON.stringify(generateResponse(false,'scene has not be QC\'d.')));
+        return;
+    }
+
+    // get any generate downloads workflows/jobs running
+    // ... const activeJobs: DBAPI.JobRun[] = await DBAPI.JobRun.fetchByType('si-generate-downloads',true);
+
+    // see if it's ours and if so, throw response
+    const isRunning: boolean = false;
+    // ...
+
+    // #endregion
+
+    // if we only want the status, we're finished and can return success
+    if(statusOnly === true) {
+        res.status(200).send(JSON.stringify(generateResponse(true,`Can generate downloads for: ${scene.Name}`,{ idWorkflow: -1, isSceneValid, isRunning })));
+        return;
+    }
+
+
+    // return success
+    res.status(200).send(JSON.stringify(generateResponse(true,`Generating Downloads for: ${scene.Name}`,{ idWorkflow: -1, isSceneValid, isRunning })));
+}

--- a/server/http/routes/api/generateDownloads.ts
+++ b/server/http/routes/api/generateDownloads.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as LOG from '../../../utils/logger';
 import * as DBAPI from '../../../db';
+// import * as COMMON from '@dpo-packrat/common';
+// import { VocabularyCache } from '../../../cache';
 
 import { Request, Response } from 'express';
 
@@ -28,11 +30,9 @@ const generateResponse = (success: boolean, message?: string | undefined, data?:
 export async function generateDownloads(req: Request, res: Response): Promise<void> {
     LOG.info('Generating Downloads from API request...', LOG.LS.eHTTP);
 
-    console.log(req.method);
-
     // get our method to see what we should do
     let statusOnly: boolean = true;
-    switch(req.method) {
+    switch(req.method.toLocaleLowerCase()) {
         case 'get': statusOnly = true; break;
         case 'post': statusOnly = false; break;
         default: {
@@ -45,7 +45,6 @@ export async function generateDownloads(req: Request, res: Response): Promise<vo
     // #region verify the status of the scene/workflow
     // extract query param for idSystemObject
     const idSystemObject: number = parseInt((req.query.id as string) ?? '0');
-    console.log(idSystemObject);
     if(idSystemObject === 0) {
         LOG.error(`API.generateDownloads failed. invalid id: ${idSystemObject}`,LOG.LS.eHTTP);
         res.status(400).send(JSON.stringify(generateResponse(false,`invalid id parameter: ${req.query.id ?? -1}`)));
@@ -54,7 +53,6 @@ export async function generateDownloads(req: Request, res: Response): Promise<vo
 
     // grab it and make sure it's a scene
     const scene: DBAPI.Scene | null = await DBAPI.Scene.fetchBySystemObject(idSystemObject);
-    console.log(scene);
     if(!scene) {
         LOG.error(`API.generateDownloads failed. cannot find Scene. (id:${idSystemObject})`,LOG.LS.eHTTP);
         res.status(400).send(JSON.stringify(generateResponse(false,`cannot find scene: ${idSystemObject}`)));
@@ -64,28 +62,50 @@ export async function generateDownloads(req: Request, res: Response): Promise<vo
     // see if scene is valid
     // TODO: add more checks to ensure it's safe to run generate downloads (e.g. master model good, names good, etc.)
     const isSceneValid: boolean = (scene.PosedAndQCd)?false:true;
-    console.log(isSceneValid);
     if(isSceneValid === false) {
         LOG.error(`API.generateDownloads failed. scene is not QC'd. (id:${idSystemObject} | scene:${scene.idScene})`,LOG.LS.eHTTP);
         res.status(400).send(JSON.stringify(generateResponse(false,'scene has not be QC\'d.')));
         return;
     }
 
+    // TODO: get our idJob from the vocabulary for COMMON.eVocabularyID.eJobJobTypeCookSIGenerateDownloads
+    // FIX: vocabulary structure/enum is returning values different than what's in the db or undefined
+    // const eVocabID: COMMON.eVocabularyID = (<any>COMMON.eVocabularyID)[COMMON.eVocabularyID.eJobJobTypeCookSIGenerateDownloads];
+    // const vocabulary: DBAPI.Vocabulary | undefined = await VocabularyCache.vocabularyByEnum(eVocabID);
+    // console.log(`vocabulary: ${eVocabID} | ${typeof(eVocabID)} | ${COMMON.eVocabularyID.eJobJobTypeCookSIGenerateDownloads} | ${typeof(COMMON.eVocabularyID.eJobJobTypeCookSIGenerateDownloads)}`);
+
+    // const jobs: DBAPI.Job[] | null = await DBAPI.Job.fetchByType(vocabulary.idVocabulary);
+    // if(!jobs) {
+    //     LOG.error(`API.generateDownloads failed. unable to find Job of correct type. (type: ${COMMON.eVocabularyID[vocabulary.idVocabulary]})`,LOG.LS.eHTTP);
+    //     res.status(400).send(JSON.stringify(generateResponse(false,'unable to find Job type')));
+    //     return;
+    // }
+
     // get any generate downloads workflows/jobs running
-    // ... const activeJobs: DBAPI.JobRun[] = await DBAPI.JobRun.fetchByType('si-generate-downloads',true);
-
-    // see if it's ours and if so, throw response
-    const isRunning: boolean = false;
-    // ...
-
+    // HACK: hardcoding the job id since vocabulary is returning different values for looking up the job
+    //       enum should provide 149, but is returning 125. The actual idJob is 8 (see above)
+    let isRunning: number = -1;
+    const activeJobs: DBAPI.JobRun[] | null = await DBAPI.JobRun.fetchByJobFiltered(8,true);
+    console.log(activeJobs);
+    if(activeJobs && activeJobs.length > 0) {
+        // see if it's ours and if so, throw response
+        for(let i=0; i< activeJobs.length; i++){
+            if(activeJobs[i].usesScene(97)) {
+                LOG.info(`API.generateDownloads found running job (${activeJobs[i].idJobRun}) for scene (${scene.idScene}).`,LOG.LS.eDEBUG);
+                isRunning = activeJobs[i].idJobRun;
+                break;
+            }
+        }
+    }
     // #endregion
 
     // if we only want the status, we're finished and can return success
     if(statusOnly === true) {
-        res.status(200).send(JSON.stringify(generateResponse(true,`Can generate downloads for: ${scene.Name}`,{ idWorkflow: -1, isSceneValid, isRunning })));
+        const message: string = (isRunning)?`Job already running (id: ${scene.idScene} | scene: ${scene.Name})`:`Job is not running but valid. (id: ${scene.idScene} | scene: ${scene.Name})`;
+        LOG.info(`API.generateDownloads ${message}`,LOG.LS.eHTTP);
+        res.status(200).send(JSON.stringify(generateResponse(true,message,{ idWorkflow: -1, isSceneValid, isRunning })));
         return;
     }
-
 
     // return success
     res.status(200).send(JSON.stringify(generateResponse(true,`Generating Downloads for: ${scene.Name}`,{ idWorkflow: -1, isSceneValid, isRunning })));

--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -181,7 +181,6 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
     }
 
     private async createSystemObjects(): Promise<H.IOResults> {
-
         // grab our Packrat Scene from the database. idScene is a parameter passed in when creating this object
 
         // grab our Packrat Scene from the database. idScene is a parameter passed in when creating this object

--- a/server/report/impl/Report.ts
+++ b/server/report/impl/Report.ts
@@ -3,15 +3,16 @@ import { WorkflowReport } from '../../db';
 import * as H from '../../utils/helpers';
 
 export class Report implements IReport {
-    private _workflowReport: WorkflowReport;
+    workflowReport: WorkflowReport;
+
     constructor(workflowReport: WorkflowReport) {
-        this._workflowReport = workflowReport;
+        this.workflowReport = workflowReport;
     }
 
     async append(content: string): Promise<H.IOResults> {
-        const seperator: string = (this._workflowReport.Data) ? '<br/>\n' : '';
-        this._workflowReport.Data += seperator + content;
-        if (await this._workflowReport.update())
+        const seperator: string = (this.workflowReport.Data) ? '<br/>\n' : '';
+        this.workflowReport.Data += seperator + content;
+        if (await this.workflowReport.update())
             return { success: true };
         return { success: false, error: 'Database error persisting WorkflowReport' };
     }

--- a/server/tests/cache/VocabularyCache.test.ts
+++ b/server/tests/cache/VocabularyCache.test.ts
@@ -86,6 +86,7 @@ function vocabularyCacheTestWorker(eMode: eCacheTestMode): void {
             for (const sVocabID in COMMON.eVocabularyID) {
                 if (!isNaN(Number(sVocabID)))
                     continue;
+
                 const eVocabID: COMMON.eVocabularyID = (<any>COMMON.eVocabularyID)[sVocabID];
                 const vocabulary: DBAPI.Vocabulary | undefined = await VocabularyCache.vocabularyByEnum(eVocabID);
                 // LOG.info(`*** sVocab=${sVocabID}, eVocabID=${COMMON.eVocabularyID[eVocabID]}, vocabulary=${JSON.stringify(vocabulary)}`, LOG.LS.eTEST);

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -539,4 +539,12 @@ export class Helpers {
         if (typeof value === 'number' && value > 0 && value < 2147483648) return true;
         return false;
     }
+
+    static getStackTrace(label: string = 'Capture Stack'): string {
+        try {
+            throw new Error(label);
+        } catch (error) {
+            return (error as Error).stack || `${label}: No stack trace available`;
+        }
+    }
 }

--- a/server/utils/localStore.ts
+++ b/server/utils/localStore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AsyncLocalStorage } from 'async_hooks';
+import { AsyncLocalStorage, AsyncResource } from 'async_hooks';
 import * as LOG from './logger';
 import * as H from './helpers';
 
@@ -122,4 +122,5 @@ export class AsyncLocalStore extends AsyncLocalStorage<LocalStore> {
     }
 }
 
+export { AsyncResource as ASR };
 export const ASL: AsyncLocalStore = new AsyncLocalStore();

--- a/server/utils/localStore.ts
+++ b/server/utils/localStore.ts
@@ -14,7 +14,7 @@ export class LocalStore {
 
     private static idRequestNext: number = 0;
     private static getIDRequestNext(): number {
-        LOG.info(`LocalStore.getIDRequestNext incrementing ID. (${LocalStore.idRequestNext}->${LocalStore.idRequestNext+1})`,LOG.LS.eDEBUG);
+        // LOG.info(`LocalStore.getIDRequestNext incrementing ID. (${LocalStore.idRequestNext}->${LocalStore.idRequestNext+1})`,LOG.LS.eDEBUG);
         return ++LocalStore.idRequestNext;
     }
 
@@ -109,12 +109,12 @@ export class AsyncLocalStore extends AsyncLocalStorage<LocalStore> {
         return LS;
     }
 
-    checkLocalStore(label: string = 'LocalStore', stackTraceOnNull: boolean = false): void {
+    checkLocalStore(label: string = 'LocalStore', logUndefined: boolean = false): void {
         label = `LocalStore [check: ${label}]`;
         LOG.info(`${label} (${H.Helpers.JSONStringify(this.getStore())})`,LOG.LS.eDEBUG);
 
         // if we don't have a store then dump the trace so we know where it came from
-        if(!this.getStore() && stackTraceOnNull===true)
+        if(!this.getStore() && logUndefined===true)
             LOG.info(`\t ${H.Helpers.getStackTrace(label)}`,LOG.LS.eDEBUG);
     }
 }

--- a/server/utils/localStore.ts
+++ b/server/utils/localStore.ts
@@ -67,11 +67,13 @@ export class AsyncLocalStore extends AsyncLocalStorage<LocalStore> {
     // we shouldn't need this routine as all LocalStore should be created when the request is first made
     // so the idRequest and idUser are consistent throughout all related operations.
     // TODO: phase out in favor of getStore().
-    async getOrCreateStore(idUser: number | undefined = undefined): Promise<LocalStore> {
+    async getOrCreateStore(idUser: number | undefined = undefined, logUse: boolean = false): Promise<LocalStore> {
         let LS: LocalStore | undefined = this.getStore();
         if (LS) {
-            LOG.info(`AsyncLocalStore.getOrCreateStore using existing store (idRequest: ${LS.idRequest} | idUser: ${LS.idUser})`,LOG.LS.eDEBUG);
-            // LOG.info(`\t ${H.Helpers.getStackTrace('AsyncLocalStore.getOrCreateStore')}`,LOG.LS.eDEBUG);
+            if(logUse===true)
+                LOG.info(`AsyncLocalStore.getOrCreateStore using existing store (idRequest: ${LS.idRequest} | idUser: ${LS.idUser})`,LOG.LS.eDEBUG);
+                // LOG.info(`\t ${H.Helpers.getStackTrace('AsyncLocalStore.getOrCreateStore')}`,LOG.LS.eDEBUG);
+
             if(!LS.idUser && idUser) {
                 LOG.error(`AsyncLocalStore.getOrCreateStore adding missing user id (idRequest: ${LS.idRequest} | idUser: ${LS.idUser})`,LOG.LS.eDEBUG);
                 LS.idUser = idUser;
@@ -81,8 +83,9 @@ export class AsyncLocalStore extends AsyncLocalStorage<LocalStore> {
 
         return new Promise<LocalStore>((resolve) => {
             LS = new LocalStore(true, idUser);
-            LOG.error(`AsyncLocalStore.getOrCreateStore creating a new store. lost context? (idRequest: ${LS.idRequest} | idUser: ${idUser})`,LOG.LS.eSYS);
-            // LOG.error(`\t${H.Helpers.getStackTrace('AsyncLocalStore.getOrCreateStore')}`,LOG.LS.eDEBUG);
+            if(logUse===true)
+                LOG.error(`AsyncLocalStore.getOrCreateStore creating a new store. lost context? (idRequest: ${LS.idRequest} | idUser: ${idUser})`,LOG.LS.eSYS);
+                // LOG.error(`\t${H.Helpers.getStackTrace('AsyncLocalStore.getOrCreateStore')}`,LOG.LS.eDEBUG);
             this.run(LS, () => { resolve(LS!); }); // eslint-disable-line @typescript-eslint/no-non-null-assertion
         });
     }

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -95,7 +95,9 @@ function configureLogger(logPath: string | null): void {
             // winston.format.json()
             // winston.format.simple(),
             winston.format.printf((info) => {
-                const LS: LocalStore | undefined = ASL.getStore();
+                // we catch if ASL is undefined (ASL?) as it will be during JEST testing
+                // otherwise it should never be undefined.
+                const LS: LocalStore | undefined = ASL?.getStore();
                 const idRequest: number | undefined = LS?.idRequest;
                 const reqID: string = idRequest ? ('00000' + (idRequest % 100000)).slice(-5) : ' --- ';
 

--- a/server/workflow/impl/Packrat/WorkflowEngine.ts
+++ b/server/workflow/impl/Packrat/WorkflowEngine.ts
@@ -9,6 +9,8 @@ import * as LOG from '../../../utils/logger';
 import * as CACHE from '../../../cache';
 import * as COMMON from '@dpo-packrat/common';
 import * as DBAPI from '../../../db';
+// import * as REP from '../../../report/interface';
+// import { Report } from '../../../report/impl/Report';
 import { NameHelpers, ModelHierarchy, UNKNOWN_NAME } from '../../../utils/nameHelpers';
 import { ASL, LocalStore } from '../../../utils/localStore';
 import * as H from '../../../utils/helpers';
@@ -42,6 +44,7 @@ type ComputeSceneInfoResult = {
     assetVersionMTL?: DBAPI.AssetVersion | undefined;
     scene?: DBAPI.Scene | undefined;
     licenseResolver?: DBAPI.LicenseResolver | undefined;
+    units?: string | undefined;
 };
 
 export class WorkflowEngine implements WF.IWorkflowEngine {
@@ -128,6 +131,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
     }
 
     async generateSceneDownloads(idScene: number, workflowParams: WF.WorkflowParameters): Promise<WF.IWorkflow[] | null> {
+
         LOG.info(`WorkflowEngine.generateSceneDownloads working...(idScene:${idScene})`,LOG.LS.eWF);
         const scene: DBAPI.Scene | null = await DBAPI.Scene.fetch(idScene);
         if (!scene) {
@@ -147,6 +151,159 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
             return null;
         }
         return await this.eventIngestionIngestObjectScene(CSIR, workflowParams, true);
+    }
+
+    async generateDownloads(idScene: number, workflowParams: WF.WorkflowParameters): Promise<WF.WorkflowCreateResult> {
+
+        // TODO: make this it's own workflow implementation instead of a routine (e.g. WorkflowGenDownloads)
+
+        //#region get and verify scene
+        // grab our scene from the DB
+        const scene: DBAPI.Scene | null = await DBAPI.Scene.fetch(idScene);
+        if(!scene) {
+            LOG.error(`API.generateDownloads failed. cannot find Scene. (idScene:${idScene})`,LOG.LS.eHTTP);
+            return { success: false, message: 'cannot find scene' };
+        }
+
+        // get our system object
+        const sceneSO: DBAPI.SystemObject | null = await scene.fetchSystemObject();
+        if(!sceneSO) {
+            LOG.error(`WorkflowEngine.generateDownloads failed. Scene is invalid without SystemObject. (idScene: ${scene.idScene})`,LOG.LS.eWF);
+            return { success: false, message: 'cannot get SystemObject', data: { isSceneValid: false } };
+        }
+
+        // get our information about the scene
+        const CSIR: ComputeSceneInfoResult | null = await this.computeSceneInfo(scene.idScene,sceneSO.idSystemObject);
+        if(!CSIR || !CSIR.idScene || CSIR.exitEarly==true) {
+            LOG.error(`WorkflowEngine.generateDownloads failed. Scene is invalid. (idScene: ${scene.idScene})`,LOG.LS.eWF);
+            return { success: false, message: 'cannot compute scene info', data: { isSceneValid: false } };
+        }
+        LOG.info(`WorkflowEngine.generateDownloads verify scene (idScene:${CSIR.idScene} | sceneFile: ${CSIR.assetSVX?.FileName} | idModel: ${CSIR.idModel} | modelFile: ${CSIR.assetVersionGeometry?.FileName})`,LOG.LS.eDEBUG);
+
+        // make sure we have a voyager scene
+        if(!CSIR.assetSVX) {
+            LOG.error(`WorkflowEngine.generateDownloads failed. No voyager scene found (idScene: ${scene.idScene})`,LOG.LS.eWF);
+            return { success: false, message: 'no voyager scene found', data: { isSceneValid: false } };
+        }
+
+        // make sure we have a master model
+        if(!CSIR.assetVersionGeometry || !CSIR.idModel) {
+            LOG.error(`WorkflowEngine.generateDownloads failed. No master model found (idScene: ${scene.idScene})`,LOG.LS.eWF);
+            return { success: false, message: 'no master model found', data: { isSceneValid: false } };
+        }
+
+        // make sure we can run the recipe (valid scene, not running, etc)
+        if(scene.PosedAndQCd === false) {
+            LOG.error(`WorkflowEngine.generateDownloads failed. Scene is invalid. (idScene: ${scene.idScene})`,LOG.LS.eWF);
+            return { success: false, message: 'not posed or QC\'d', data: { isSceneValid: false } };
+        }
+        const isSceneValid: boolean = true;
+        //#endregion
+
+        //#region check for duplicate jobs
+        // make sure we don't have any jobs running. >0 if a running job was found.
+        const activeJobs: DBAPI.JobRun[] | null = await DBAPI.JobRun.fetchActiveByScene(8,scene.idScene);
+        if(!activeJobs) {
+            LOG.error(`WorkflowEngine.generateDownloads failed. cannot determine if job is running. (idScene: ${scene.idScene})`,LOG.LS.eWF);
+            return { success: false, message: 'failed to get acti e jobs from DB', data: { isSceneValid: false } };
+        }
+
+        // if we're running, we don't duplicate our efforts
+        // TODO: allow for cancelling/overwritting existing jobs
+        const idActiveJobRun: number[] = activeJobs.map(job => job.idJobRun);
+        if(activeJobs.length > 0) {
+            LOG.info(`WorkflowEngine.generateDownloads did not start. Job already running (idScene: ${scene.idScene} | activeJobRun: ${idActiveJobRun.join(',')}}).`,LOG.LS.eWF);
+            return { success: false, message: 'Job already running', data: { isSceneValid: true, activeJobs } };
+        }
+        //#endregion
+
+        //#region get system objects to act on
+        const SOGeometry: DBAPI.SystemObject| null = await CSIR.assetVersionGeometry.fetchSystemObject();
+        if (!SOGeometry) {
+            LOG.error(`WorkflowEngine.eventIngestionIngestObjectScene unable to compute geometry file systemobject from ${JSON.stringify(CSIR.assetVersionGeometry, H.Helpers.saferStringify)}`, LOG.LS.eWF);
+            return { success: false, message: 'cannot get SystemObject for geometry file', data: { isSceneValid: false, activeJobs } };
+        }
+        const idSystemObject: number[] = [SOGeometry.idSystemObject];
+
+        const SOSVX: DBAPI.SystemObject| null = CSIR.assetSVX ? await CSIR.assetSVX.fetchSystemObject() : null;
+        if (!SOSVX) {
+            LOG.error(`WorkflowEngine.eventIngestionIngestObjectScene unable to compute scene file systemobject from ${JSON.stringify(CSIR.assetSVX, H.Helpers.saferStringify)}`, LOG.LS.eWF);
+            return { success: false, message: 'cannot get SystemObject for voyager scene file', data: { isSceneValid: false, activeJobs } };
+        }
+        idSystemObject.push(SOSVX.idSystemObject);
+
+        const SODiffuse: DBAPI.SystemObject| null = CSIR.assetVersionDiffuse ? await CSIR.assetVersionDiffuse.fetchSystemObject() : null;
+        if (SODiffuse)
+            idSystemObject.push(SODiffuse.idSystemObject);
+
+        const SOMTL: DBAPI.SystemObject| null = CSIR.assetVersionMTL ? await CSIR.assetVersionMTL.fetchSystemObject() : null;
+        if (SOMTL)
+            idSystemObject.push(SOMTL.idSystemObject);
+        //#endregion
+
+        // build our base names
+        const { sceneBaseName, modelBaseName } = await WorkflowEngine.computeSceneAndModelBaseNames(CSIR.idModel, CSIR.assetVersionGeometry.FileName);
+        LOG.info(`WorkflowEngine.generateDownloads comput names (sceneBaseName: ${sceneBaseName} | modelBaseName: ${modelBaseName})`,LOG.LS.eDEBUG);
+
+        // #region build our scene parameters
+        const parameterHelper: COOK.JobCookSIVoyagerSceneParameterHelper | null = await COOK.JobCookSIVoyagerSceneParameterHelper.compute(CSIR.idModel);
+        if(parameterHelper==null) {
+            LOG.error(`WorkflowEngine.generateDownloads cannot create workflow parameters\n(CSIR:${H.Helpers.JSONStringify(CSIR)})`, LOG.LS.eWF);
+            return { success: false, message: 'cannot create workflow parameters', data: { isSceneValid, activeJobs } };
+        }
+
+        // create our parameters for generating downloads job
+        const jobParamSIGenerateDownloads: WFP.WorkflowJobParameters =
+            new WFP.WorkflowJobParameters(COMMON.eVocabularyID.eJobJobTypeCookSIGenerateDownloads,
+                new COOK.JobCookSIGenerateDownloadsParameters(CSIR.idScene, CSIR.idModel, CSIR.assetVersionGeometry.FileName,
+                    CSIR.assetSVX.FileName, CSIR.assetVersionDiffuse?.FileName, CSIR.assetVersionMTL?.FileName, sceneBaseName, CSIR.units, undefined, parameterHelper ));
+
+        // get our project for this scene.
+        // if no project found then have integrity issue and should not make things by creating additional assets
+        const sceneProjects: DBAPI.Project[] | null = await DBAPI.Project.fetchFromScene(scene.idScene);
+        if(!sceneProjects || sceneProjects.length!=1) {
+            LOG.error(`WorkflowEngine.generateDownloads cannot find project for scene. (idScene: ${scene.idScene})`, LOG.LS.eWF);
+            return { success: false, message: `cannot create workflow if scene does not have a Project (${scene.idScene})`, data: { isSceneValid, activeJobs } };
+        }
+
+        // create parameters for the workflow based on those created for the job
+        const wfParamSIGenerateDownloads: WF.WorkflowParameters = {
+            eWorkflowType: COMMON.eVocabularyID.eWorkflowTypeCookJob,
+            idSystemObject,
+            idProject: sceneProjects[0].idProject,
+            idUserInitiator: workflowParams.idUserInitiator,
+            parameters: jobParamSIGenerateDownloads,
+        };
+        LOG.info(`WorkflowEngine.generateDownloads generating downloads... (${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)})`, LOG.LS.eDEBUG);
+        return { success: true, message: 'generating downloads', data: { isSceneValid, activeJobs } };
+        //#endregion
+
+        // create our workflow
+        // const wf: WF.IWorkflow | null = await this.create(wfParamSIGenerateDownloads);
+        // if (!wf) {
+        //     LOG.error(`WorkflowEngine.generateDownloads unable to create Cook si-generate-downloads workflow: ${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)}`, LOG.LS.eWF);
+        //     return { success: false, message: 'cannot create downloads workflow', data: { isSceneValid, activeJobs } };
+        // }
+
+        // // get our Workflow object from the database
+        // const workflow: DBAPI.Workflow | null = await wf.getWorkflowObject();
+        // if(!workflow) {
+        //     LOG.error(`WorkflowEngine.generateDownloads unable to get DB object for workflow. (${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)})`, LOG.LS.eWF);
+        //     return { success: false, message: 'cannot get worfklow object', data: { isSceneValid, activeJobs } };
+        // }
+
+        // // get our workflow report for the new workflow
+        // // const report: REP.IReport | null = await REP.ReportFactory.getReport();
+        // // const workflowReport: DBAPI.WorkflowReport = (report as Report).workflowReport;
+
+        // const workflowReport: DBAPI.WorkflowReport[] | null = await DBAPI.WorkflowReport.fetchFromWorkflow(workflow.idWorkflow);
+        // if(!workflowReport || workflowReport.length <= 0) {
+        //     LOG.error(`WorkflowEngine.generateDownloads unable to get workflow report. (${workflow.idWorkflow}))`, LOG.LS.eWF);
+        //     return { success: false, message: 'cannot get worfklow object', data: { isSceneValid, activeJobs } };
+        // }
+
+        // // return success
+        // return { success: true, message: 'generating downloads', data: { isSceneValid, activeJobs, workflow, workflowReport } };
     }
 
     private async eventIngestionIngestObject(workflowParams: WF.WorkflowParameters | null): Promise<WF.IWorkflow[] | null> {
@@ -237,7 +394,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
         return workflows.length > 0 ? workflows : null;
     }
 
-    private async eventIngestionIngestObjectModel(CMIR: ComputeModelInfoResult, workflowParams: WF.WorkflowParameters, assetsIngested: boolean, generateDownloads: boolean = true): Promise<WF.IWorkflow[] | null> {
+    private async eventIngestionIngestObjectModel(CMIR: ComputeModelInfoResult, workflowParams: WF.WorkflowParameters, assetsIngested: boolean, generateDownloads: boolean = false): Promise<WF.IWorkflow[] | null> {
         if (!assetsIngested) {
             LOG.info(`WorkflowEngine.eventIngestionIngestObjectModel skipping post-ingest workflows as no assets were updated for ${JSON.stringify(CMIR, H.Helpers.saferStringify)}`, LOG.LS.eWF);
             return null;
@@ -317,6 +474,13 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
         // do we want to generate downloads for this ingestion
         if(generateDownloads===true) {
 
+            // TEMP: preventing automatic download generation
+            if(generateDownloads===true) {
+                LOG.info(`!!! WorkflowEngine.generateDownloads reached w/ ingest model. (idScene: ${CMIR.idModel})`,LOG.LS.eDEBUG);
+                console.trace('WorkflowEngine.generateDownloads');
+                return null;
+            }
+
             // does this ingested model have a scene child?  If so, initiate WorkflowJob for cook si-generate-downloads
             const SODerived: DBAPI.SystemObject[] | null = CMIR.idSystemObjectModel ? await DBAPI.SystemObject.fetchDerivedFromXref(CMIR.idSystemObjectModel) : null;
             if (!SODerived)
@@ -379,7 +543,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
         return workflows.length > 0 ? workflows : null;
     }
 
-    private async eventIngestionIngestObjectScene(CSIR: ComputeSceneInfoResult, workflowParams: WF.WorkflowParameters, assetsIngested: boolean, generateDownloads: boolean = true): Promise<WF.IWorkflow[] | null> {
+    private async eventIngestionIngestObjectScene(CSIR: ComputeSceneInfoResult, workflowParams: WF.WorkflowParameters, assetsIngested: boolean, generateDownloads: boolean = false): Promise<WF.IWorkflow[] | null> {
         if (!assetsIngested) {
             LOG.info(`WorkflowEngine.eventIngestionIngestObjectScene skipping post-ingest workflows as no assets were updated for ${JSON.stringify(CSIR, H.Helpers.saferStringify)}`, LOG.LS.eWF);
             return null;
@@ -413,8 +577,14 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
             idSystemObject.push(SOMTL.idSystemObject);
 
         // do we want to generate downloads for this scene
-        // TODO: currently always true. needs to be fed upstream from business logic
         if(generateDownloads===true) {
+
+            // TEMP: preventing automatic download generation
+            if(generateDownloads===true) {
+                LOG.info(`!!! WorkflowEngine.generateDownloads reached w/ ingest scene. (idScene: ${CSIR.idScene})`,LOG.LS.eDEBUG);
+                console.trace('WorkflowEngine.generateDownloads');
+                return null;
+            }
 
             // initiate WorkflowJob for cook si-generate-download
             const { sceneBaseName } = await WorkflowEngine.computeSceneAndModelBaseNames(CSIR.idModel, CSIR.assetVersionGeometry.FileName);
@@ -754,6 +924,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
         }
 
         // Search for master model for this scene, among "source" objects
+        // assuming Scene has models as source/parent
         const SOMasters: DBAPI.SystemObject[] | null =  await DBAPI.SystemObject.fetchMasterFromXref(idSystemObjectScene);
         if (!SOMasters) {
             LOG.error(`WorkflowEngine.computeSceneInfo unable to compute scene's master objects from system object ${JSON.stringify(idSystemObjectScene)}`, LOG.LS.eWF);
@@ -779,7 +950,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
 
         const retValue = { exitEarly: false, idScene, idModel: CMIR.idModel, idSystemObjectScene,
             assetSVX, assetVersionGeometry: CMIR.assetVersionGeometry, assetVersionDiffuse: CMIR.assetVersionDiffuse,
-            assetVersionMTL: CMIR.assetVersionMTL, scene, licenseResolver };
+            assetVersionMTL: CMIR.assetVersionMTL, scene, licenseResolver, units: CMIR.units };
         LOG.info(`WorkflowEngine.computeSceneInfo returning ${JSON.stringify(retValue, H.Helpers.saferStringify)}`, LOG.LS.eWF);
         return retValue;
     }

--- a/server/workflow/impl/Packrat/WorkflowEngine.ts
+++ b/server/workflow/impl/Packrat/WorkflowEngine.ts
@@ -275,35 +275,40 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
             parameters: jobParamSIGenerateDownloads,
         };
         LOG.info(`WorkflowEngine.generateDownloads generating downloads... (${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)})`, LOG.LS.eDEBUG);
-        return { success: true, message: 'generating downloads', data: { isSceneValid, activeJobs } };
         //#endregion
 
+        const doCreate: boolean = false;
+        if(doCreate) {
         // create our workflow
-        // const wf: WF.IWorkflow | null = await this.create(wfParamSIGenerateDownloads);
-        // if (!wf) {
-        //     LOG.error(`WorkflowEngine.generateDownloads unable to create Cook si-generate-downloads workflow: ${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)}`, LOG.LS.eWF);
-        //     return { success: false, message: 'cannot create downloads workflow', data: { isSceneValid, activeJobs } };
-        // }
+            const wf: WF.IWorkflow | null = await this.create(wfParamSIGenerateDownloads);
+            if (!wf) {
+                LOG.error(`WorkflowEngine.generateDownloads unable to create Cook si-generate-downloads workflow: ${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)}`, LOG.LS.eWF);
+                return { success: false, message: 'cannot create downloads workflow', data: { isSceneValid, activeJobs } };
+            }
 
-        // // get our Workflow object from the database
-        // const workflow: DBAPI.Workflow | null = await wf.getWorkflowObject();
-        // if(!workflow) {
-        //     LOG.error(`WorkflowEngine.generateDownloads unable to get DB object for workflow. (${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)})`, LOG.LS.eWF);
-        //     return { success: false, message: 'cannot get worfklow object', data: { isSceneValid, activeJobs } };
-        // }
+            // get our Workflow object from the database
+            const workflow: DBAPI.Workflow | null = await wf.getWorkflowObject();
+            if(!workflow) {
+                LOG.error(`WorkflowEngine.generateDownloads unable to get DB object for workflow. (${H.Helpers.JSONStringify(wfParamSIGenerateDownloads)})`, LOG.LS.eWF);
+                return { success: false, message: 'cannot get worfklow object', data: { isSceneValid, activeJobs } };
+            }
 
-        // // get our workflow report for the new workflow
-        // // const report: REP.IReport | null = await REP.ReportFactory.getReport();
-        // // const workflowReport: DBAPI.WorkflowReport = (report as Report).workflowReport;
+            // get our workflow report for the new workflow
+            // const report: REP.IReport | null = await REP.ReportFactory.getReport();
+            // const workflowReport: DBAPI.WorkflowReport = (report as Report).workflowReport;
 
-        // const workflowReport: DBAPI.WorkflowReport[] | null = await DBAPI.WorkflowReport.fetchFromWorkflow(workflow.idWorkflow);
-        // if(!workflowReport || workflowReport.length <= 0) {
-        //     LOG.error(`WorkflowEngine.generateDownloads unable to get workflow report. (${workflow.idWorkflow}))`, LOG.LS.eWF);
-        //     return { success: false, message: 'cannot get worfklow object', data: { isSceneValid, activeJobs } };
-        // }
+            const workflowReport: DBAPI.WorkflowReport[] | null = await DBAPI.WorkflowReport.fetchFromWorkflow(workflow.idWorkflow);
+            if(!workflowReport || workflowReport.length <= 0) {
+                LOG.error(`WorkflowEngine.generateDownloads unable to get workflow report. (${workflow.idWorkflow}))`, LOG.LS.eWF);
+                return { success: false, message: 'cannot get worfklow object', data: { isSceneValid, activeJobs } };
+            }
 
-        // // return success
-        // return { success: true, message: 'generating downloads', data: { isSceneValid, activeJobs, workflow, workflowReport } };
+            // return success
+            return { success: true, message: 'generating downloads', data: { isSceneValid, activeJobs, workflow, workflowReport } };
+        } else {
+            return { success: true, message: 'generating downloads', data: { isSceneValid, activeJobs } };
+        }
+
     }
 
     private async eventIngestionIngestObject(workflowParams: WF.WorkflowParameters | null): Promise<WF.IWorkflow[] | null> {

--- a/server/workflow/impl/Packrat/WorkflowIngestion.ts
+++ b/server/workflow/impl/Packrat/WorkflowIngestion.ts
@@ -2,6 +2,7 @@ import * as WF from '../../interface';
 import * as DBAPI from '../../../db';
 import * as H from '../../../utils/helpers';
 import * as COMMON from '@dpo-packrat/common';
+import * as LOG  from '../../../utils/logger';
 
 // This Workflow represents an ingestion action, typically initiated by a user.
 // The workflow itself performs no work (ingestion is performed in the graphQl ingestData routine)
@@ -55,5 +56,17 @@ export class WorkflowIngestion implements WF.IWorkflow {
 
     async workflowConstellation(): Promise<DBAPI.WorkflowConstellation | null> {
         return this.workflowData;
+    }
+
+    async getWorkflowObject(): Promise<DBAPI.Workflow | null> {
+
+        // get our constellation
+        const wfConstellation: DBAPI.WorkflowConstellation | null = await this.workflowConstellation();
+        if(!wfConstellation) {
+            LOG.error('WorkflowIngestion.getWorkflowObject failed. No constellation found. unitialized?',LOG.LS.eWF);
+            return null;
+        }
+
+        return wfConstellation.workflow;
     }
 }

--- a/server/workflow/impl/Packrat/WorkflowJob.ts
+++ b/server/workflow/impl/Packrat/WorkflowJob.ts
@@ -266,4 +266,16 @@ export class WorkflowJob implements WF.IWorkflow {
         this.idAssetVersions = WFUVersion.idAssetVersions;
         return { success: true };
     }
+
+    async getWorkflowObject(): Promise<DBAPI.Workflow | null> {
+
+        // get our constellation
+        const wfConstellation: DBAPI.WorkflowConstellation | null = await this.workflowConstellation();
+        if(!wfConstellation) {
+            LOG.error('WorkflowJob.getWorkflowObject failed. No constellation found. unitialized?',LOG.LS.eWF);
+            return null;
+        }
+
+        return wfConstellation.workflow;
+    }
 }

--- a/server/workflow/impl/Packrat/WorkflowUpload.ts
+++ b/server/workflow/impl/Packrat/WorkflowUpload.ts
@@ -249,4 +249,16 @@ export class WorkflowUpload implements WF.IWorkflow {
         this.results = { success: false, error: (this.results.error ? this.results.error + '/n' : '') + error };
         return this.results;
     }
+
+    async getWorkflowObject(): Promise<DBAPI.Workflow | null> {
+
+        // get our constellation
+        const wfConstellation: DBAPI.WorkflowConstellation | null = await this.workflowConstellation();
+        if(!wfConstellation) {
+            LOG.error('WorkflowUpload.getWorkflowObject failed. No constellation found. unitialized?',LOG.LS.eWF);
+            return null;
+        }
+
+        return wfConstellation.workflow;
+    }
 }

--- a/server/workflow/interface/IWorkflow.ts
+++ b/server/workflow/interface/IWorkflow.ts
@@ -15,4 +15,5 @@ export interface IWorkflow {
     updateStatus(eStatus: COMMON.eWorkflowJobRunStatus): Promise<WorkflowUpdateResults>;
     waitForCompletion(timeout: number): Promise<H.IOResults>;
     workflowConstellation(): Promise<DBAPI.WorkflowConstellation | null>;
+    getWorkflowObject(): Promise<DBAPI.Workflow | null>;
 }

--- a/server/workflow/interface/IWorkflowEngine.ts
+++ b/server/workflow/interface/IWorkflowEngine.ts
@@ -10,9 +10,17 @@ export interface WorkflowParameters {
     parameters?: any | undefined;                     // Additional workflow parameters; each workflow template should define their own parameter interface
 }
 
+export interface WorkflowCreateResult {
+    success: boolean;
+    message?: string | undefined;
+    workflow?: IWorkflow[] | undefined;
+    data?: any | undefined;
+}
+
 export interface IWorkflowEngine {
     create(workflowParams: WorkflowParameters): Promise<IWorkflow | null>;
     jobUpdated(idJobRun: number): Promise<boolean>;
     event(eWorkflowEvent: COMMON.eVocabularyID, workflowParams: WorkflowParameters | null): Promise<IWorkflow[] | null>;
     generateSceneDownloads(idScene: number, workflowParams: WorkflowParameters): Promise<IWorkflow[] | null>;
+    generateDownloads(idScene: number, workflowParams: WorkflowParameters): Promise<WorkflowCreateResult>;
 }


### PR DESCRIPTION
- Fixed issues with the user/request context being lost (e.g. HTTP requests, WebDAV, etc.)
- Improved logging and reports for auditing
- New button on the Scene details tab for manually (re)generating downloads. 

Note: The downloads button is enabled/disabled depending on the state of the scene and prevents creating downloads if the job is running or the scene is lacking basic requirements. (e.g. QC'd) It may require a page refresh, but the backend will prevent invalid requests with client-side toasts.