### PR TITLE
DPO3DPKRT-815/Scene details asset table too wide

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetGrid.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/AssetGrid.tsx
@@ -38,13 +38,13 @@ export const useStyles = makeStyles(({ palette }) => ({
         height: 'fit-content',
         backgroundColor: palette.secondary.light,
         paddingBottom: '5px',
-        borderBottomLeftRadius: '5px',
-        borderBottomRightRadius: '5px',
         // need to specify top radius in table container AND MuiToolbar override
-        borderTopRightRadius: '5px',
-        borderTopLeftRadius: '5px',
-        width: 'fit-content',
+        borderRadius: '5px',
+        width: '100%',
         minWidth: '400px'
+    },
+    muiTable: {
+        minWidth: '100%'
     },
     centeredTableHead: {
         '& > span': {
@@ -53,7 +53,7 @@ export const useStyles = makeStyles(({ palette }) => ({
     },
     container: {
         background: palette.secondary.light,
-        padding: 5,
+        // padding: 5,
         borderRadius: 5,
         marginBottom: 7,
         borderCollapse: 'collapse'
@@ -221,8 +221,29 @@ function AssetGrid(props: AssetGridProps): React.ReactElement {
 
     const initializeAssetGridColumnCookie = (cookieName, columns) => {
         const columnsToDisplay = {};
-        columns.forEach(column => columnsToDisplay[column.colName] = column.colDisplay);
-        document.cookie = `${cookieName}=${JSON.stringify(columnsToDisplay)};path=/;max-age=630700000`;
+
+        // initialize to core fields
+        columns.forEach(column => {
+            switch(column.colName) {
+                // 7 column table (e.g. scene details)
+                case 'link':
+                case 'name':
+                case 'assetType':
+                case 'version':
+                case 'dateCreated':
+                case 'size':
+                case 'quality':
+                case 'uvResolution':
+                case 'boundingBox':
+                    columnsToDisplay[column.colName] = true;
+                    break;
+                default:
+                    columnsToDisplay[column.colName] = false;
+            }
+            console.log(`${column.colName}:${column.colDisplay}`);
+            // columnsToDisplay[column.colName] = column.colDisplay;
+        });
+        document.cookie = `${cookieName}=${JSON.stringify(columnsToDisplay)};path=/;max-age=34560000`;
     };
 
     const getColumnsObjectByName = (cookieName) => {
@@ -418,7 +439,7 @@ function AssetGrid(props: AssetGridProps): React.ReactElement {
             <MuiThemeProvider theme={getMuiTheme()}>
                 <Box className={classes.tableContainer}>
                     {assetRows.length > 0 && (
-                        <MUIDataTable title='Assets' data={assetRows} columns={assetColumns} options={options} />
+                        <MUIDataTable title='Assets' data={assetRows} columns={assetColumns} options={options} className={classes.muiTable} />
                     )}
                     {assetRows.length === 0 && (
                         <Typography align='center' className={classes.emptyValue}>

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/index.tsx
@@ -57,10 +57,10 @@ import MetadataDisplayTable from './MetadataDisplayTable';
 
 const useStyles = makeStyles(({ palette }) => ({
     tab: {
-        backgroundColor: fade(palette.primary.main, 0.25)
+        backgroundColor: fade(palette.primary.main, 0.25),
     },
     tabpanel: {
-        backgroundColor: fade(palette.primary.main, 0.25)
+        backgroundColor: fade(palette.primary.main, 0.25),
     },
     assetOwner: {
         display: 'flex',
@@ -409,7 +409,7 @@ function DetailsTab(props: DetailsTabParams): React.ReactElement {
     }
 
     return (
-        <Box display='flex' flex={1} flexDirection='column' mt={2}>
+        <Box display='flex' flex={1} flexDirection='column' mt={2} style={{ width: '41rem' }}>
             <Tabs value={tab} classes={{ root: classes.tab }} indicatorColor='primary' textColor='primary' onChange={handleTabChange} aria-label='detailsTab'>
                 {tabs.map((tab: string, index: number) => (
                     <StyledTab key={index} label={tab} aria-label={tab} />

--- a/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
@@ -235,7 +235,6 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
             flex={1}
             flexDirection='column'
             alignItems='start'
-            maxWidth='52vw'
         >
             {objectType !== eSystemObjectType.eScene && thumbnailContent}
             {(objectType === eSystemObjectType.eScene || objectType === eSystemObjectType.eModel) && rootExplorerLink.length > 0 && documentLink.length > 0 && (


### PR DESCRIPTION
- adjusted styling and format of Asset table in Scene Details to fit the page.
- introduced better default columns to view for scene assets. still customizable. reset cookies to see.
- fixed width of voyager thumbnail to use entire width section.