### PR TITLE
DPO3DPKRT-802/large model zip failure

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
@@ -64,7 +64,7 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
     const [rootStoryLink, setRootStoryLink] = useState('');
     const [documentLink, setDocumentLink] = useState('');
     const [openVoyagerStory, setOpenVoyagerStory] = React.useState(false);
-    const [showVoyagerExplorer, setShowVoyagerExplorer] = React.useState(false);
+    const [showVoyagerExplorer, setShowVoyagerExplorer] = React.useState(true);
 
     // helper function to wait X ms
     const delay = (ms) => {

--- a/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
@@ -64,6 +64,7 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
     const [rootStoryLink, setRootStoryLink] = useState('');
     const [documentLink, setDocumentLink] = useState('');
     const [openVoyagerStory, setOpenVoyagerStory] = React.useState(false);
+    const [showVoyagerExplorer, setShowVoyagerExplorer] = React.useState(false);
 
     // helper function to wait X ms
     const delay = (ms) => {
@@ -215,6 +216,7 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
 
         // attach an event listener for Voyager 'Exit'
         await addVoyagerExitListener();
+        setShowVoyagerExplorer(false);
     };
     const handleCloseVoyagerStory = async () => {
         console.log('[PACKRAT] Closing Voyager Story...');
@@ -226,6 +228,7 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
         if(!removeVoyagerStoryElement())
             console.log('[PACKRAT: ERROR] Failed to remove Voyager Story');
 
+        setShowVoyagerExplorer(true);
         setOpenVoyagerStory(false);
     };
 
@@ -239,12 +242,14 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
             {objectType !== eSystemObjectType.eScene && thumbnailContent}
             {(objectType === eSystemObjectType.eScene || objectType === eSystemObjectType.eModel) && rootExplorerLink.length > 0 && documentLink.length > 0 && (
                 <React.Fragment>
-                    <voyager-explorer
-                        id='Voyager-Explorer'
-                        root={rootExplorerLink}
-                        document={encodeURIComponent(documentLink)}
-                        style={{ width: '100%', height: '500px', display: 'block', position: 'relative' }}
-                    />
+                    { showVoyagerExplorer && (
+                        <voyager-explorer
+                            id='Voyager-Explorer'
+                            root={rootExplorerLink}
+                            document={encodeURIComponent(documentLink)}
+                            style={{ width: '100%', height: '500px', display: 'block', position: 'relative' }}
+                        />
+                    )}
                     <Button
                         className={classes.editButton}
                         variant='contained'

--- a/server/http/routes/api/generateDownloads.ts
+++ b/server/http/routes/api/generateDownloads.ts
@@ -87,6 +87,7 @@ export async function generateDownloads(req: Request, res: Response): Promise<vo
     // if we only want the status then we need to do some quick checks ourself instead of WorkflowEngine
     if(statusOnly === true) {
         // see if scene is valid
+        // TODO: shouldn't be an error if first run by page but only when responding to user action
         const isSceneValid: boolean = (scene.PosedAndQCd)?true:false;
         if(isSceneValid === false) {
             LOG.error(`API.generateDownloads failed. scene is not QC'd. (id:${idSystemObject} | scene:${scene.idScene})`,LOG.LS.eHTTP);

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -13,13 +13,11 @@ import * as REP from '../../../report/interface';
 import * as H from '../../../utils/helpers';
 import { eEventKey } from '../../../event/interface/EventEnums';
 import { IZip } from '../../../utils/IZip';
-// import { ZipStream } from '../../../utils/zipStream';
 import { ZipFile } from '../../../utils/zipFile';
 import { maybe, maybeString } from '../../../utils/types';
 
 import { isArray } from 'lodash';
 import * as path from 'path';
-// import tmp from 'tmp-promise';
 
 export class JobCookSIPackratInspectParameters {
     /** Specify sourceMeshStream when we have the stream for sourceMeshFile in hand (e.g. during upload fo a scene zip that contains this model) */
@@ -838,12 +836,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             LOG.info(`JobCookSIPackratInspect.fetchZip processing zip file ${RSR.fileName}`, LOG.LS.eJOB);
         }
 
-        // if (assetVersion.StorageSize <= BigInt(500 * 1024 * 1024)) {
-        //     LOG.info(`JobCookSIPackratInspect.fetchZip zip smaller than 500MB. using in-memory (assetVersion: ${assetVersion.FileName})`,LOG.LS.eDEBUG);
-        //     return new ZipStream(RSR.readStream);
-        // }
-
-        // if our zipped asset is larger than 500MB, copy it locally so that we can avoid loading the full zip into memory
+        // copy our zip locally so that we can avoid loading the full zip into memory and use ZipFile
         // This also avoids an issue we're experiencing (as of 8/1/2022) with JSZip not emitting "end" events
         // when we've fully read a (very large) zip entry with its nodeStream method
 
@@ -856,8 +849,6 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         // construct our full path with a random filename to avoid collisions
         // and then write our stream to that location.
         this.tempFilePath = path.join(Config.storage.rootStaging,'tmp', H.Helpers.randomFilename('',RSR.fileName));
-        // console.log(filePath);
-        // const tempFile: tmp.FileResult = await tmp.file({ mode: 0o666, postfix: '.zip' });
         try {
             const res: H.IOResults = await H.Helpers.writeStreamToFile(RSR.readStream, this.tempFilePath);
             if (!res.success) {
@@ -870,11 +861,6 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         } catch (err) {
             LOG.error(`JobCookSIPackratInspect.fetchZip unable to copy asset version ${assetVersion.idAssetVersion} locally to ${this.tempFilePath}`, LOG.LS.eJOB, err);
             return null;
-        } finally {
-            // LOG.info(`JobCookSIPackratInspect.fetchZip finally: ${this.tempFilePath}`,LOG.LS.eDEBUG);
-            // TODO: delete temp file
-            // H.Helpers.removeFile(filePath);
-            // await tempFile.cleanup();
         }
     }
 }

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -19,7 +19,7 @@ import { maybe, maybeString } from '../../../utils/types';
 
 import { isArray } from 'lodash';
 import * as path from 'path';
-import tmp from 'tmp-promise';
+// import tmp from 'tmp-promise';
 
 export class JobCookSIPackratInspectParameters {
     /** Specify sourceMeshStream when we have the stream for sourceMeshFile in hand (e.g. during upload fo a scene zip that contains this model) */
@@ -841,23 +841,23 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
 
         // construct our full path with a random filename to avoid collisions
         // and then write our stream to that location.
-        // const filePath: string = path.join(Config.storage.rootStaging,'tmp', H.Helpers.randomFilename('',RSR.fileName));
+        const filePath: string = path.join(Config.storage.rootStaging,'tmp', H.Helpers.randomFilename('',RSR.fileName));
         // console.log(filePath);
-        const tempFile: tmp.FileResult = await tmp.file({ mode: 0o666, postfix: '.zip' });
+        // const tempFile: tmp.FileResult = await tmp.file({ mode: 0o666, postfix: '.zip' });
         try {
-            const res: H.IOResults = await H.Helpers.writeStreamToFile(RSR.readStream, tempFile.path);
+            const res: H.IOResults = await H.Helpers.writeStreamToFile(RSR.readStream, filePath);
             if (!res.success) {
-                LOG.error(`JobCookSIPackratInspect.fetchZip unable to copy asset version ${assetVersion.idAssetVersion} locally to ${tempFile.path}: ${res.error}`, LOG.LS.eJOB);
+                LOG.error(`JobCookSIPackratInspect.fetchZip unable to copy asset version ${assetVersion.idAssetVersion} locally to ${filePath}: ${res.error}`, LOG.LS.eJOB);
                 return null;
             }
 
-            LOG.info(`JobCookSIPackratInspect.fetchZip stream stored at: ${tempFile.path} (${H.Helpers.JSONStringify(res)})`,LOG.LS.eDEBUG);
-            return new ZipFile(tempFile.path);
+            LOG.info(`JobCookSIPackratInspect.fetchZip stream stored at: ${filePath} (${H.Helpers.JSONStringify(res)})`,LOG.LS.eDEBUG);
+            return new ZipFile(filePath);
         } catch (err) {
-            LOG.error(`JobCookSIPackratInspect.fetchZip unable to copy asset version ${assetVersion.idAssetVersion} locally to ${tempFile.path}`, LOG.LS.eJOB, err);
+            LOG.error(`JobCookSIPackratInspect.fetchZip unable to copy asset version ${assetVersion.idAssetVersion} locally to ${filePath}`, LOG.LS.eJOB, err);
             return null;
         } finally {
-            LOG.info(`JobCookSIPackratInspect.fetchZip finally: ${tempFile.path}`,LOG.LS.eDEBUG);
+            LOG.info(`JobCookSIPackratInspect.fetchZip finally: ${filePath}`,LOG.LS.eDEBUG);
             // TODO: delete temp file
             // H.Helpers.removeFile(filePath);
             // await tempFile.cleanup();

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -13,7 +13,7 @@ import * as REP from '../../../report/interface';
 import * as H from '../../../utils/helpers';
 import { eEventKey } from '../../../event/interface/EventEnums';
 import { IZip } from '../../../utils/IZip';
-import { ZipStream } from '../../../utils/zipStream';
+// import { ZipStream } from '../../../utils/zipStream';
 import { ZipFile } from '../../../utils/zipFile';
 import { maybe, maybeString } from '../../../utils/types';
 
@@ -823,17 +823,17 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
 
         LOG.info(`JobCookSIPackratInspect.fetchZip fetching ZIP file (${H.Helpers.JSONStringify(assetVersion)})`,LOG.LS.eDEBUG);
         const RSR: STORE.ReadStreamResult = await STORE.AssetStorageAdapter.readAssetVersionByID(assetVersion.idAssetVersion);
-        if (!RSR.success || !RSR.readStream) { //} || !RSR.fileName) {
+        if (!RSR.success || !RSR.readStream || !RSR.fileName) {
             LOG.error(`JobCookSIPackratInspect.fetchZip unable to read asset version ${assetVersion.idAssetVersion}: ${RSR.error} (${RSR.success} | ${RSR.readStream ? true:false} | ${ RSR.fileName ? true:false})`, LOG.LS.eJOB);
             return null;
         } else {
             LOG.info(`JobCookSIPackratInspect.fetchZip processing zip file ${RSR.fileName}`, LOG.LS.eJOB);
         }
 
-        if (assetVersion.StorageSize <= BigInt(500 * 1024 * 1024)) {
-            LOG.info(`JobCookSIPackratInspect.fetchZip zip larger than 500MB. using in-memory (assetVersion: ${assetVersion.FileName})`,LOG.LS.eDEBUG);
-            return new ZipStream(RSR.readStream);
-        }
+        // if (assetVersion.StorageSize <= BigInt(500 * 1024 * 1024)) {
+        //     LOG.info(`JobCookSIPackratInspect.fetchZip zip smaller than 500MB. using in-memory (assetVersion: ${assetVersion.FileName})`,LOG.LS.eDEBUG);
+        //     return new ZipStream(RSR.readStream);
+        // }
 
         // if our zipped asset is larger than 500MB, copy it locally so that we can avoid loading the full zip into memory
         // This also avoids an issue we're experiencing (as of 8/1/2022) with JSZip not emitting "end" events

--- a/server/storage/impl/LocalStorage/LocalStorage.ts
+++ b/server/storage/impl/LocalStorage/LocalStorage.ts
@@ -109,6 +109,7 @@ export class LocalStorage implements STORE.IStorage {
             return retValue;
         }
 
+        LOG.info(`LocalStorage.writeStream writing to disk (res: ${H.Helpers.JSONStringify(res)})`,LOG.LS.eDEBUG);
         try {
             retValue.writeStream = fs.createWriteStream(res.locationPrivate);
             retValue.storageKey = res.locationPublic;

--- a/server/storage/interface/AssetStorageAdapter.ts
+++ b/server/storage/interface/AssetStorageAdapter.ts
@@ -205,6 +205,7 @@ export class AssetStorageAdapter {
         LOG.info(`AssetStorageAdapter.commitNewAssetVersion idAsset ${asset.idAsset}: ${commitWriteStreamInput.storageKey}`, LOG.LS.eSTR);
         // LOG.info(`AssetStorageAdapter.commitNewAssetVersion write stream. (${H.Helpers.JSONStringify(commitWriteStreamInput)})`, LOG.LS.eDEBUG);
 
+        // get our storage system
         const storage: IStorage | null = await StorageFactory.getInstance(); /* istanbul ignore next */
         if (!storage) {
             const error: string = 'AssetStorageAdapter.commitNewAssetVersion: Unable to retrieve Storage Implementation from StorageFactory.getInstace()';
@@ -711,7 +712,7 @@ export class AssetStorageAdapter {
         // for bulk ingest, the folder from the zip from which to extract assets is specified in asset.FilePath
         const fileID = bulkIngest ? `/${BAGIT_DATA_DIRECTORY}${assetVersion.FilePath}/` : '';
         for (const entry of (bulkIngest ? await zip.getAllEntries(null) : await zip.getJustFiles(null))) {
-            // LOG.info(`Checking ${entry} for ${fileID}`, LOG.LS.eSTR);
+            LOG.info(`Checking ${entry} for ${fileID}`, LOG.LS.eDEBUG);
             if (bulkIngest && !entry.includes(fileID)) // only process assets found in our path
                 continue;
 
@@ -735,7 +736,7 @@ export class AssetStorageAdapter {
             // Get a second readstream to that part of the zip, to reset stream position after computing the hash
             inputStream = await zip.streamContent(entry); /* istanbul ignore next */
             if (!inputStream) {
-                const error: string = `AssetStorageAdapter.ingestAssetBulkZipWorker unable to stream entry ${entry} of AssetVersion ${JSON.stringify(assetVersion, H.Helpers.saferStringify)}`;
+                const error: string = `AssetStorageAdapter.ingestAssetBulkZipWorker unable to stream entry ${entry} of AssetVersion (reset) ${JSON.stringify(assetVersion, H.Helpers.saferStringify)}`;
                 LOG.error(error, LOG.LS.eSTR);
                 if (IAR.success)
                     IAR = { success: false, error, assets, assetVersions, systemObjectVersion: null };
@@ -801,7 +802,7 @@ export class AssetStorageAdapter {
                 await DBAPI.Asset.fetchMatching(asset.idSystemObject, FileName, idVAssetType) : null;
 
             if (assetComponent) {
-                LOG.info(`AssetStorageAdapter.ingestAssetBulkZipWorker FOUND matching idSystemObject=${asset.idSystemObject}; FileName=${FileName}; FilePath=${FilePath}; idVAssetType=${idVAssetType}; assetComponent=${JSON.stringify(assetComponent, H.Helpers.saferStringify)}`, LOG.LS.eSTR);
+                LOG.info(`AssetStorageAdapter.ingestAssetBulkZipWorker FOUND matching idSystemObject:${asset.idSystemObject} (FileName: ${FileName} | FilePath:${FilePath} | idVAssetType:${idVAssetType} | assetComponent:${JSON.stringify(assetComponent, H.Helpers.saferStringify)})`, LOG.LS.eSTR);
                 // examine most recent asset version, if any; if the hash matches, avoid creating a new version
                 assetVersionComponent = await DBAPI.AssetVersion.fetchLatestFromAsset(assetComponent.idAsset);
                 if (assetVersionComponent && assetVersionComponent.StorageHash === hashResults.hash) {

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -353,6 +353,12 @@ export class Helpers {
     static async writeStreamToFile(readStream: NodeJS.ReadableStream, fileName: string): Promise<IOResults> {
         let writeStream: NodeJS.WritableStream | null = null;
         try {
+
+            // extract the directory from our path and make sure it exists
+            const dirName: string = path.dirname(fileName);
+            await Helpers.createDirectory(dirName);
+
+            // write our stream to file
             writeStream = await fs.createWriteStream(fileName);
             const retValue: IOResults = await Helpers.writeStreamToStream(readStream, writeStream);
             return retValue;


### PR DESCRIPTION
- All model uploads now using streaming for zips
- Using 'staging' for temporary files instead of system temp directories
- Fixed losing user context when uploading assets
- Removes Voyager Explorer when Story is open