### PR TITLE
DPO3DPKRT-882/Robust Cook Inspection Responses

### DIFF
--- a/server/graphql/schema/asset/resolvers/mutations/uploadAsset.ts
+++ b/server/graphql/schema/asset/resolvers/mutations/uploadAsset.ts
@@ -141,7 +141,6 @@ class UploadAssetWorker extends ResolverBase {
                     // make sure Promise resolves only one and avoid multiple calls
                     if (!isResolved) {
                         isResolved = true;
-                        console.log('>>>> uploadAsset: on resolved');
                         resolve(value);
                     }
                 };
@@ -159,12 +158,6 @@ class UploadAssetWorker extends ResolverBase {
                 });
                 fileStream.once('close', () => {
                     LOG.info('UploadAssetWorker.uploadWorker: fileStream closed.', LOG.LS.eDEBUG);
-                });
-                fileStream.on('pipe', (dest) => {
-                    LOG.info(`UploadAssetWorker.uploadWorker: fileStream piped to ${dest.constructor.name}.`, LOG.LS.eDEBUG);
-                });
-                fileStream.on('unpipe', (dest) => {
-                    LOG.info(`UploadAssetWorker.uploadWorker: fileStream unpiped from ${dest.constructor.name}.`, LOG.LS.eDEBUG);
                 });
 
                 // (write) stream callbacks for storing the transferred bytes to disk

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -256,7 +256,7 @@ export abstract class JobCook<T> extends JobPackrat {
         if(verifyResult.success===false) {
             LOG.info(`JobCook [${this.name()}] failed verification: ${verifyResult.error}`, LOG.LS.eJOB);
             this.recordFailure(`JobCook [${this.name()}] failed verification: ${verifyResult.error}`,verifyResult.error);
-            return { success: false, error: verifyResult.error, allowRetry: false }
+            return { success: false, error: verifyResult.error, allowRetry: false };
         }
 
         const res: H.IOResults = await JobCook._cookJobSempaphore.runExclusive(async (value) => {
@@ -433,7 +433,7 @@ export abstract class JobCook<T> extends JobPackrat {
                     return { success: false, allowRetry: false, connectFailure: false, otherCookError: false, error: cookJobReport['error'] };
                 }
                 case 'done': {
-                    const verifyResult: JobIOResults = await this.verifyResponse(cookJobReport); 
+                    const verifyResult: JobIOResults = await this.verifyResponse(cookJobReport);
                     if(verifyResult.success===true) {
                         this.recordSuccess(JSON.stringify(cookJobReport));
                         return { ...verifyResult, connectFailure: false, otherCookError: false };
@@ -443,7 +443,7 @@ export abstract class JobCook<T> extends JobPackrat {
                     }
                 }
                 case 'error': {
-                    const verifyResult: JobIOResults = await this.verifyResponse(cookJobReport); 
+                    const verifyResult: JobIOResults = await this.verifyResponse(cookJobReport);
                     this.recordFailure(JSON.stringify(cookJobReport),verifyResult.error);
                     return { ...verifyResult, connectFailure: false, otherCookError: false };
                 }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -250,6 +250,15 @@ export abstract class JobCook<T> extends JobPackrat {
 
     // #region JobPackrat interface
     async startJobWorker(fireDate: Date): Promise<JobIOResults> {
+
+        // make sure our properties are valid
+        const verifyResult: CookIOResults = await this.verifyRequest();
+        if(verifyResult.success===false) {
+            LOG.info(`JobCook [${this.name()}] failed verification: ${verifyResult.error}`, LOG.LS.eJOB);
+            this.recordFailure(`JobCook [${this.name()}] failed verification: ${verifyResult.error}`,verifyResult.error);
+            return { success: false, error: verifyResult.error, allowRetry: false }
+        }
+
         const res: H.IOResults = await JobCook._cookJobSempaphore.runExclusive(async (value) => {
             LOG.info(`JobCook [${this.name()}] starting job; semaphore count ${value}`, LOG.LS.eJOB);
             return this.startJobWorkerInternal(fireDate);
@@ -272,8 +281,7 @@ export abstract class JobCook<T> extends JobPackrat {
                 try {
                     LOG.info(`JobCook [${this.name()}] creating job: ${requestUrl} body ${JSON.stringify(jobCookPostBody, H.Helpers.saferStringify)}`, LOG.LS.eJOB);
                     const axiosResponse: AxiosResponse<any> | null = await axios.post(encodeURI(requestUrl), jobCookPostBody);
-
-                    console.log(`>>>> Inspect: JobCook: create job axios response (${H.Helpers.JSONStringify(axiosResponse)})`);
+                    // LOG.info(`JobCook.startJobWorkerInternal: create job axios response (${H.Helpers.JSONStringify(axiosResponse)})`,LOG.LS.eDEBUG);
 
                     if (axiosResponse?.status === 201) {
                         LOG.info(`JobCook [${this.name()}] creating job: ${requestUrl} successful post response (${axiosResponse.status}:${axiosResponse.statusText} - ${axiosResponse.data}`,LOG.LS.eJOB);
@@ -317,8 +325,7 @@ export abstract class JobCook<T> extends JobPackrat {
                 try {
                     LOG.info(`JobCook [${this.name()}] starting job: ${requestUrl}`, LOG.LS.eJOB);
                     const axiosResponse = await axios.patch(encodeURI(requestUrl));
-
-                    console.log(`>>>> Inspect: JobCook: start job axios response (${H.Helpers.JSONStringify(axiosResponse)})`);
+                    // LOG.info(`JobCook.startJobWorkerInternal: start job axios response (${H.Helpers.JSONStringify(axiosResponse)})`,LOG.LS.eDEBUG);
 
                     if (axiosResponse.status >= 200 && axiosResponse.status <= 299) {
                         LOG.info(`JobCook [${this.name()}] starting job: ${requestUrl} successful response (${axiosResponse.status}:${axiosResponse.statusText})`,LOG.LS.eJOB);
@@ -392,8 +399,7 @@ export abstract class JobCook<T> extends JobPackrat {
         const requestUrl: string = this.CookServerURL() + `clients/${this._configuration.clientId}/jobs/${this._configuration.jobId}/report`;
         try {
             const axiosResponse = await axios.get(encodeURI(requestUrl));
-
-            console.log(`>>>> Inspect: JobCook: polling job axios response (${H.Helpers.JSONStringify(axiosResponse)})`);
+            // LOG.info(`JobCook.pollingCallback: polling job axios response (${H.Helpers.JSONStringify(axiosResponse)})`,LOG.LS.eDEBUG);
 
             if (axiosResponse.status < 200 || axiosResponse.status > 299) {
                 // only log errors after first attempt, as job creation may not be complete on Cook server
@@ -422,12 +428,27 @@ export abstract class JobCook<T> extends JobPackrat {
                 case 'created':     await this.recordCreated();                                                         break;
                 case 'waiting':     await this.recordWaiting();                                                         break;
                 case 'running':     await this.recordStart(cookJobID);                                                  break;
-                case 'done':        await this.recordSuccess(JSON.stringify(cookJobReport));                            return { success: true, allowRetry: false, connectFailure: false, otherCookError: false };
-                case 'error':       await this.recordFailure(JSON.stringify(cookJobReport), cookJobReport['error']);    return { success: false, allowRetry: false, connectFailure: false, otherCookError: false, error: cookJobReport['error'] };
-                case 'cancelled':   await this.recordCancel(JSON.stringify(cookJobReport), cookJobReport['error']);     return { success: false, allowRetry: false, connectFailure: false, otherCookError: false, error: cookJobReport['error'] };
+                case 'cancelled': {
+                    await this.recordCancel(JSON.stringify(cookJobReport), cookJobReport['error']);
+                    return { success: false, allowRetry: false, connectFailure: false, otherCookError: false, error: cookJobReport['error'] };
+                }
+                case 'done': {
+                    const verifyResult: JobIOResults = await this.verifyResponse(cookJobReport); 
+                    if(verifyResult.success===true) {
+                        this.recordSuccess(JSON.stringify(cookJobReport));
+                        return { ...verifyResult, connectFailure: false, otherCookError: false };
+                    } else {
+                        this.recordFailure(JSON.stringify(cookJobReport),verifyResult.error);
+                        return { ...verifyResult, connectFailure: false, otherCookError: false };
+                    }
+                }
+                case 'error': {
+                    const verifyResult: JobIOResults = await this.verifyResponse(cookJobReport); 
+                    this.recordFailure(JSON.stringify(cookJobReport),verifyResult.error);
+                    return { ...verifyResult, connectFailure: false, otherCookError: false };
+                }
             }
-
-            LOG.info(`>>>> Inspect: JobCook: job ${cookJobReport['state']} report\n${H.Helpers.JSONStringify(cookJobReport)}`,LOG.LS.eJOB);
+            // LOG.info(`JobCook.pollingCallback: job ${cookJobReport['state']} report\n${H.Helpers.JSONStringify(cookJobReport)}`,LOG.LS.eDEBUG);
 
             // we always update our output so it represents the latest from Cook
             // TODO: measure performance and wrap into staggered updates if needed
@@ -437,6 +458,21 @@ export abstract class JobCook<T> extends JobPackrat {
             return this.handleRequestException(err, requestUrl, 'get', undefined);
         }
         return { success: false, allowRetry: true, connectFailure: false, otherCookError: false };
+    }
+
+    protected async verifyRequest(): Promise<CookIOResults> {
+        // make sure our request is valid before sending to Cook
+        return { success: true, allowRetry: false, connectFailure: false, otherCookError: false };
+    }
+
+    protected async verifyResponse(cookJobReport: any): Promise<JobIOResults> {
+        // verify the response received from Cook, checking the report and job details
+        if(cookJobReport['state']==='error') {
+            return { success: false, allowRetry: false, error: cookJobReport['error'] };
+        }
+
+        // we made it here so the job appears successful
+        return { success: true };
     }
 
     protected async fetchFile(fileName: string): Promise<STORE.ReadStreamResult> {
@@ -459,7 +495,7 @@ export abstract class JobCook<T> extends JobPackrat {
                 // TODO: more robust support with alt type
                 // const stat = await webdavClient.stat(destination);
                 // const fileSize = (stat as FileStat).size;
-                // LOG.info(`>>>> fetchFile file size: ${fileSize} | ${destination}`,LOG.LS.eDEBUG);
+                // LOG.info(`fetchFile file size: ${fileSize} | ${destination}`,LOG.LS.eDEBUG);
                 // if(fileSize <= 0)
                 //     throw new Error(`destination file doesn't exist or is empty. (${fileSize} bytes | ${destination})`);
 

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -329,7 +329,7 @@ export class JobCookSIPackratInspectOutput implements H.IOResults {
         // if we have merged reports (legacy inspection) use it, otherwise use the 'inspect-mesh' stage
         // const mergeReport: any = steps ? steps['merge-reports'] : undefined;
         const mergeReport: any = steps?.['merged-reports'] ?? steps?.['inspect-mesh'];
-        
+
         // extract meaningful sections of the report for analysis
         const inspection: any = mergeReport?.result?.inspection;
         const meshes: any[] | undefined = inspection?.meshes;
@@ -875,7 +875,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
     }
 
     protected async verifyRequest(): Promise<JobIOResults> {
-        const superResult:JobIOResults = await super.verifyRequest();
+        const superResult: JobIOResults = await super.verifyRequest();
         if(superResult.success===false) {
             this.appendToReportAndLog(`[CookJob:Inspection] request is invalid. ${superResult.error} (${this.parameters.sourceMeshFile})`);
             return superResult;
@@ -902,12 +902,12 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         // make sure we have logs. we use 'inspect-mesh' even for legacy since legacy 'merged-reports'
         // does not consolidate the log messages.
         if(!cookJobReport.steps['inspect-mesh'] || !cookJobReport.steps['inspect-mesh'].log) {
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. missing inspect-mesh and/or log objects`);
+            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. missing inspect-mesh and/or log objects');
             return { success: false, error: 'missing log objects in Cook report', allowRetry: false };
         }
         const logs = cookJobReport.steps['inspect-mesh'].log;
 
-        const superResult:JobIOResults = await super.verifyResponse(cookJobReport);
+        const superResult: JobIOResults = await super.verifyResponse(cookJobReport);
         if(superResult.success===false) {
             // check for known issues and improve error message returned
             if(superResult.error?.includes('Tool Blender: terminated with code: 1')===true) {
@@ -923,35 +923,35 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
 
         // check for ZIP processing errors
         if(logContains(logs,'Error: Unsupported file type: .zip')===true) {
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. Zip package incomplete or corrupt.`);
+            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Zip package incomplete or corrupt.');
             return { success: false, error: 'Zip package incomplete or corrupt.', allowRetry: false };
         }
-        
+
         // check for missing material
         if(logContains(logs,'OBJ import: cannot read from MTL file')===true) {
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. Referenced material not found.`);
+            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Referenced material not found.');
             return { success: false, error: 'Referenced material not found.', allowRetry: false };
         }
-        
+
         // get our 'root' for properties supporting legacy and modern inspection reports for stats
         const inspectionRoot: any = cookJobReport.steps?.['merged-reports'] ?? cookJobReport.steps?.['inspect-mesh']?.result?.inspection;
 
         // get our geometry results
         if (!inspectionRoot?.meshes) {
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. Missing meshes in inspection result.`);
+            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Missing meshes in inspection result.');
             return { success: false, error: 'Missing meshes in Cook report', allowRetry: false };
         }
 
         // check for invalid bounding box
         const sizeSum = inspectionRoot.scene.geometry.size.reduce((acc, num) => acc + num, 0);
         if(sizeSum <= 0) {
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. Mesh size is zero.`);
+            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Mesh size is zero.');
             return { success: false, error: 'Invalid mesh. Size is zero.', allowRetry: false };
         }
 
         // check for invalid geometry counts
         if(inspectionRoot.scene.statistics.numFaces<=0 || inspectionRoot.scene.statistics.numVertices<=0 || inspectionRoot.scene.statistics.numEdges<=0 || inspectionRoot.scene.statistics.numTriangles<=0 || logContains(logs,'Invalid vertex index')===true) {
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. Mesh missing vertices and/or faces.`);
+            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Mesh missing vertices and/or faces.');
             return { success: false, error: 'Invalid mesh. Missing vertices/faces.', allowRetry: false };
         }
 
@@ -959,7 +959,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         if(inspectionRoot.scene.statistics.numLinkedTextures > 0 || inspectionRoot.scene.statistics.numEmbeddedTextures > 0) {
             // NOTE: just looking at first mesh. multi-model inspection will need special handling
             if(inspectionRoot.meshes[0].statistics.hasTexCoords===false) {
-                this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. Mesh missing UVs for included texture.`);
+                this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Mesh missing UVs for included texture.');
                 return { success: false, error: 'Invalid mesh. Missing UVs for included texture.', allowRetry: false };
             }
         }

--- a/server/workflow/impl/Packrat/WorkflowEngine.ts
+++ b/server/workflow/impl/Packrat/WorkflowEngine.ts
@@ -539,7 +539,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
 
     private async eventIngestionIngestObject(workflowParams: WF.WorkflowParameters | null): Promise<WF.IWorkflow[] | null> {
         LOG.info(`WorkflowEngine.eventIngestionIngestObject params=${JSON.stringify(workflowParams)}`, LOG.LS.eWF);
-        LOG.info(H.Helpers.getStackTrace('WorkflowEngine.eventIngestionIngestObject'),LOG.LS.eDEBUG);
+        // LOG.info(H.Helpers.getStackTrace('WorkflowEngine.eventIngestionIngestObject'),LOG.LS.eDEBUG);
         if (!workflowParams || !workflowParams.idSystemObject)
             return null;
 
@@ -627,7 +627,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
     }
 
     private async eventIngestionIngestObjectModel(CMIR: ComputeModelInfoResult, workflowParams: WF.WorkflowParameters, assetsIngested: boolean, generateDownloads: boolean = false): Promise<WF.IWorkflow[] | null> {
-        LOG.info(H.Helpers.getStackTrace('WorkflowEngine.eventIngestionIngestObjectModel'),LOG.LS.eDEBUG);
+        // LOG.info(H.Helpers.getStackTrace('WorkflowEngine.eventIngestionIngestObjectModel'),LOG.LS.eDEBUG);
         if (!assetsIngested) {
             LOG.info(`WorkflowEngine.eventIngestionIngestObjectModel skipping post-ingest workflows as no assets were updated for ${JSON.stringify(CMIR, H.Helpers.saferStringify)}`, LOG.LS.eWF);
             return null;
@@ -777,7 +777,7 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
     }
 
     private async eventIngestionIngestObjectScene(CSIR: ComputeSceneInfoResult, workflowParams: WF.WorkflowParameters, assetsIngested: boolean, generateDownloads: boolean = false): Promise<WF.IWorkflow[] | null> {
-        LOG.info(H.Helpers.getStackTrace('WorkflowEngine.eventIngestionIngestObjectScene'),LOG.LS.eDEBUG);
+        // LOG.info(H.Helpers.getStackTrace('WorkflowEngine.eventIngestionIngestObjectScene'),LOG.LS.eDEBUG);
 
         if (!assetsIngested) {
             LOG.info(`WorkflowEngine.eventIngestionIngestObjectScene skipping post-ingest workflows as no assets were updated for ${JSON.stringify(CSIR, H.Helpers.saferStringify)}`, LOG.LS.eWF);


### PR DESCRIPTION
Verify model inspection results from Cook
- Fail models with invalid vertices, faces, or edges
- Fail models with invalid zip packages
- Fail models with missing materials, UVs, etc.
- Support for legacy and new Blender-centric inspection reports