### PR TITLE
DPO3DPKRT-890/UX Date Created Blocking Current Date

### DIFF
--- a/client/src/store/detailTab.tsx
+++ b/client/src/store/detailTab.tsx
@@ -632,7 +632,8 @@ const schemaCD = yup.object().shape({
 });
 
 const schemaModel = yup.object().shape({
-    dateCreated: yup.date().max(Date(), 'Date Created cannot be set in the future')
+    // ignore time from date comparison to avoid timezone issues
+    dateCreated: yup.date().max(new Date(new Date().setHours(0, 0, 0, 0)), 'Date Created cannot be set in the future')
 });
 
 const schemaItemAndSubject = yup.object().shape({


### PR DESCRIPTION
Resolve Date validation when ingesting
- Different time zones no longer affect validation results