### PR TITLE
DPO3DPKRT-906/Scene Generation Not Receiving Textures

### DIFF
--- a/client/src/store/metadata/metadata.defaults.ts
+++ b/client/src/store/metadata/metadata.defaults.ts
@@ -189,7 +189,7 @@ export const modelFieldsSchemaUpdate = yup.object().shape({
     systemCreated: yup.boolean().required(),
     uvMaps: yup.array().of(uvMapSchema),
     sourceObjects: yup.array().of(sourceObjectSchema),
-    dateCreated: yup.date().typeError('Date Created is required').max(Date(), 'Date Created cannot be set in the future'),
+    dateCreated: yup.date().typeError('Date Created is required').max(new Date().setSeconds(0,0), 'Date Created cannot be set in the future'),
     creationMethod: yup.number().typeError('Creation method is required'),
     modality: yup.number().typeError('Modality is required'),
     units: yup.number().typeError('Units is required'),


### PR DESCRIPTION
- Issue related to earlier fixed bug with long filenames in Cook
- Provided a more robust check for ingest Model date metadata