### PR TITLE
DPO3DPKRT-998/Migrate Clone to Audit Transaction

### DIFF
--- a/server/audit/withAuditTransaction.ts
+++ b/server/audit/withAuditTransaction.ts
@@ -53,12 +53,20 @@ export async function withAuditTransaction<T>(
     fn: () => Promise<T>,
     options: TransactionOptions = {},
 ): Promise<T> {
-    // Short-circuit when already inside a wrapping tx. The outer wrapper's
-    // auditBuffer accumulates emits and the outer commit flushes them; nesting
-    // a fresh Prisma $transaction inside one is not supported and would split
-    // the audit rows away from the business writes anyway.
+    // Short-circuit when an outer transaction is already active on this scope.
+    // Two flavors both qualify:
+    //   - auditBuffer set: an outer withAuditTransaction is wrapping us; its
+    //     buffer accumulates emits and the outer commit flushes them.
+    //   - transactionNumber set without auditBuffer: a legacy caller opened
+    //     its own prismaClient.$transaction and registered the tx client via
+    //     DBConnection.setPrismaTransaction (e.g. SystemObjectVersion.cloneObjectAndXrefs).
+    //     AuditFactory.emit falls through to a direct insert via DBConnection.prisma,
+    //     which resolves to that tx client, so the audit row still commits with
+    //     the business write.
+    // Either way, nesting a fresh Prisma $transaction inside an existing one
+    // is unsupported and would split audit rows away from business writes.
     const existingLS: LocalStore | undefined = ASL.getStore();
-    if (existingLS?.auditBuffer !== undefined)
+    if (existingLS?.auditBuffer !== undefined || existingLS?.transactionNumber !== undefined)
         return fn();
 
     const timeout = options.timeoutMs ?? Config.audit.txStatementTimeoutMs;

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -213,6 +213,7 @@ export const Config: ConfigType = {
             [eAuditType.eActionAccessGrant]:        AuditTier.PROTECT,
             [eAuditType.eActionAccessRevoke]:       AuditTier.PROTECT,
             [eAuditType.eActionUpload]:             AuditTier.PROTECT,
+            [eAuditType.eActionIngestFailed]:       AuditTier.PROTECT,
             // TIER_STANDARD - CRUD on meaningful business entities (routed at the entity level via logOnlyObjectTypes)
             [eAuditType.eDBCreate]:                 AuditTier.STANDARD,
             [eAuditType.eDBUpdate]:                 AuditTier.STANDARD,

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -212,6 +212,7 @@ export const Config: ConfigType = {
             [eAuditType.eActionIngest]:             AuditTier.PROTECT,
             [eAuditType.eActionAccessGrant]:        AuditTier.PROTECT,
             [eAuditType.eActionAccessRevoke]:       AuditTier.PROTECT,
+            [eAuditType.eActionUpload]:             AuditTier.PROTECT,
             // TIER_STANDARD - CRUD on meaningful business entities (routed at the entity level via logOnlyObjectTypes)
             [eAuditType.eDBCreate]:                 AuditTier.STANDARD,
             [eAuditType.eDBUpdate]:                 AuditTier.STANDARD,

--- a/server/db/api/ObjectType.ts
+++ b/server/db/api/ObjectType.ts
@@ -299,6 +299,7 @@ export enum eAuditType {
     eActionAccessRevoke = 114,
     eActionSystemMaintenance = 115,
     eActionUpload = 116,
+    eActionIngestFailed = 117,
 }
 
 export function LicenseRestrictLevelToPublishedStateEnum(restrictLevel: number): COMMON.ePublishedState {

--- a/server/db/api/ObjectType.ts
+++ b/server/db/api/ObjectType.ts
@@ -298,6 +298,7 @@ export enum eAuditType {
     eActionAccessGrant = 113,
     eActionAccessRevoke = 114,
     eActionSystemMaintenance = 115,
+    eActionUpload = 116,
 }
 
 export function LicenseRestrictLevelToPublishedStateEnum(restrictLevel: number): COMMON.ePublishedState {

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -4,7 +4,6 @@ import { SystemObject, SystemObjectBased } from '..';
 import * as DBC from '../connection';
 import * as H from '../../utils/helpers';
 import { RecordKeeper as RK } from '../../records/recordKeeper';
-import { eEventKey } from '../../event/interface/EventEnums';
 import { AuditFactory } from '../../audit/interface/AuditFactory';
 import { eAuditType } from './ObjectType';
 import * as COMMON from '@dpo-packrat/common';
@@ -82,16 +81,14 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
 
             // Audit if someone marks this scene as QC'd
             if (ApprovedForPublication) {
-                this.audit(eEventKey.eSceneQCd); // don't await, allow this to continue asynchronously
-                AuditFactory.emitSemantic({
+                await AuditFactory.emitSemantic({
                     action: eAuditType.eActionApproveForPublication,
                     target: { idObject: this.idScene, eObjectType: COMMON.eSystemObjectType.eScene },
                     payload: { before: { ApprovedForPublication: false }, after: { ApprovedForPublication: true } },
                 });
             }
             if (PosedAndQCd) {
-                this.audit(eEventKey.eSceneQCd); // don't await, allow this to continue asynchronously
-                AuditFactory.emitSemantic({
+                await AuditFactory.emitSemantic({
                     action: eAuditType.eActionPoseAndQC,
                     target: { idObject: this.idScene, eObjectType: COMMON.eSystemObjectType.eScene },
                     payload: { before: { PosedAndQCd: false }, after: { PosedAndQCd: true } },
@@ -122,8 +119,7 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
 
             // Audit if someone marks this scene as QC'd
             if (ApprovedForPublication && !ApprovedForPublicationOrig) {
-                this.audit(eEventKey.eSceneQCd); // don't await, allow this to continue asynchronously
-                AuditFactory.emitSemantic({
+                await AuditFactory.emitSemantic({
                     action: eAuditType.eActionApproveForPublication,
                     target: { idObject: idScene, eObjectType: COMMON.eSystemObjectType.eScene },
                     payload: {
@@ -133,8 +129,7 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
                 });
             }
             if (PosedAndQCd && !PosedAndQCdOrig) {
-                this.audit(eEventKey.eSceneQCd); // don't await, allow this to continue asynchronously
-                AuditFactory.emitSemantic({
+                await AuditFactory.emitSemantic({
                     action: eAuditType.eActionPoseAndQC,
                     target: { idObject: idScene, eObjectType: COMMON.eSystemObjectType.eScene },
                     payload: {

--- a/server/db/api/SystemObjectVersion.ts
+++ b/server/db/api/SystemObjectVersion.ts
@@ -1,10 +1,11 @@
 /* eslint-disable camelcase */
-import { PrismaClient, SystemObjectVersion as SystemObjectVersionBase } from '@prisma/client';
+import { SystemObjectVersion as SystemObjectVersionBase } from '@prisma/client';
 import { SystemObjectVersionAssetVersionXref } from '..';
 import * as COMMON from '@dpo-packrat/common';
 import * as DBC from '../connection';
 import * as H from '../../utils/helpers';
 import { RecordKeeper as RK } from '../../records/recordKeeper';
+import { withAuditTransaction } from '../../audit/withAuditTransaction';
 
 export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> implements SystemObjectVersionBase {
     idSystemObjectVersion!: number;
@@ -140,95 +141,65 @@ export class SystemObjectVersion extends DBC.DBObject<SystemObjectVersionBase> i
         if (!idSystemObject)
             return null;
         try {
-            const prismaClient: PrismaClient | DBC.PrismaClientTrans = DBC.DBConnection.prisma;
-            // if our current prisma client does not have the $transaction method, then we're in a transaction already, so just do the work
-            /* istanbul ignore next */
-            if (!DBC.DBConnection.isFullPrismaClient(prismaClient))
-                return SystemObjectVersion.cloneObjectAndXrefsTrans(idSystemObject, idSystemObjectVersion, Comment, assetVersionOverrideMap, assetsUnzipped);
+            return await withAuditTransaction(async () => {
+                try {
+                    let assetVersionMap: Map<number, number> | null = null;
+                    if (idSystemObjectVersion)
+                        assetVersionMap = await SystemObjectVersionAssetVersionXref.fetchAssetVersionMap(idSystemObjectVersion);
+                    else if (!assetsUnzipped)
+                        assetVersionMap = await SystemObjectVersionAssetVersionXref.fetchLatestAssetVersionMap(idSystemObject); /* istanbul ignore next */
+                    else // unzipped assets -- don't use old asset versions; the unzipped assets will be our full set of assets
+                        assetVersionMap = new Map<number, number>();
 
-            // set our options for all transactions. these timeout values help with situations
-            // where concurrent requests to the DB take longer than expected. (in ms)
-            const transactionOptions = {
-                maxWait: 10000, // how long Prisma will wait to get a connection (default: 2000)
-                timeout: 20000  // how long an interactive transaction can take (default: 5000)
-                // isolationLevel: Prisma.TransactionIsolationLevel.Serializable, // how much concurrency is allowed 'serializable' is most strict (default: RepeatableRead)
-            };
+                    /* istanbul ignore next */
+                    if (!assetVersionMap) {
+                        RK.logError(RK.LogSection.eDB,'clone object and xrefs failed',`unable to fetch assetVersionMap from idSystemObject ${idSystemObject}, idSystemObjectVersion ${idSystemObjectVersion}`,{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
+                        return null;
+                    }
 
-            // otherwise, start a new transaction:
-            // LOG.info('DBAPI.SystemObjectVersion.cloneObjectAndXrefs starting a new DB transaction', LOG.LS.eDB);
-            return await prismaClient.$transaction(async (prisma) => {
-                const transactionNumber: number = await DBC.DBConnection.setPrismaTransaction(prisma);
-                const retValue: SystemObjectVersion | null = await SystemObjectVersion.cloneObjectAndXrefsTrans(idSystemObject, idSystemObjectVersion, Comment, assetVersionOverrideMap, assetsUnzipped);
-                DBC.DBConnection.clearPrismaTransaction(transactionNumber);
-                return retValue;
-            },transactionOptions);
+                    const SOV: SystemObjectVersion = new SystemObjectVersion({
+                        idSystemObjectVersion: 0,
+                        idSystemObject,
+                        PublishedState: COMMON.ePublishedState.eNotPublished,
+                        DateCreated: new Date(),
+                        Comment
+                    }); /* istanbul ignore next */
+
+                    if (!await SOV.create()) {
+                        RK.logError(RK.LogSection.eDB,'clone object and xrefs failed',`failed to create new SystemObjectVersion for ${idSystemObject}`,{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
+                        return null;
+                    }
+
+                    if (assetVersionOverrideMap) {
+                        for (const [idAsset, idAssetVersion] of assetVersionOverrideMap)
+                            assetVersionMap.set(idAsset, idAssetVersion);
+                    }
+
+                    let success: boolean = true;
+                    for (const idAssetVersion of assetVersionMap.values()) {
+                        /* istanbul ignore else */
+                        if (idAssetVersion) {
+                            const SOVAVX: SystemObjectVersionAssetVersionXref = new SystemObjectVersionAssetVersionXref({
+                                idSystemObjectVersionAssetVersionXref: 0,
+                                idSystemObjectVersion: SOV.idSystemObjectVersion,
+                                idAssetVersion
+                            });
+                            success = await SOVAVX.create() && success;
+                        }
+                    } /* istanbul ignore next */
+
+                    if (!success) {
+                        RK.logError(RK.LogSection.eDB,'clone object and xrefs failed',`failed to create all SystemObjectVersionAssetVersionXref's for ${JSON.stringify(SOV)}`,{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
+                        return null;
+                    }
+                    return SOV;
+                } catch (error) /* istanbul ignore next */ {
+                    RK.logError(RK.LogSection.eDB,'clone object and xrefs failed',H.Helpers.getErrorString(error),{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
+                    return null;
+                }
+            }, { timeoutMs: 20000 });
         } catch (error) /* istanbul ignore next */ {
             RK.logError(RK.LogSection.eDB,'clone object and xrefs failed',H.Helpers.getErrorString(error),{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
-            return null;
-        }
-    }
-
-    private static async cloneObjectAndXrefsTrans(idSystemObject: number, idSystemObjectVersion: number | null,
-        Comment: string | null, assetVersionOverrideMap?: Map<number, number> | undefined, assetsUnzipped?: boolean | undefined): Promise<SystemObjectVersion | null> {
-        try {
-            // LOG.info(`DBAPI.SystemObjectVersion.cloneObjectAndXrefsTrans(${idSystemObject}, ${idSystemObjectVersion}, ${JSON.stringify(assetVersionOverrideMap, H.Helpers.saferStringify)})`, LOG.LS.eDB);
-            // fetch latest SystemObjectVerion's mapping of idAsset -> idAssetVersion
-            let assetVersionMap: Map<number, number> | null = null;
-            if (idSystemObjectVersion)
-                assetVersionMap = await SystemObjectVersionAssetVersionXref.fetchAssetVersionMap(idSystemObjectVersion);
-            else if (!assetsUnzipped)
-                assetVersionMap = await SystemObjectVersionAssetVersionXref.fetchLatestAssetVersionMap(idSystemObject); /* istanbul ignore next */
-            else // unzipped assets -- don't use old asset versions; the unzipped assets will be our full set of assets
-                assetVersionMap = new Map<number, number>();
-
-            /* istanbul ignore next */
-            if (!assetVersionMap) {
-                RK.logError(RK.LogSection.eDB,'clone object and xrefs trans failed',`unable to fetch assetVersionMap from idSystemObject ${idSystemObject}, idSystemObjectVersion ${idSystemObjectVersion}`,{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
-                return null;
-            }
-
-            // create new SystemObjectVersion
-            const SOV: SystemObjectVersion = new SystemObjectVersion({
-                idSystemObjectVersion: 0,
-                idSystemObject,
-                PublishedState: COMMON.ePublishedState.eNotPublished,
-                DateCreated: new Date(),
-                Comment
-            }); /* istanbul ignore next */
-
-            if (!await SOV.create()) {
-                RK.logError(RK.LogSection.eDB,'clone object and xrefs trans failed',`failed to create new SystemObjectVersion for ${idSystemObject}`,{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
-                return null;
-            }
-
-            // apply overrides, specifying asset versions for specific assets
-            if (assetVersionOverrideMap) {
-                for (const [idAsset, idAssetVersion] of assetVersionOverrideMap)
-                    assetVersionMap.set(idAsset, idAssetVersion);
-            }
-
-            // Create new xref records for these asset versions:
-            let success: boolean = true;
-            for (const idAssetVersion of assetVersionMap.values()) {
-                /* istanbul ignore else */
-                if (idAssetVersion) {
-                    const SOVAVX: SystemObjectVersionAssetVersionXref = new SystemObjectVersionAssetVersionXref({
-                        idSystemObjectVersionAssetVersionXref: 0,
-                        idSystemObjectVersion: SOV.idSystemObjectVersion,
-                        idAssetVersion
-                    });
-                    success = await SOVAVX.create() && success;
-                }
-                // LOG.info(`DBAPI.SystemObjectVersion.cloneObjectAndXrefsTrans(${idSystemObject}, ${idSystemObjectVersion}) created ${JSON.stringify(SOVAVX, H.Helpers.saferStringify)})`, LOG.LS.eDB);
-            } /* istanbul ignore next */
-
-            if (!success) {
-                RK.logError(RK.LogSection.eDB,'clone object and xrefs trans failed',`failed to create all SystemObjectVersionAssetVersionXref's for ${JSON.stringify(SOV)}`,{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
-                return null;
-            }
-            return SOV;
-        } catch (error) /* istanbul ignore next */ {
-            RK.logError(RK.LogSection.eDB,'clone object and xrefs trans failed',H.Helpers.getErrorString(error),{ idSystemObject, idSystemObjectVersion },'DB.SystemObject.Version');
             return null;
         }
     }

--- a/server/db/connection/DBObject.ts
+++ b/server/db/connection/DBObject.ts
@@ -60,11 +60,13 @@ export abstract class DBObject<T> {
             // Each attempt is its own tx so the business write + buffered
             // audit row commit atomically. withAuditTransaction is idempotent:
             // when an outer wrapper is active, this short-circuits and the
-            // outer commit flushes the audit row.
+            // outer commit flushes the audit row. A false from this.audit
+            // fails the wrap so the business write rolls back rather than
+            // committing with a missing audit row.
             const ok = await withAuditTransaction(async () => {
                 if (!await this.createWorker()) return false;
                 this.updateCachedValues();
-                await this.audit(eEventKey.eDBCreate);
+                if (!await this.audit(eEventKey.eDBCreate)) return false;
                 return true;
             });
             if (ok) return this.logSuccess('create', retry);
@@ -81,7 +83,7 @@ export abstract class DBObject<T> {
                 // pre-mutation snapshot for diff-payload shaping. After the
                 // audit emits, refresh *Orig so any subsequent update on the
                 // same instance compares against the now-persisted state.
-                await this.audit(eEventKey.eDBUpdate);
+                if (!await this.audit(eEventKey.eDBUpdate)) return false;
                 this.updateCachedValues();
                 return true;
             });
@@ -95,7 +97,7 @@ export abstract class DBObject<T> {
         for (let retry = 1; retry <= DB_OPERATION_RETRIES; retry++) {
             const ok = await withAuditTransaction(async () => {
                 if (!await this.deleteWorker()) return false;
-                await this.audit(eEventKey.eDBDelete);
+                if (!await this.audit(eEventKey.eDBDelete)) return false;
                 return true;
             });
             if (ok) return this.logSuccess('delete', retry);
@@ -110,7 +112,7 @@ export abstract class DBObject<T> {
             const ok = await withAuditTransaction(async () => {
                 if (!await this.createManyWorker<T>(data)) return false;
                 for (const dataItem of data)
-                    await dataItem.audit(eEventKey.eDBCreate);
+                    if (!await dataItem.audit(eEventKey.eDBCreate)) return false;
                 return true;
             });
             if (ok) return true;

--- a/server/graphql/schema/asset/resolvers/mutations/uploadAsset.ts
+++ b/server/graphql/schema/asset/resolvers/mutations/uploadAsset.ts
@@ -11,7 +11,7 @@ import * as REP from '../../../../../report/interface';
 import { RouteBuilder, eHrefMode } from '../../../../../http/routes/routeBuilder';
 import { ASL, ASR, LocalStore } from '../../../../../utils/localStore';
 import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
-import { eEventKey } from '../../../../../event/interface/EventEnums';
+import { eAuditType } from '../../../../../db/api/ObjectType';
 import * as COMMON from '@dpo-packrat/common';
 import { RecordKeeper as RK } from '../../../../../records/recordKeeper';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
@@ -128,11 +128,11 @@ class UploadAssetWorker extends ResolverBase {
             : this.idSOAttachment
                 ? 'Scene attachment'
                 : 'New asset';
-        const auditResult: boolean = await AuditFactory.audit(
-            { url, fileName: filename, reason, source: 'GraphQL upload', auth: (this.user !== undefined) },
-            { eObjectType: COMMON.eSystemObjectType.eAsset, idObject: this.idAsset ?? 0 },
-            eEventKey.eHTTPUpload,
-        );
+        const auditResult: boolean = await AuditFactory.emitSemantic({
+            action: eAuditType.eActionUpload,
+            target: { eObjectType: COMMON.eSystemObjectType.eAsset, idObject: this.idAsset ?? 0 },
+            payload: { url, fileName: filename, reason, source: 'GraphQL upload', auth: (this.user !== undefined) },
+        });
         if(auditResult===false) {
             RK.logError(RK.LogSection.eGQL,'property check failed','unknown error',{ file: this.apolloFile.filename, url, idUser: this.user?.idUser ?? -1, idAsset: this.idAsset },'GraphQL.Upload.AssetWorker');
             return { status: UploadStatus.Failed, error: 'Failed property audit' };

--- a/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
+++ b/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
@@ -27,6 +27,7 @@ import { eSystemObjectType } from '@dpo-packrat/common';
 import { RecordKeeper as RK } from '../../../../../records/recordKeeper';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
+import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
 import { eAuditType } from '../../../../../db/api/ObjectType';
 import { ASL } from '../../../../../utils/localStore';
 import * as fs from 'fs';
@@ -170,11 +171,15 @@ class IngestDataWorker extends ResolverBase {
     }
 
     /**
-     * Emit a single logCritical with the structured cleanup payload. Called
-     * from the soft-failure return paths and the catch block in ingest().
-     * Never called on successful ingest.
+     * Emit a single logCritical AND a semantic eActionIngestFailed audit row
+     * with the structured cleanup payload. Called from the soft-failure return
+     * paths and the catch block in ingest(). Never called on successful ingest.
+     *
+     * The audit row gives operators a queryable failure record alongside the
+     * scattered eDBCreate rows produced before the failure. The shared
+     * correlationId on every row ties them together in the audit lifeline.
      */
-    private recordPartialStateFailure(reason: string, error: unknown | null): void {
+    private async recordPartialStateFailure(reason: string, error: unknown | null): Promise<void> {
         const phase = this.partialState.phase;
         const payload = {
             sentinel: PARTIAL_STATE_SENTINEL,
@@ -209,6 +214,27 @@ class IngestDataWorker extends ResolverBase {
             },
         };
         RK.logCritical(RK.LogSection.eHTTP, PARTIAL_STATE_SENTINEL, reason, payload, 'GraphQL.Ingestion.Data');
+
+        // Persist the same payload as an audit row so the failure is queryable
+        // alongside the eDBCreate rows produced before the failure. Wrap so the
+        // emit gets deadlock retry; the ingest body itself is not in a tx, so
+        // this wrap is the only tx active at this point.
+        try {
+            await withAuditTransaction(async () => {
+                await AuditFactory.emitSemantic({
+                    action: eAuditType.eActionIngestFailed,
+                    payload,
+                });
+            });
+        } catch (auditErr) {
+            // Audit-row emit is best-effort: the logCritical above already
+            // captured the same payload, so failure here is recoverable from
+            // logs. Log the audit failure and continue with the caller's
+            // original failure return.
+            RK.logError(RK.LogSection.eAUDIT, 'ingest-failure audit row failed to emit',
+                auditErr instanceof Error ? auditErr.message : String(auditErr),
+                { phase, reason }, 'GraphQL.Ingestion.Data');
+        }
     }
 
     async ingest(): Promise<IngestDataResult> {
@@ -224,7 +250,7 @@ class IngestDataWorker extends ResolverBase {
             // Hard failure: ingestWorker threw. Emit the cleanup payload and
             // surface a generic failure to the caller. Behaviour preserved
             // (resolver returns success:false, same as a soft failure).
-            this.recordPartialStateFailure('ingestWorker threw', err);
+            await this.recordPartialStateFailure('ingestWorker threw', err);
             IDR = { success: false, message: err instanceof Error ? err.message : 'ingest threw an exception' };
         }
 
@@ -232,7 +258,7 @@ class IngestDataWorker extends ResolverBase {
         // already populated partialState.phase by the time it returns, so
         // the cleanup payload reflects the right phase.
         if (!IDR.success)
-            this.recordPartialStateFailure(IDR.message ?? 'ingestWorker returned failure', null);
+            await this.recordPartialStateFailure(IDR.message ?? 'ingestWorker returned failure', null);
 
         if (this.workflowHelper?.workflow)
             await this.workflowHelper.workflow.updateStatus(IDR.success ? COMMON.eWorkflowJobRunStatus.eDone : COMMON.eWorkflowJobRunStatus.eError);

--- a/server/graphql/schema/systemobject/resolvers/mutations/publish.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/publish.ts
@@ -5,6 +5,7 @@ import * as DBAPI from '../../../../../db';
 import * as COMMON from '@dpo-packrat/common';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
+import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
 import { eAuditType } from '../../../../../db/api/ObjectType';
 
 export default async function publish(_: Parent, args: MutationPublishArgs): Promise<PublishResult> {
@@ -31,13 +32,20 @@ export default async function publish(_: Parent, args: MutationPublishArgs): Pro
     const success: boolean = await ICol.publish(idSystemObject, eState);
     if (success) {
         const isUnpublish: boolean = eState === COMMON.ePublishedState.eNotPublished;
-        await AuditFactory.emitSemantic({
-            action: isUnpublish ? eAuditType.eActionUnpublish : eAuditType.eActionPublish,
-            idSystemObject,
-            payload: {
-                before: { eState: prevState, eStateName: prevState !== null ? COMMON.ePublishedState[prevState] : null },
-                after:  { eState, eStateName: COMMON.ePublishedState[eState] },
-            },
+        // Wrap only the semantic emit so the audit row inherits deadlock retry
+        // and atomic commit. The EDAN call above stays outside any tx — it does
+        // external HTTP and stages files into the hot folder and must not hold
+        // a Prisma transaction. The SystemObjectVersion update ICol.publish
+        // performs writes its own audit row through the standard DBObject path.
+        await withAuditTransaction(async () => {
+            await AuditFactory.emitSemantic({
+                action: isUnpublish ? eAuditType.eActionUnpublish : eAuditType.eActionPublish,
+                idSystemObject,
+                payload: {
+                    before: { eState: prevState, eStateName: prevState !== null ? COMMON.ePublishedState[prevState] : null },
+                    after:  { eState, eStateName: COMMON.ePublishedState[eState] },
+                },
+            });
         });
         return { success, eState };
     }

--- a/server/http/routes/WebDAVServer.ts
+++ b/server/http/routes/WebDAVServer.ts
@@ -6,6 +6,8 @@ import * as COMMON from '@dpo-packrat/common';
 import * as H from '../../utils/helpers';
 import { BufferStream } from '../../utils/bufferStream';
 import { AuditFactory } from '../../audit/interface/AuditFactory';
+import { Actor } from '../../audit/Actor';
+import { eAuditType } from '../../db/api/ObjectType';
 import { eEventKey } from '../../event/interface/EventEnums';
 import { ASL, ASR, LocalStore } from '../../utils/localStore';
 import { isAuthenticated } from '../auth';
@@ -125,10 +127,19 @@ class WebDAVAuthentication implements webdav.HTTPAuthentication {
                     const idUser: number = entry.idUser;
                     const user: DBAPI.User | undefined = await CACHE.UserCache.getUser(idUser);
                     if (user) {
-                        // Update the existing LocalStore with the authenticated user
+                        // Token-based auth resolves only after the WebDAV library
+                        // invokes this callback, which is past the HTTP-middleware
+                        // ASL.run scope-entry. Patch idUser AND actor onto the
+                        // existing LocalStore so downstream audit emits attribute
+                        // to the real user rather than the WebDAV system actor.
+                        // Safe under concurrency: each request has its own LS via
+                        // ASL.run; we only fill an idUser slot the middleware left
+                        // empty for an initially-unauthenticated request.
                         const LS: LocalStore | undefined = ASL.getStore();
-                        if (LS && !LS.idUser)
+                        if (LS && !LS.idUser) {
                             LS.idUser = idUser;
+                            LS.actor = Actor.user(idUser);
+                        }
 
                         RK.logInfo(RK.LogSection.eHTTP,'get user','authenticated via token',{ idUser: user.idUser, name: user.Name },'HTTP.Route.WebDAV');
                         // @ts-ignore: ts(2345)
@@ -534,15 +545,17 @@ class WebDAVFileSystem extends webdav.FileSystem {
             // it's the surface Voyager uses to round-trip scene edits back to
             // Packrat. Tag with that intent so the lifeline UI doesn't render
             // a bare URL.
-            const auditData = {
-                url: `${WebDAVServer.httpRoute}${DP.requestURLV}`,
-                fileName: path.basename(pathS),
-                reason: 'Voyager Story edit',
-                source: 'WebDAV',
-                auth: true,
-            };
-            const auditOID: DBAPI.ObjectIDAndType = { eObjectType: DP.eObjectTypeV, idObject: DP.idObjectV };
-            AuditFactory.audit(auditData, auditOID, eEventKey.eHTTPUpload);
+            await AuditFactory.emitSemantic({
+                action: eAuditType.eActionUpload,
+                target: { eObjectType: DP.eObjectTypeV, idObject: DP.idObjectV },
+                payload: {
+                    url: `${WebDAVServer.httpRoute}${DP.requestURLV}`,
+                    fileName: path.basename(pathS),
+                    reason: 'Voyager Story edit',
+                    source: 'WebDAV',
+                    auth: true,
+                },
+            });
 
             const SOP: DBAPI.SystemObjectPairs | null = (DP.idSystemObjectV) ? await DBAPI.SystemObjectPairs.fetch(DP.idSystemObjectV) : null;
             const SOBased: DBAPI.SystemObjectBased | null = SOP ? SOP.SystemObjectBased : null;

--- a/server/http/routes/api/authorization.ts
+++ b/server/http/routes/api/authorization.ts
@@ -22,11 +22,12 @@ async function auditAuthChange(
 ): Promise<void> {
     // idAdminUser is the operator performing the grant/revoke. When the REST
     // caller isn't authenticated we attribute the change to a system actor so
-    // the row still satisfies the "never both-null" invariant.
+    // the row still satisfies the "never both-null" invariant. Routed through
+    // emitSemantic for a uniform contract with every other semantic emitter.
     const actor: Actor = idAdminUser != null
         ? Actor.user(idAdminUser)
         : Actor.system('AuthorizationAPI');
-    const ok = await AuditFactory.emit({
+    const ok = await AuditFactory.emitSemantic({
         action: type,
         actor,
         payload: data,


### PR DESCRIPTION
- DBObject now rolls back when its audit row fails to write
- Publish audit row gains deadlock retry and atomic commit
- Authorization API uses same semantic emit as every other surface
- Scene QC no longer writes a duplicate row from a legacy path
- Uploads now produce a permanent semantic audit row
- Voyager Story saves attribute to the user, not the system
- Upload events retained forever, not pruned with transients
- Ingest failures now leave a queryable audit row with cleanup ids
- Failure row joins to its CRUD rows by shared correlationId
- Recovery hint and phase tag included in the audit payload