### PR TITLE
DPO3DPKRT-1000/Server Ops Disk Redirect + Code Audit

### DIFF
--- a/conf/scripts/server_ops/lib/common.sh
+++ b/conf/scripts/server_ops/lib/common.sh
@@ -75,8 +75,26 @@ __load_ops_env_file
 # Constants
 # ---------------------------------------------------------------------------
 
-OPS_AUDIT_LOG="${OPS_AUDIT_LOG:-/var/log/packrat-ops.log}"
-OPS_LOCK_DIR="${OPS_LOCK_DIR:-/var/lock/packrat-ops}"
+# Transient/intermediate file root. Mirrors the original FS layout under a
+# single non-system mount so /tmp, /var, /home stay clean. Every ops script
+# that creates temp files, lock files, audit logs, or in-place backups
+# resolves its path under this root by default.
+OPS_TRANSIENT_ROOT="${OPS_TRANSIENT_ROOT:-/staging/tmp/system}"
+
+# Try to provision the transient tmpdir. On hosts where the root doesn't
+# exist (developer workstations without /staging mounted), this silently
+# fails and we leave $TMPDIR alone so the system default (/tmp) keeps
+# working. Production hosts have /staging, so the export takes effect.
+if mkdir -p "$OPS_TRANSIENT_ROOT/tmp" 2>/dev/null; then
+    # Route every consumer of $TMPDIR (mktemp, Docker BuildKit, openssl
+    # scratch, ...) into the transient root, so we don't have to touch
+    # each call site. Only override if the caller hasn't pinned one.
+    export TMPDIR="${TMPDIR:-$OPS_TRANSIENT_ROOT/tmp}"
+fi
+
+OPS_AUDIT_LOG="${OPS_AUDIT_LOG:-$OPS_TRANSIENT_ROOT/var/log/packrat-ops.log}"
+OPS_LOCK_DIR="${OPS_LOCK_DIR:-$OPS_TRANSIENT_ROOT/var/lock/packrat-ops}"
+OPS_AUDIT_MAX_BYTES="${OPS_AUDIT_MAX_BYTES:-52428800}"   # 50 MB
 
 # Containers that must NEVER be stopped/removed automatically in prod.
 # Used by ops_container.sh as a safety gate. Edit here, not in each caller.
@@ -281,7 +299,7 @@ init_traps() {
 # no-op instead of queueing or producing two concurrent writers.
 #
 # Lock file: $OPS_LOCK_DIR/<name>.lock
-# If $OPS_LOCK_DIR isn't writable, falls back to /tmp/packrat-ops-locks.
+# If $OPS_LOCK_DIR isn't writable, falls back to $OPS_TRANSIENT_ROOT/tmp/packrat-ops-locks.
 
 with_lock() {
     local name="$1"; shift
@@ -303,7 +321,7 @@ with_lock() {
 
     if [[ ! -d "$OPS_LOCK_DIR" ]]; then
         if ! mkdir -p "$OPS_LOCK_DIR" 2>/dev/null; then
-            OPS_LOCK_DIR="/tmp/packrat-ops-locks"
+            OPS_LOCK_DIR="$OPS_TRANSIENT_ROOT/tmp/packrat-ops-locks"
             mkdir -p "$OPS_LOCK_DIR"
         fi
     fi
@@ -349,6 +367,22 @@ audit_log() {
     env="${ENVIRONMENT:-n/a}"
     op="${OPS_CURRENT_OP:-n/a}"
     line="${ts} | ${host} | ${user} | ${script} | ${env} | ${op} | ${status} | ${elapsed}s"
+
+    # Ensure the audit log directory exists. The default path lives under
+    # $OPS_TRANSIENT_ROOT, which may not have been provisioned on a fresh host.
+    local audit_dir
+    audit_dir="$(dirname -- "$OPS_AUDIT_LOG")"
+    [[ -d "$audit_dir" ]] || mkdir -p "$audit_dir" 2>/dev/null || true
+
+    # Single-step size cap. When the audit log exceeds OPS_AUDIT_MAX_BYTES,
+    # rotate to .1 (overwriting any prior .1). Cheap, no logrotate dependency.
+    if [[ -f "$OPS_AUDIT_LOG" ]]; then
+        local cur_size
+        cur_size="$(stat -c %s -- "$OPS_AUDIT_LOG" 2>/dev/null || echo 0)"
+        if (( cur_size > OPS_AUDIT_MAX_BYTES )); then
+            mv -f -- "$OPS_AUDIT_LOG" "${OPS_AUDIT_LOG}.1" 2>/dev/null || true
+        fi
+    fi
 
     # Best-effort append. If unwritable (dev workstation, perms, etc.),
     # emit to stderr instead of failing the op.

--- a/conf/scripts/server_ops/lib/smoke_test_cert.sh
+++ b/conf/scripts/server_ops/lib/smoke_test_cert.sh
@@ -51,6 +51,7 @@ cd "$PKI"
 RUN_ENV=(
     OPS_AUDIT_LOG="$AUDIT"
     OPS_LOCK_DIR="$LOCKS"
+    OPS_TRANSIENT_ROOT="$TMP_ROOT"
 )
 run_c() { env "${RUN_ENV[@]}" bash "$SCRIPT" "$@"; }
 
@@ -258,7 +259,7 @@ banner_line "format 3-block bundle (relaxed)"
 orig_size=$(wc -c < bundle3.pem)
 out=$(run_c format bundle3.pem 2>&1)
 echo "$out" | grep -q "Rewrote" || fail "expected rewrite message"
-ls bundle3.pem.bak.* >/dev/null 2>&1 || fail "no backup file created"
+ls "$TMP_ROOT/cert$PKI"/bundle3.pem.bak.* >/dev/null 2>&1 || fail "no backup file created"
 # Mutated file should NOT contain the ROOT anymore
 if openssl x509 -in <(awk '/BEGIN/{n++}n==3' bundle3.pem | head) -noout -subject 2>/dev/null \
     | grep -q "Root"; then
@@ -278,7 +279,7 @@ pass "format --strict rejects non-4-block"
 banner_line "format 4-block --strict passes"
 out=$(run_c format bundle4.pem --strict 2>&1)
 echo "$out" | grep -q "Rewrote" || fail "--strict on 4 blocks should rewrite"
-ls bundle4.pem.bak.* >/dev/null 2>&1 || fail "no backup for 4-block"
+ls "$TMP_ROOT/cert$PKI"/bundle4.pem.bak.* >/dev/null 2>&1 || fail "no backup for 4-block"
 pass "format --strict 4-block"
 
 banner_line "audit log populated"

--- a/conf/scripts/server_ops/ops_cert.sh
+++ b/conf/scripts/server_ops/ops_cert.sh
@@ -447,10 +447,13 @@ op_format() {
         ordered+=( "${remaining[@]}" )
     fi
 
-    # Backup + rewrite LEAF + INTERMEDIATES (root omitted)
+    # Backup + rewrite LEAF + INTERMEDIATES (root omitted).
+    # Backup mirrors the cert's absolute path under $OPS_TRANSIENT_ROOT/cert/
+    # so reformatting a cert in /etc does not leave .bak.* siblings on /.
     local ts backup
     ts=$(date +%Y%m%d%H%M%S)
-    backup="${cert_file}.bak.${ts}"
+    backup="$OPS_TRANSIENT_ROOT/cert${cert_file}.bak.${ts}"
+    mkdir -p -- "$(dirname -- "$backup")"
     cp -p -- "$cert_file" "$backup"
     note "backup: $backup"
 
@@ -602,7 +605,7 @@ main_menu() {
     menu_clear
     banner "PACKRAT CERT OPS"
     echo "[1] Inspect - per-block details (read-only)"
-    echo "[2] Format  - !! rewrite cert bundle in place (.bak.* saved first)"
+    echo "[2] Format  - !! rewrite cert bundle in place (.bak.* saved to staging)"
     echo "[3] Expiry  - check days remaining (exit 1 if within warn-days)"
     echo ""
     echo "[B] Back to top menu     [Q] Quit"

--- a/conf/scripts/server_ops/ops_container.sh
+++ b/conf/scripts/server_ops/ops_container.sh
@@ -527,7 +527,9 @@ __predeploy_run() {
     # 8. Optional /tmp remount (only hosts with /tmp mounted noexec need this)
     if [[ "$remount_tmp" == "true" ]]; then
         note "remounting /tmp with exec (--remount-tmp)..."
-        local tmpdir="/home/${deploy_user}/tmp"
+        # BuildKit scratch lives under $OPS_TRANSIENT_ROOT so multi-GB image
+        # context unpacks do not push /home toward its quota during deploys.
+        local tmpdir="$OPS_TRANSIENT_ROOT/home/${deploy_user}/tmp"
         export TMPDIR="$tmpdir"
         if [[ ! -d "$tmpdir" ]]; then
             mkdir -p "$tmpdir"

--- a/conf/scripts/server_ops/ops_logs.sh
+++ b/conf/scripts/server_ops/ops_logs.sh
@@ -388,7 +388,10 @@ op_copy() {
 
     local archive_name tmp_archive
     archive_name="PackratLogs_${ENV_DIR_NAME,,}_${start_date}_to_${end_date}.zip"
-    tmp_archive="/tmp/$archive_name"
+    # Staged under $TMPDIR (set by lib/common.sh to $OPS_TRANSIENT_ROOT/tmp
+    # when /staging is available) so a multi-GB archive does not land on /
+    # on hosts where /tmp is small. Falls back to /tmp for dev workstations.
+    tmp_archive="${TMPDIR:-/tmp}/$archive_name"
     register_tmp_file "$tmp_archive"
 
     # Build file list as an array for `zip -j` (junk paths -> flat archive).


### PR DESCRIPTION
- Redirected all ops temp/lock/audit/cert backups to /staging/tmp/system
- Audit log gets a 50MB cap (overrideable via OPS_AUDIT_MAX_BYTES)
- Falls back gracefully on dev boxes that don't have /staging mounted
- Old /var/log/packrat-ops.log left in place; new writes go to staging