### PR TITLE
DPO3DPKRT-1005/Volume Ingest Config & Upload Type Validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -59,5 +59,9 @@ PACKRAT_SOLR_REINDEX_SCHEDULE=
 # (Stage 4b). Off by default — it is O(slices) and slow on large stacks.
 PACKRAT_VOLUME_PER_SLICE_VALIDATION=
 
+# Set to true/1 to enable user-facing volumetric ingest (UI option + upload/ingest paths).
+# Off by default — the datatype is gated pending stakeholder sign-off.
+PACKRAT_INGEST_VOLUMETRIC=
+
 # PROXY
 PACKRAT_PROXY_PORT=

--- a/.env.template
+++ b/.env.template
@@ -63,5 +63,9 @@ PACKRAT_VOLUME_PER_SLICE_VALIDATION=
 # Off by default — the datatype is gated pending stakeholder sign-off.
 PACKRAT_INGEST_VOLUMETRIC=
 
+# Upload package/asset-type compatibility check: off | warn | enforce.
+# off (default) disables it; warn logs mismatches without blocking; enforce rejects them.
+PACKRAT_INGEST_VALIDATION_MODE=
+
 # PROXY
 PACKRAT_PROXY_PORT=

--- a/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
@@ -285,6 +285,7 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
                         case 'capture data set: spherical laser':
                         case 'capture data set: structured light':
                         case 'capture data set: other':
+                        case 'capture data set: volumetric':
                         case 'capture data file':
                         case 'model geometry file':
                         case 'model uv map file':

--- a/client/src/store/vocabulary.ts
+++ b/client/src/store/vocabulary.ts
@@ -7,7 +7,7 @@ import lodash from 'lodash';
 import create, { GetState, SetState } from 'zustand';
 import { apolloClient } from '../graphql';
 import { GetVocabularyEntriesDocument, Vocabulary } from '../types/graphql';
-import { eVocabularyID, eVocabularySetID } from '@dpo-packrat/common';
+import { eVocabularyID, eVocabularySetID, ModelFileExtensions } from '@dpo-packrat/common';
 
 export type VocabularyOption = Pick<Vocabulary, 'idVocabulary' | 'Term' | 'eVocabID'>;
 export type StateVocabulary = Map<eVocabularySetID, VocabularyOption[]>;
@@ -181,8 +181,12 @@ export const useVocabularyStore = create<VocabularyStore>((set: SetState<Vocabul
     getAssetTypeForExtension: (extension: string): number | null => {
         const { vocabularyMap } = get();
         let eVocabEnum: eVocabularyID | null = null;
+        const ext: string = extension.toLowerCase();
 
-        switch (extension.toLowerCase()) {
+        // Mesh extensions are centralized in @dpo-packrat/common so client and server agree.
+        if (ModelFileExtensions.includes(ext)) {
+            eVocabEnum = eVocabularyID.eAssetAssetTypeModel;
+        } else switch (ext) {
             // .zip is intentionally NOT auto-mapped — the contents could be a volumetric
             // ZIP, a photogrammetry bulk ingest, a scene archive, or other. Returning
             // null forces the user to pick from the inline asset-type dropdown.
@@ -200,23 +204,6 @@ export const useVocabularyStore = create<VocabularyStore>((set: SetState<Vocabul
             case '.tiff':
             case '.jpg':
             case '.jpeg': eVocabEnum = eVocabularyID.eAssetAssetTypeCaptureDataFile; break;
-
-            case '.obj':
-            case '.ply':
-            case '.stl':
-            case '.glb':
-            case '.gltf':
-            case '.usda':
-            case '.usdc':
-            case '.usdz':
-            case '.x3d':
-            case '.wrl':
-            case '.dae':
-            case '.fbx':
-            case '.ma':
-            case '.3ds':
-            case '.ptx':
-            case '.pts': eVocabEnum = eVocabularyID.eAssetAssetTypeModel; break;
 
             case '.svx.json':
             case '.json': eVocabEnum = eVocabularyID.eAssetAssetTypeScene; break;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -483,12 +483,70 @@ export const authenticationFailureMessage: string = 'GraphQL user is not authent
 
 export const repositoryRowCount = 300;
 
-// File extensions that unambiguously signal a volumetric dataset and may only be ingested via the
-// Volumetric asset type: DICOM slices (.dcm, .dicom, and Siemens .ima) and Phoenix scan sidecars
-// (.pca acquisition, .pcr reconstruction). TIFF/PNG slice stacks are also volumetric but share
-// extensions with ordinary images, so they are intentionally excluded — extension alone cannot
-// disambiguate them.
-export const VolumetricFileExtensions: string[] = ['.dcm', '.dicom', '.ima', '.pca', '.pcr'];
+// Single source of truth mapping a file's extension to a coarse category, used to reason about which
+// asset type(s) an uploaded package is compatible with. This is intentionally separate from the
+// model-file-TYPE vocabulary map (VocabularyCache.mapModelFileByExtensionID), which resolves an
+// extension to a specific Model.FileType vocabulary row.
+export enum eFileCategory {
+    eMesh = 'mesh',
+    eModelMaterial = 'modelMaterial',
+    eImage = 'image',
+    eVolumetricSlice = 'volumetricSlice',
+    eVolumetricSidecar = 'volumetricSidecar',
+    eSceneDescriptor = 'sceneDescriptor',
+    eDocument = 'document',
+    eAudio = 'audio',
+    eUnknown = 'unknown',
+}
+
+// Mesh / geometry extensions. Mirrors VocabularyCache.mapModelFileByExtensionID's supported set.
+export const ModelFileExtensions: string[] = [
+    '.obj', '.ply', '.stl', '.glb', '.gltf', '.usda', '.usdc', '.usdz',
+    '.x3d', '.wrl', '.dae', '.fbx', '.ma', '.3ds', '.ptx', '.pts',
+];
+
+// Model support files (accompany a mesh).
+export const ModelMaterialFileExtensions: string[] = ['.mtl'];
+
+// Raster image extensions: processed formats plus raw camera formats.
+export const ImageFileExtensions: string[] = [
+    '.jpg', '.jpeg', '.png', '.tif', '.tiff', '.tga', '.bmp', '.gif', '.webp', '.avif', '.svg',
+    '.cr2', '.cr3', '.nef', '.arw', '.dng', '.raf', '.rw2', '.orf', '.camdng',
+];
+
+// Volumetric slice data — the only hard volumetric signal (actual slices).
+export const VolumetricSliceFileExtensions: string[] = ['.dcm', '.dicom', '.ima'];
+
+// Volumetric scan sidecars (Phoenix acquisition/reconstruction logs). These are documents that also
+// veto a Photogrammetry reading when slice/stack data is present; they are not volumetric data alone.
+export const VolumetricSidecarFileExtensions: string[] = ['.pca', '.pcr'];
+
+// Document formats (sidecars also count as documents).
+export const DocumentFileExtensions: string[] = ['.pdf', '.doc', '.docx', '.txt', '.rtf', '.odf', '.html', '.htm'];
+
+export const AudioFileExtensions: string[] = ['.mp3', '.wav', '.aif', '.aiff', '.flac'];
+
+// Union of the two volumetric tiers. Consumed by the upload-time volumetric guard.
+export const VolumetricFileExtensions: string[] = [...VolumetricSliceFileExtensions, ...VolumetricSidecarFileExtensions];
+
+export const fileExtension = (fileName: string): string => {
+    const lower: string = fileName.toLowerCase();
+    const dot: number = lower.lastIndexOf('.');
+    return dot >= 0 ? lower.slice(dot) : '';
+};
+
+export function classifyFile(fileName: string): eFileCategory {
+    if (fileName.toLowerCase().endsWith('.svx.json'))   return eFileCategory.eSceneDescriptor;
+    const ext: string = fileExtension(fileName);
+    if (ModelFileExtensions.includes(ext))              return eFileCategory.eMesh;
+    if (ModelMaterialFileExtensions.includes(ext))      return eFileCategory.eModelMaterial;
+    if (VolumetricSliceFileExtensions.includes(ext))    return eFileCategory.eVolumetricSlice;
+    if (VolumetricSidecarFileExtensions.includes(ext))  return eFileCategory.eVolumetricSidecar;
+    if (ImageFileExtensions.includes(ext))              return eFileCategory.eImage;
+    if (DocumentFileExtensions.includes(ext))           return eFileCategory.eDocument;
+    if (AudioFileExtensions.includes(ext))              return eFileCategory.eAudio;
+    return eFileCategory.eUnknown;
+}
 
 export const isVolumetricFileExtension = (extOrName: string): boolean => {
     const lower: string = extOrName.toLowerCase();

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -482,3 +482,15 @@ export enum eWorkflowListSortColumns {
 export const authenticationFailureMessage: string = 'GraphQL user is not authenticated';
 
 export const repositoryRowCount = 300;
+
+// File extensions that unambiguously signal a volumetric dataset and may only be ingested via the
+// Volumetric asset type: DICOM slices (.dcm, .dicom, and Siemens .ima) and Phoenix scan sidecars
+// (.pca acquisition, .pcr reconstruction). TIFF/PNG slice stacks are also volumetric but share
+// extensions with ordinary images, so they are intentionally excluded — extension alone cannot
+// disambiguate them.
+export const VolumetricFileExtensions: string[] = ['.dcm', '.dicom', '.ima', '.pca', '.pcr'];
+
+export const isVolumetricFileExtension = (extOrName: string): boolean => {
+    const lower: string = extOrName.toLowerCase();
+    return VolumetricFileExtensions.some(ext => lower === ext || lower.endsWith(ext));
+};

--- a/common/index.ts
+++ b/common/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './constants';
+export * from './packageValidation';

--- a/common/packageValidation.ts
+++ b/common/packageValidation.ts
@@ -1,0 +1,129 @@
+/**
+ * Package type validation — pure predicates that decide which asset type(s) an uploaded package
+ * (a single file, or the file list inside a zip) is compatible with, and whether the user's selected
+ * asset type is allowed.
+ *
+ * Decision rule is membership: a package is compatible with the selected type iff that type is among
+ * the types the package could be. Each predicate evaluates the WHOLE file list (it must account for
+ * every decisive file), so a contaminated package (e.g. a mesh alongside DICOM slices) satisfies no
+ * structured predicate and is therefore rejected for any concrete selection.
+ *
+ * Pure and dependency-free so the same logic backs both the server upload gate and client-side UX.
+ */
+import { eVocabularyID, eFileCategory, classifyFile } from './constants';
+
+export interface PackageSummary {
+    counts: Record<eFileCategory, number>;
+    total: number;
+    hasHtml: boolean;
+}
+
+const emptyCounts = (): Record<eFileCategory, number> => ({
+    [eFileCategory.eMesh]: 0,
+    [eFileCategory.eModelMaterial]: 0,
+    [eFileCategory.eImage]: 0,
+    [eFileCategory.eVolumetricSlice]: 0,
+    [eFileCategory.eVolumetricSidecar]: 0,
+    [eFileCategory.eSceneDescriptor]: 0,
+    [eFileCategory.eDocument]: 0,
+    [eFileCategory.eAudio]: 0,
+    [eFileCategory.eUnknown]: 0,
+});
+
+export function summarizePackage(files: string[]): PackageSummary {
+    const counts: Record<eFileCategory, number> = emptyCounts();
+    let hasHtml = false;
+    for (const file of files) {
+        counts[classifyFile(file)] += 1;
+        const lower: string = file.toLowerCase();
+        if (lower.endsWith('.html') || lower.endsWith('.htm'))
+            hasHtml = true;
+    }
+    return { counts, total: files.length, hasHtml };
+}
+
+const has = (s: PackageSummary, c: eFileCategory): boolean => s.counts[c] > 0;
+
+// ─── Per-type predicates (whole-package) ─────────────────────────────────────
+// Each: required anchor present AND no foreign decisive category present.
+
+export function canBeModel(s: PackageSummary): boolean {
+    return has(s, eFileCategory.eMesh)
+        && !has(s, eFileCategory.eSceneDescriptor)
+        && !has(s, eFileCategory.eVolumetricSlice);
+}
+
+export function canBePhotogrammetry(s: PackageSummary): boolean {
+    return has(s, eFileCategory.eImage)
+        && !has(s, eFileCategory.eMesh)
+        && !has(s, eFileCategory.eSceneDescriptor)
+        && !has(s, eFileCategory.eVolumetricSlice)
+        && !has(s, eFileCategory.eVolumetricSidecar);   // a sidecar pushes the package to Volumetric
+}
+
+export function canBeVolumetric(s: PackageSummary): boolean {
+    // Anchored by slice data OR an image stack (tiff/png). Sidecar/Document ride along as ancillary.
+    return (has(s, eFileCategory.eVolumetricSlice) || has(s, eFileCategory.eImage))
+        && !has(s, eFileCategory.eMesh)
+        && !has(s, eFileCategory.eSceneDescriptor);
+}
+
+export function canBeScene(s: PackageSummary): boolean {
+    // Plausibility only: an svx plus at least one mesh. Full 5/6-derivative completeness is enforced
+    // downstream in scene ingestion, not here.
+    return has(s, eFileCategory.eSceneDescriptor)
+        && has(s, eFileCategory.eMesh)
+        && !has(s, eFileCategory.eVolumetricSlice);
+}
+
+export function canBeDocumentation(s: PackageSummary): boolean {
+    // A scan sidecar (.pca/.pcr) is itself a document, so it can anchor a documentation package alone.
+    const docAnchor: boolean = has(s, eFileCategory.eDocument) || has(s, eFileCategory.eVolumetricSidecar);
+    // Images are only acceptable as part of html articles; a bare image set is capture data, not docs.
+    const bareImages: boolean = has(s, eFileCategory.eImage) && !s.hasHtml;
+    return docAnchor
+        && !has(s, eFileCategory.eMesh)
+        && !has(s, eFileCategory.eSceneDescriptor)
+        && !has(s, eFileCategory.eVolumetricSlice)
+        && !bareImages;
+}
+
+// ─── Aggregation ─────────────────────────────────────────────────────────────
+
+// Asset types this module adjudicates. Anything outside this set — Other, Bulk Ingestion, and the
+// silenced legacy capture types — is intentionally NOT gated (see isCompatible).
+const validatableTypes: ReadonlySet<eVocabularyID> = new Set<eVocabularyID>([
+    eVocabularyID.eAssetAssetTypeModel,
+    eVocabularyID.eAssetAssetTypeCaptureDataSetPhotogrammetry,
+    eVocabularyID.eAssetAssetTypeCaptureDataSetVolumetric,
+    eVocabularyID.eAssetAssetTypeScene,
+    eVocabularyID.eAssetAssetTypeProjectDocumentation,
+]);
+
+export function isValidatableType(selected: eVocabularyID): boolean {
+    return validatableTypes.has(selected);
+}
+
+export interface PackageAssessment {
+    possibleTypes: Set<eVocabularyID>;
+    summary: PackageSummary;
+}
+
+export function assessPackage(files: string[]): PackageAssessment {
+    const summary: PackageSummary = summarizePackage(files);
+    const possibleTypes: Set<eVocabularyID> = new Set<eVocabularyID>();
+    if (canBeModel(summary))          possibleTypes.add(eVocabularyID.eAssetAssetTypeModel);
+    if (canBePhotogrammetry(summary)) possibleTypes.add(eVocabularyID.eAssetAssetTypeCaptureDataSetPhotogrammetry);
+    if (canBeVolumetric(summary))     possibleTypes.add(eVocabularyID.eAssetAssetTypeCaptureDataSetVolumetric);
+    if (canBeScene(summary))          possibleTypes.add(eVocabularyID.eAssetAssetTypeScene);
+    if (canBeDocumentation(summary))  possibleTypes.add(eVocabularyID.eAssetAssetTypeProjectDocumentation);
+    return { possibleTypes, summary };
+}
+
+// Compatible iff the selected type is one we don't gate (Other / Bulk / legacy), or the package could
+// be that type. A package matching no structured predicate is incompatible with every gated type.
+export function isCompatible(selected: eVocabularyID, possibleTypes: Set<eVocabularyID>): boolean {
+    if (!isValidatableType(selected))
+        return true;
+    return possibleTypes.has(selected);
+}

--- a/server/cache/VocabularyCache.ts
+++ b/server/cache/VocabularyCache.ts
@@ -750,22 +750,12 @@ export class VocabularyCache {
     static mapModelFileByExtensionID(fileName: string): COMMON.eVocabularyID | undefined {
         const extension: string = path.extname(fileName).toLowerCase() || fileName.toLowerCase();
 
-        // early out if known type (image, mtl, etc)
+        // early out if a known non-model type (image, mtl, archive). Extension sets are centralized in
+        // @dpo-packrat/common so classification stays consistent across client and server.
         const nonModelTypes: string[] = [
-            // images (processed)
-            '.jpg','.jpeg','.png',
-            '.tif','.tiff',
-            '.tga','.bmp',
-
-            // images (raw capture)
-            '.cr2','.cr3','.nef','.arw',
-            '.dng','.raf','.rw2','.orf',
-
-            // model support files
-            '.mtl',
-
-            // other
-            '.zip'
+            ...COMMON.ImageFileExtensions,
+            ...COMMON.ModelMaterialFileExtensions,
+            '.zip',
         ];
         if(nonModelTypes.includes(extension)) {
             RK.logDebug(RK.LogSection.eCACHE,'map model extension','attempting to map known type, but not a model',{ extension },'Cache.Vocabulary');

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -127,6 +127,9 @@ export type ConfigType = {
         /** Gate for user-facing volumetric capture-data ingest. Off in production until stakeholder
          *  sign-off. When false, the upload inspector and the ingest path reject volumetric assets. */
         volumetricIngest: boolean;
+        /** Upload-time package/asset-type compatibility check. 'off' disables it; 'warn' logs mismatches
+         *  without blocking (rollout/observation); 'enforce' rejects mismatched uploads. */
+        packageValidationMode: 'off' | 'warn' | 'enforce';
     },
     environment: {
         type: ENVIRONMENT_TYPE;
@@ -306,6 +309,10 @@ export const Config: ConfigType = {
             if (!raw) return false;
             const normalized: string = raw.trim().toLowerCase();
             return normalized === 'true' || normalized === '1';
+        })(),
+        packageValidationMode: ((): 'off' | 'warn' | 'enforce' => {
+            const raw: string = (process.env.PACKRAT_INGEST_VALIDATION_MODE ?? '').trim().toLowerCase();
+            return (raw === 'warn' || raw === 'enforce') ? raw : 'off';
         })(),
     },
     environment: {

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -123,6 +123,11 @@ export type ConfigType = {
     event: {
         type: EVENT_TYPE;
     },
+    features: {
+        /** Gate for user-facing volumetric capture-data ingest. Off in production until stakeholder
+         *  sign-off. When false, the upload inspector and the ingest path reject volumetric assets. */
+        volumetricIngest: boolean;
+    },
     environment: {
         type: ENVIRONMENT_TYPE;
         isJest: boolean;
@@ -294,6 +299,14 @@ export const Config: ConfigType = {
     },
     event: {
         type: EVENT_TYPE.INPROCESS,
+    },
+    features: {
+        volumetricIngest: ((): boolean => {
+            const raw: string | undefined = process.env.PACKRAT_INGEST_VOLUMETRIC;
+            if (!raw) return false;
+            const normalized: string = raw.trim().toLowerCase();
+            return normalized === 'true' || normalized === '1';
+        })(),
     },
     environment: {
         type: (process.env.NODE_ENV && process.env.NODE_ENV=='production') ? ENVIRONMENT_TYPE.PRODUCTION : ENVIRONMENT_TYPE.DEVELOPMENT,

--- a/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
+++ b/server/graphql/schema/ingestion/resolvers/mutations/ingestData.ts
@@ -15,6 +15,7 @@ import { SceneHelpers } from '../../../../../utils';
 import * as WF from '../../../../../workflow/interface';
 import * as REP from '../../../../../report/interface';
 import * as NAV from '../../../../../navigation/interface';
+import { Config } from '../../../../../config';
 import { AssetStorageAdapter, IngestAssetInput, IngestAssetResult, OperationInfo, StorageFactory, IStorage } from '../../../../../storage/interface';
 import { VocabularyCache } from '../../../../../cache';
 import { JobCookSIPackratInspectOutput } from '../../../../../job/impl/Cook';
@@ -2132,6 +2133,12 @@ class IngestDataWorker extends ResolverBase {
         this.ingestVolume           = this.input.volume && this.input.volume.length > 0;
         this.ingestNew              = false;
         this.ingestUpdate           = false;
+
+        if (this.ingestVolume && !Config.features.volumetricIngest) {
+            const error: string = 'Volumetric ingest is currently disabled';
+            RK.logError(RK.LogSection.eGQL,'validate input failed',error,{},'GraphQL.Ingestion.Data');
+            return { success: false, error };
+        }
 
         if (this.ingestPhotogrammetry) {
             for (const photogrammetry of this.input.photogrammetry) {

--- a/server/tests/graphql/mutations/ingestion/ingestData.test.ts
+++ b/server/tests/graphql/mutations/ingestion/ingestData.test.ts
@@ -204,6 +204,54 @@ const ingestDataTest = (utils: TestSuiteUtils): void => {
                 }
             }
         });
+
+        test('rejects volumetric ingest while the feature flag is disabled', async done => {
+            // PACKRAT_INGEST_VOLUMETRIC is unset in CI, so Config.features.volumetricIngest is
+            // false. validateInput rejects any non-empty volume payload before touching its contents.
+            const userInput = createUserInput();
+            const { User } = await graphQLApi.createUser(userInput);
+            expect(User).toBeTruthy();
+
+            if (User) {
+                const context: Context = { user: User, isAuthenticated: true };
+
+                const volume = {
+                    idAssetVersion: 1,
+                    name: 'gated volume',
+                    dateCaptured: new Date().toISOString(),
+                    systemCreated: true,
+                    description: '',
+                    modality: 0,
+                    scanType: 0,
+                    contentType: 0,
+                    voxelSizeX: 1,
+                    voxelSizeY: 1,
+                    voxelSizeZ: 1,
+                    voxelSizeUnit: 0,
+                    fileCount: 1,
+                    directory: '',
+                    identifiers: [],
+                    sourceObjects: [],
+                    derivedObjects: []
+                };
+
+                const ingestDataInput = {
+                    subjects: [],
+                    project: { id: 0, name: '' },
+                    item: { id: null, subtitle: '', entireSubject: true },
+                    photogrammetry: [],
+                    model: [],
+                    scene: [],
+                    other: [],
+                    sceneAttachment: [],
+                    volume: [volume]
+                };
+
+                const result = await graphQLApi.ingestData(ingestDataInput, context);
+                expect(result.success).toBe(false);
+                done();
+            }
+        });
     });
 };
 

--- a/server/tests/utils/packageValidation.test.ts
+++ b/server/tests/utils/packageValidation.test.ts
@@ -1,0 +1,75 @@
+import * as COMMON from '@dpo-packrat/common';
+
+// Pure unit tests for the @dpo-packrat/common package-type validation predicates. No DB or I/O.
+
+const V = COMMON.eVocabularyID;
+
+const shortName: Map<COMMON.eVocabularyID, string> = new Map([
+    [V.eAssetAssetTypeModel, 'Model'],
+    [V.eAssetAssetTypeCaptureDataSetPhotogrammetry, 'Photo'],
+    [V.eAssetAssetTypeCaptureDataSetVolumetric, 'Volume'],
+    [V.eAssetAssetTypeScene, 'Scene'],
+    [V.eAssetAssetTypeProjectDocumentation, 'Doc'],
+]);
+
+const possibleNames = (files: string[]): string[] =>
+    [...COMMON.assessPackage(files).possibleTypes].map(t => shortName.get(t) ?? String(t)).sort();
+
+describe('common: file classification', () => {
+    test('classifies decisive extensions', () => {
+        expect(COMMON.classifyFile('a.obj')).toBe(COMMON.eFileCategory.eMesh);
+        expect(COMMON.classifyFile('a.dcm')).toBe(COMMON.eFileCategory.eVolumetricSlice);
+        expect(COMMON.classifyFile('a.DICOM')).toBe(COMMON.eFileCategory.eVolumetricSlice);
+        expect(COMMON.classifyFile('a.pca')).toBe(COMMON.eFileCategory.eVolumetricSidecar);
+        expect(COMMON.classifyFile('scene.svx.json')).toBe(COMMON.eFileCategory.eSceneDescriptor);
+        expect(COMMON.classifyFile('a.png')).toBe(COMMON.eFileCategory.eImage);
+        expect(COMMON.classifyFile('a.pdf')).toBe(COMMON.eFileCategory.eDocument);
+        expect(COMMON.classifyFile('a.unknownext')).toBe(COMMON.eFileCategory.eUnknown);
+        expect(COMMON.classifyFile('noextension')).toBe(COMMON.eFileCategory.eUnknown);
+    });
+});
+
+describe('common: assessPackage possible types', () => {
+    test.each([
+        [['model.obj'], ['Model']],
+        [['m.obj', 'm.mtl', 't.png'], ['Model']],
+        [['a.glb'], ['Model']],
+        [['scan.dcm'], ['Volume']],
+        [['scan.dcm', 'readme.pdf'], ['Volume']],
+        [['log.pca'], ['Doc']],
+        [['log.pca', 'notes.pdf'], ['Doc']],
+        [['s1.tif', 's2.tif', 's3.tif'], ['Photo', 'Volume']],
+        [['s1.tif', 's2.tif', 'log.pca'], ['Volume']],
+        [['scene.svx.json', 'm1.glb', 'm2.glb'], ['Scene']],
+        [['scene.svx.json'], []],
+        [['doc.pdf'], ['Doc']],
+        [['mesh.obj', 'scan.dcm'], []],
+        [['random.xyz'], []],
+        [['a.obj', 'b.svx.json'], ['Scene']],
+    ])('%j -> %j', (files: string[], expected: string[]) => {
+        expect(possibleNames(files)).toEqual([...expected].sort());
+    });
+});
+
+describe('common: isCompatible', () => {
+    test('membership: selected type must be a possible type', () => {
+        const stack = COMMON.assessPackage(['s1.tif', 's2.tif']).possibleTypes;
+        expect(COMMON.isCompatible(V.eAssetAssetTypeCaptureDataSetPhotogrammetry, stack)).toBe(true);
+        expect(COMMON.isCompatible(V.eAssetAssetTypeCaptureDataSetVolumetric, stack)).toBe(true);
+        expect(COMMON.isCompatible(V.eAssetAssetTypeModel, stack)).toBe(false);
+    });
+
+    test('contaminated package is incompatible with every gated type', () => {
+        const bad = COMMON.assessPackage(['mesh.obj', 'scan.dcm']).possibleTypes;
+        expect(COMMON.isCompatible(V.eAssetAssetTypeModel, bad)).toBe(false);
+        expect(COMMON.isCompatible(V.eAssetAssetTypeCaptureDataSetVolumetric, bad)).toBe(false);
+    });
+
+    test('Other and Bulk Ingestion are exempt (never gated)', () => {
+        const bad = COMMON.assessPackage(['mesh.obj', 'scan.dcm']).possibleTypes;
+        expect(COMMON.isCompatible(V.eAssetAssetTypeOther, bad)).toBe(true);
+        expect(COMMON.isCompatible(V.eAssetAssetTypeBulkIngestion, bad)).toBe(true);
+        expect(COMMON.isValidatableType(V.eAssetAssetTypeOther)).toBe(false);
+        expect(COMMON.isValidatableType(V.eAssetAssetTypeModel)).toBe(true);
+    });
+});

--- a/server/workflow/impl/Packrat/WorkflowUpload.ts
+++ b/server/workflow/impl/Packrat/WorkflowUpload.ts
@@ -194,6 +194,8 @@ export class WorkflowUpload implements WF.IWorkflow {
                 // if we're a model, zipped or not, validate the entire file/collection as is:
                 fileRes = await this.validateFileModel(RSR.fileName, RSR.readStream, false, idSystemObject);
             } else if (isVolume) {
+                if (!Config.features.volumetricIngest)
+                    return this.handleError('Volumetric ingest is currently disabled');
                 // Volumetric ZIP — inspect as a single archive. Must precede the
                 // generic ZIP-cracking branch below or the archive would be unzipped
                 // and validated entry-by-entry, defeating the point.
@@ -226,7 +228,11 @@ export class WorkflowUpload implements WF.IWorkflow {
                     const readStream: NodeJS.ReadableStream | null = await ZS.streamContent(fileName);
                     if (!readStream)
                         return this.handleError(`WorkflowUpload.validateFiles unable to fetch read stream for ${fileName} in zip of asset version ${JSON.stringify(assetVersion, H.Helpers.saferStringify)}`);
-                    await this.validateFile(fileName, readStream, true, idSystemObject, asset);
+                    const entryRes: H.IOResults = await this.validateFile(fileName, readStream, true, idSystemObject, asset);
+                    if (!entryRes.success) {
+                        fileRes = entryRes;
+                        break;
+                    }
                 }
             }
 
@@ -246,30 +252,45 @@ export class WorkflowUpload implements WF.IWorkflow {
         return this.results;
     }
 
+    // Image formats validated via Sharp. Used to tie image validation to the chosen asset type.
+    private static readonly imageFileExtensions: ReadonlySet<string> =
+        new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.svg', '.tif', '.tiff', '.webp']);
+
     private async validateFile(fileName: string, readStream: NodeJS.ReadableStream, fromZip: boolean, idSystemObject: number,
         asset: DBAPI.Asset): Promise<H.IOResults> {
 
-        // validate scene file by loading it:
+        const ext: string = path.extname(fileName).toLowerCase();
+
+        // Volumetric dataset files (.dcm/.pca/.pcr) may only enter via the Volumetric asset type, which
+        // is inspected as a whole archive and never reaches validateFile. Reaching here with one means
+        // it was placed under a non-volumetric type — reject and hard-fail the upload.
+        if (COMMON.isVolumetricFileExtension(ext))
+            return this.handleError(`${fileName} is a volumetric dataset file (${ext}) and can only be ingested using the Volumetric asset type`);
+
+        // Scene descriptor is self-describing by name, independent of the asset type.
         if (fileName.toLowerCase().endsWith('.svx.json'))
             return this.validateFileScene(fileName, readStream);
-        else if (await this.testIfModel(fileName, asset))
-            return this.validateFileModel(fileName, readStream, fromZip, idSystemObject);
-        else {
-            // validate formats handled by Sharp
-            switch (path.extname(fileName).toLowerCase()) {
-                case '.avif':
-                case '.gif':
-                case '.jpg':
-                case '.jpeg':
-                case '.png':
-                case '.svg':
-                case '.tif':
-                case '.tiff':
-                case '.webp':
-                    return this.validateFileImage(fileName, readStream);
 
-                default: break;
-            }
+        // Tie remaining validation to the chosen asset type rather than inferring it from content.
+        // Files that do not match the type's expected formats are skipped (capture-data sets routinely
+        // carry sidecar/metadata files), but the volumetric guard above is never lenient.
+        const eAssetType: COMMON.eVocabularyID | undefined = await asset.assetType();
+        switch (eAssetType) {
+            case COMMON.eVocabularyID.eAssetAssetTypeModel:
+            case COMMON.eVocabularyID.eAssetAssetTypeModelGeometryFile:
+            case COMMON.eVocabularyID.eAssetAssetTypeModelUVMapFile:
+                if (await this.testIfModel(fileName, asset))
+                    return this.validateFileModel(fileName, readStream, fromZip, idSystemObject);
+                break;
+
+            case COMMON.eVocabularyID.eAssetAssetTypeCaptureDataSetPhotogrammetry:
+            case COMMON.eVocabularyID.eAssetAssetTypeCaptureDataFile:
+                if (WorkflowUpload.imageFileExtensions.has(ext))
+                    return this.validateFileImage(fileName, readStream);
+                break;
+
+            default:
+                break;
         }
 
         this.appendToWFReport(`Upload validation skipped for ${fileName}`);

--- a/server/workflow/impl/Packrat/WorkflowUpload.ts
+++ b/server/workflow/impl/Packrat/WorkflowUpload.ts
@@ -189,8 +189,12 @@ export class WorkflowUpload implements WF.IWorkflow {
                 return this.handleError(`WorkflowUpload.validateFiles unable to read asset version ${JSON.stringify(assetVersion, H.Helpers.saferStringify)}: ${RSR.error}`);
             this.appendToWFReport(`Upload validation of ${RSR.fileName}`);
 
-            let fileRes: H.IOResults = { success: true };
-            if (isModel) {
+            // Package/asset-type compatibility pre-flight (off|warn|enforce). In enforce mode a mismatch
+            // fails here, before model/volume/Cook processing; in warn mode it only logs.
+            let fileRes: H.IOResults = await this.validatePackageType(assetVersion, asset, RSR.fileName);
+            if (!fileRes.success) {
+                // fall through to the shared post-processing below, which discards the asset version.
+            } else if (isModel) {
                 // if we're a model, zipped or not, validate the entire file/collection as is:
                 fileRes = await this.validateFileModel(RSR.fileName, RSR.readStream, false, idSystemObject);
             } else if (isVolume) {
@@ -254,7 +258,7 @@ export class WorkflowUpload implements WF.IWorkflow {
 
     // Image formats validated via Sharp. Used to tie image validation to the chosen asset type.
     private static readonly imageFileExtensions: ReadonlySet<string> =
-        new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.svg', '.tif', '.tiff', '.webp']);
+    new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.svg', '.tif', '.tiff', '.webp']);
 
     private async validateFile(fileName: string, readStream: NodeJS.ReadableStream, fromZip: boolean, idSystemObject: number,
         asset: DBAPI.Asset): Promise<H.IOResults> {
@@ -364,6 +368,73 @@ export class WorkflowUpload implements WF.IWorkflow {
             return this.handleError(results.error ?? '');
         this.appendToWFReport(`Upload validated ${fileName}${results.error ? ': ' + results.error : ''}`);
         return results;
+    }
+
+    // Friendly labels for the asset types the package validator adjudicates (for user-facing messages).
+    private static readonly packageTypeLabels: ReadonlyMap<COMMON.eVocabularyID, string> = new Map([
+        [COMMON.eVocabularyID.eAssetAssetTypeModel, 'Model'],
+        [COMMON.eVocabularyID.eAssetAssetTypeCaptureDataSetPhotogrammetry, 'Photogrammetry'],
+        [COMMON.eVocabularyID.eAssetAssetTypeCaptureDataSetVolumetric, 'Volumetric'],
+        [COMMON.eVocabularyID.eAssetAssetTypeScene, 'Scene'],
+        [COMMON.eVocabularyID.eAssetAssetTypeProjectDocumentation, 'Project Documentation'],
+    ]);
+
+    private packageTypeLabel(type: COMMON.eVocabularyID): string {
+        return WorkflowUpload.packageTypeLabels.get(type) ?? COMMON.eVocabularyID[type] ?? String(type);
+    }
+
+    // Pre-flight: does the uploaded package's file set match the selected asset type? Honors
+    // Config.features.packageValidationMode (off|warn|enforce). Returns failure only in enforce mode on
+    // a mismatch; off / warn / compatible all return success.
+    private async validatePackageType(assetVersion: DBAPI.AssetVersion, asset: DBAPI.Asset, fileName: string): Promise<H.IOResults> {
+        const mode: 'off' | 'warn' | 'enforce' = Config.features.packageValidationMode;
+        if (mode === 'off')
+            return { success: true };
+
+        const selectedType: COMMON.eVocabularyID | undefined = await asset.assetType();
+        if (selectedType === undefined || !COMMON.isValidatableType(selectedType))
+            return { success: true };   // Other / Bulk Ingestion / legacy capture types are not gated
+
+        const files: string[] | null = await this.collectPackageFiles(assetVersion, fileName);
+        if (!files || files.length === 0)
+            return { success: true };   // unreadable / empty here — let normal validation surface it
+
+        const possibleTypes: Set<COMMON.eVocabularyID> = COMMON.assessPackage(files).possibleTypes;
+        if (COMMON.isCompatible(selectedType, possibleTypes))
+            return { success: true };
+
+        const selectedLabel: string = this.packageTypeLabel(selectedType);
+        const detected: string = [...possibleTypes].map(t => this.packageTypeLabel(t)).join(', ') || 'an unrecognized combination of files';
+        const message: string = `Upload contents do not match the selected asset type '${selectedLabel}'. Detected: ${detected}.`;
+
+        if (mode === 'enforce')
+            return this.handleError(message);
+
+        RK.logWarning(RK.LogSection.eWF, 'package validation mismatch', message, { fileName, selected: selectedLabel, detected }, 'Workflow.Upload');
+        await this.appendToWFReport(`[package-validation] would reject (warn mode): ${message}`);
+        return { success: true };
+    }
+
+    // Resolve the list of file names a package contains: the entries of a zip, or the single file name.
+    // Returns null on an unreadable / corrupt archive so the caller skips assessment and the normal
+    // upload path surfaces the real error.
+    private async collectPackageFiles(assetVersion: DBAPI.AssetVersion, fileName: string): Promise<string[] | null> {
+        if (path.extname(fileName).toLowerCase() !== '.zip')
+            return [fileName];
+
+        const storage: STORE.IStorage | null = await STORE.StorageFactory.getInstance();
+        if (!storage)
+            return null;
+        const filePath: string = await storage.stagingFileName(assetVersion.StorageKeyStaging);
+        const ZS: ZipFile = new ZipFile(filePath);
+        const zipRes: H.IOResults = await ZS.load();
+        if (!zipRes.success)
+            return null;
+        try {
+            return await ZS.getJustFiles(null);
+        } finally {
+            await ZS.close();
+        }
     }
 
     private async appendToWFReport(message: string, isError?: boolean | undefined): Promise<H.IOResults> {


### PR DESCRIPTION
- Gates volumetric ingest behind a config flag (off by default)
- Hides volumetric in the upload type dropdown
- Server rejects volumetric ingest when disabled
- Centralized file-extension classifier in common
- Shared by client and server (one source of truth)
- Validates upload package vs selected asset type
- Tri-state flag: off, warn, or enforce (ships warn)
- Pure type predicates; covered by unit tests
- Enforcement and client UX deferred to a later phase
- Based on develop; clean fast-forward merge