### PR TITLE
DPO3DPKRT-818/Fix Duplicate Published Name And Subtitle

### DIFF
--- a/server/collections/impl/PublishScene.ts
+++ b/server/collections/impl/PublishScene.ts
@@ -885,7 +885,7 @@ export class PublishScene {
 
         const subjectName: string = this.subject ? this.subject.Name : '';
         const sceneName: string = this.scene ? this.scene.Name : '';
-        const name: string = subjectName + ((sceneName && sceneName != 'Scene') ? `: ${sceneName}` : '');   // Full title of edanmdm record, plus a possible scene title
+        const name: string = subjectName + ((sceneName && sceneName != 'Scene' && sceneName != subjectName) ? `: ${sceneName}` : '');   // Full title of edanmdm record, plus a possible scene title
         const title: string = `${name} (${category} ${type}, ${MODEL_FILE_TYPE}, scale in ${UNITS})`;       // name, below, plus ($$category$$ $$type$$, $$attributes.MODEL_FILE_TYPE$$, scale in $$attributes.UNITS$$)
 
         const url: string = `https://3d-api.si.edu/content/document/3d_package:${uuid}/resources/${SAC.assetVersion.FileName}`;

--- a/server/graphql/schema/unit/resolvers/queries/getIngestionItems.ts
+++ b/server/graphql/schema/unit/resolvers/queries/getIngestionItems.ts
@@ -43,7 +43,7 @@ export default async function getIngestionItems(_: Parent, args: QueryGetIngesti
         IngestionItem.push({
             idItem: itemAndProject.idItem,
             EntireSubject: itemAndProject.EntireSubject ?? true,
-            MediaGroupName: itemAndProject.Name ?? '',
+            MediaGroupName: itemAndProject.Title ?? '',
             idProject: itemAndProject.idProject,
             ProjectName: itemAndProject.ProjectName ?? 'Unknown',
         });


### PR DESCRIPTION
- Skip scene name in package title when equals subject
- Return Item.Title not Item.Name for media subtitle

Note: cleaned out duplicates in DB. Affected scenes will require republishing for changes to be reflected in EDAN.