### PR TITLE
DPO3DPKRT-1012/Unpublish Retired Scenes

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -111,6 +111,12 @@ export default class API {
         return this.request(uri, { method: 'PATCH', body });
     }
 
+    // object action — describe/retire/reinstate an object and its resolved dependents/assets
+    static async objectAction(idSystemObject: number, action: 'describe' | 'retire' | 'reinstate'): Promise<RequestResponse> {
+        const body = JSON.stringify({ idSystemObject, action });
+        return this.request('api/object/action', { method: 'POST', body });
+    }
+
     // volumetric inspection results — returns the JSON produced by JobVolumeInspect
     // for the given asset version. data is null when no completed inspection exists.
     static async getVolumetricInspectionResults(idAssetVersion: number): Promise<RequestResponse> {

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -117,6 +117,11 @@ export default class API {
         return this.request('api/object/action', { method: 'POST', body });
     }
 
+    // scenes still in a published EDAN state (retired-first); orphan reconciliation report
+    static async getPublishedScenes(): Promise<RequestResponse> {
+        return this.request('api/scene/published', { method: 'GET' });
+    }
+
     // volumetric inspection results — returns the JSON produced by JobVolumeInspect
     // for the given asset version. data is null when no completed inspection exists.
     static async getVolumetricInspectionResults(idAssetVersion: number): Promise<RequestResponse> {

--- a/client/src/pages/Admin/components/AdminToolsView.tsx
+++ b/client/src/pages/Admin/components/AdminToolsView.tsx
@@ -19,6 +19,7 @@ import ToolsAssetValidation from './Tools/ToolsAssetValidation';
 import ToolsSystemOps from './Tools/ToolsSystemOps';
 import ToolsAuthorizationOverview from './Tools/ToolsAuthorizationOverview';
 import ToolsExternalSources from './Tools/ToolsExternalSources';
+import ToolsPublishedScenes from './Tools/ToolsPublishedScenes';
 
 // styles
 import { makeStyles } from '@material-ui/core/styles';
@@ -83,6 +84,7 @@ function AdminToolsView(): React.ReactElement {
         batchOps: false,
         assetValidation: false,
         systemOps: false,
+        publishedScenes: false,
         authorization: false,
         externalSources: false,
     });
@@ -133,6 +135,17 @@ function AdminToolsView(): React.ReactElement {
                                 </IconButton>
                                 <Collapse in={openSections.systemOps} className={classes.collapseContainer}>
                                     <ToolsSystemOps />
+                                </Collapse>
+                            </Box>
+
+                            {/* Published Scenes (EDAN orphan reconciliation) */}
+                            <Box>
+                                <IconButton className={classes.collapseHeader} onClick={() => toggleSection('publishedScenes')}>
+                                    EDAN: Published Scenes
+                                    {openSections.publishedScenes ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                                </IconButton>
+                                <Collapse in={openSections.publishedScenes} className={classes.collapseContainer}>
+                                    {openSections.publishedScenes && <ToolsPublishedScenes />}
                                 </Collapse>
                             </Box>
 

--- a/client/src/pages/Admin/components/Tools/ToolsPublishedScenes.tsx
+++ b/client/src/pages/Admin/components/Tools/ToolsPublishedScenes.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable camelcase */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, Typography, Button } from '@material-ui/core';
+import { toast } from 'react-toastify';
+import API, { RequestResponse } from '../../../../api';
+import { ColumnHeader, useStyles as useToolsStyles } from '../shared/DataTypesStyles';
+import { DataTableSelect } from '../shared/DataTableSelect';
+
+type PublishedSceneRow = {
+    id: number;                 // idSystemObject — drives the details link and the row id
+    name: string;
+    name_link: string;
+    publishedState: string;
+    retired: string;
+    edanUUID: string;
+    _edanUUID: string | null;
+};
+
+const columns: ColumnHeader[] = [
+    { key: 'name', label: 'Scene', align: 'left', link: true },
+    { key: 'publishedState', label: 'Published State', align: 'center' },
+    { key: 'retired', label: 'Retired', align: 'center' },
+    { key: 'edanUUID', label: 'EDAN UUID', align: 'left' },
+];
+
+function ToolsPublishedScenes(): React.ReactElement {
+    const classes = useToolsStyles();
+
+    const [rows, setRows] = useState<PublishedSceneRow[]>([]);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [total, setTotal] = useState<number>(0);
+    const [orphanCount, setOrphanCount] = useState<number>(0);
+
+    const fetchData = useCallback(async () => {
+        try {
+            setIsLoading(true);
+            const result: RequestResponse = await API.getPublishedScenes();
+            if (!result?.success) {
+                toast.error(result?.message ?? 'Failed to load published scenes');
+                return;
+            }
+            const data = result.data ?? { scenes: [], total: 0, orphanCount: 0 };
+            const mapped: PublishedSceneRow[] = (data.scenes ?? []).map((s: any) => ({
+                id: s.idSystemObject,
+                name: s.name ?? `Scene ${s.idScene}`,
+                name_link: `/repository/details/${s.idSystemObject}`,
+                publishedState: s.publishedState,
+                retired: s.retired ? '⚠ Yes' : 'No',
+                edanUUID: s.edanUUID ?? '',
+                _edanUUID: s.edanUUID ?? null,
+            }));
+            setRows(mapped);
+            setTotal(data.total ?? mapped.length);
+            setOrphanCount(data.orphanCount ?? mapped.filter(m => m.retired.includes('Yes')).length);
+        } catch (error) {
+            console.error('[Packrat:ERROR] fetchPublishedScenes:', error);
+            toast.error('Failed to load published scenes');
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { fetchData(); }, [fetchData]);
+
+    const noop = () => { /* DataTableSelect requires onUpdateSelection */ };
+
+    return (
+        <Box>
+            <Typography variant='body1' gutterBottom>
+                Scenes whose latest version is in a published EDAN state. Rows marked <b>⚠ Yes</b> under Retired are
+                orphans — retired in Packrat but still live in EDAN — and should be unpublished from their details page.
+            </Typography>
+            <Typography variant='body2' gutterBottom>
+                <b>{total}</b> published scene(s), <b>{orphanCount}</b> orphan(s).
+            </Typography>
+
+            <Box display='flex' mb={1}>
+                <Button className={classes.btn} variant='contained' color='primary' onClick={fetchData}
+                    style={{ width: 'auto', minWidth: 100, paddingLeft: 16, paddingRight: 16 }}
+                >
+                    Refresh
+                </Button>
+            </Box>
+
+            <DataTableSelect
+                columns={columns}
+                data={rows}
+                onUpdateSelection={noop}
+                isLoading={isLoading}
+                selectable={false}
+                expandable
+                renderExpanded={(row: PublishedSceneRow) => (
+                    <Box p={1} display='flex' style={{ gap: 8 }}>
+                        <Button size='small' variant='contained' color='primary' style={{ color: 'white' }}
+                            onClick={() => { window.open(row.name_link, '_blank'); }}
+                        >
+                            Open in Repository
+                        </Button>
+                        <Button size='small' variant='contained' color='primary' style={{ color: 'white' }}
+                            disabled={!row._edanUUID}
+                            onClick={() => { if (row._edanUUID) { navigator.clipboard.writeText(row._edanUUID); toast.info('EDAN UUID copied'); } }}
+                        >
+                            Copy EDAN UUID
+                        </Button>
+                    </Box>
+                )}
+            />
+        </Box>
+    );
+}
+
+export default ToolsPublishedScenes;

--- a/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/FileListItem.tsx
@@ -15,7 +15,7 @@ import { FaCheckCircle, FaRedo, FaRegCircle } from 'react-icons/fa';
 import { IoIosCloseCircle } from 'react-icons/io';
 import { MdFileUpload } from 'react-icons/md';
 import { Progress } from '../../../../components';
-import { FileId, VocabularyOption, UNASSIGNED_ASSET_TYPE } from '../../../../store';
+import { FileId, VocabularyOption, UNASSIGNED_ASSET_TYPE, useServiceStatusStore } from '../../../../store';
 import { palette } from '../../../../theme';
 import Colors from '../../../../theme/colors';
 import { formatBytes } from '../../../../utils/upload';
@@ -197,6 +197,7 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
         onSelect
     } = props;
     const classes = useStyles(props);
+    const volumetricIngestEnabled = useServiceStatusStore(state => state.features.volumetricIngest);
     const upload = () => {
         onUpload(id);
     };
@@ -283,8 +284,13 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
                     Select type…
                 </MenuItem>
                 {typeOptions.map(function (option: VocabularyOption, index) {
+                    const term: string = option.Term.toLowerCase();
+                    // Volumetric is a gated rollout: only selectable when the server enables
+                    // it, keeping the option in sync with what the upload/ingest paths accept.
+                    if (term === 'capture data set: volumetric' && !volumetricIngestEnabled)
+                        return null;
                     // Silence unsupported types:
-                    switch (option.Term.toLowerCase()) {
+                    switch (term) {
                         case 'bulk ingestion':
                         case 'capture data set: diconde':
                         case 'capture data set: dicom':
@@ -292,7 +298,6 @@ function FileListItem(props: FileListItemProps): React.ReactElement {
                         case 'capture data set: spherical laser':
                         case 'capture data set: structured light':
                         case 'capture data set: other':
-                        case 'capture data set: volumetric':
                         case 'capture data file':
                         case 'model geometry file':
                         case 'model uv map file':

--- a/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
@@ -4,13 +4,12 @@
  *
  * This component renders object details for the Repository Details UI.
  */
-import { Box, Checkbox, Typography, Select, MenuItem, Tooltip, Divider } from '@material-ui/core';
-import { withStyles, makeStyles, createStyles } from '@material-ui/core/styles';
-import React, { useEffect, useState } from 'react';
+import { Box, Button, Typography, Select, MenuItem, Tooltip, Divider } from '@material-ui/core';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
+import React, { useEffect, useRef, useState } from 'react';
 import { NewTabLink } from '../../../../components';
 import { GetSystemObjectDetailsResult, RepositoryPath, License, ObjectPropertyResult, Unit } from '../../../../types/graphql';
-import { getDetailsUrlForObject, getUpdatedCheckboxProps, isFieldUpdated } from '../../../../utils/repository';
-import { withDefaultValueBoolean } from '../../../../utils/shared';
+import { getDetailsUrlForObject } from '../../../../utils/repository';
 import { useLicenseStore, useDetailTabStore } from '../../../../store';
 import { clearLicenseAssignment, assignLicense, publish } from '../../hooks/useDetailsView';
 import { getTermForSystemObjectType } from '../../../../utils/repository';
@@ -20,6 +19,7 @@ import { eSystemObjectType, ePublishedState } from '@dpo-packrat/common';
 import { ToolTip } from '../../../../components';
 import { HelpOutline } from '@material-ui/icons';
 import { getUnitsList } from '../../../Admin/hooks/useAdminView';
+import RetireActionModal from './RetireActionModal';
 
 const useStyles = makeStyles(({ palette }) => createStyles({
     detail: {
@@ -93,16 +93,6 @@ const useObjectDetailsStyles = makeStyles(({ breakpoints, palette }) => ({
     }
 }));
 
-const CheckboxNoPadding = withStyles({
-    root: {
-        border: '0px',
-        padding: '0px',
-        height: 10,
-        width: 10,
-        paddingLeft: 3
-    }
-})(Checkbox);
-
 interface ObjectDetailsProps {
     unit?: RepositoryPath[] | null;
     project?: RepositoryPath[] | null;
@@ -119,6 +109,7 @@ interface ObjectDetailsProps {
     objectType?: number;
     originalFields?: GetSystemObjectDetailsResult;
     onRetiredUpdate?: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
+    onRetireComplete?: () => void;
     onLicenseUpdate?: (event) => void;
     onPublishUpdate?: () => void;
     onLicenseChange?: () => void;
@@ -145,8 +136,7 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
         hideRetired,
         objectType,
         disabled,
-        originalFields,
-        onRetiredUpdate,
+        onRetireComplete,
         onLicenseUpdate,
         onPublishUpdate,
         idSystemObject,
@@ -158,8 +148,9 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
     } = props;
     const [licenseList, setLicenseList] = useState<License[]>([]);
     const [loading, setLoading] = useState(false);
+    const [retireModalOpen, setRetireModalOpen] = useState(false);
+    const retireChangedRef = useRef(false);
     const [unitList, setUnitList] = useState<Unit[]>([]);
-    const isRetiredUpdated: boolean = isFieldUpdated({ retired }, originalFields, 'retired');
     const getEntries = useLicenseStore(state => state.getEntries);
     const [ProjectDetails, updateDetailField] = useDetailTabStore(state => [state.ProjectDetails, state.updateDetailField]);
     const classes = useObjectDetailsStyles(props);
@@ -378,18 +369,35 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
                     <Divider className={classes.sectionDivider} />
                     <Detail
                         label='Retired'
-                        name='retired'
                         valueComponent={
-                            <CheckboxNoPadding
-                                id='retired'
-                                name='retired'
-                                disabled={disabled}
-                                checked={withDefaultValueBoolean(retired, false)}
-                                onChange={onRetiredUpdate}
-                                {...getUpdatedCheckboxProps(isRetiredUpdated)}
-                                color='primary'
-                            />
+                            <Box className={classes.buttonRow}>
+                                <Typography className={classes.value}>{retired ? 'Yes' : 'No'}</Typography>
+                                <Button
+                                    size='small'
+                                    variant='contained'
+                                    color='primary'
+                                    style={{ color: '#fff' }}
+                                    disabled={disabled}
+                                    onClick={() => setRetireModalOpen(true)}
+                                >
+                                    {retired ? 'Reinstate' : 'Retire'}
+                                </Button>
+                            </Box>
                         }
+                    />
+                    <Divider className={classes.sectionDivider} />
+                    <RetireActionModal
+                        open={retireModalOpen}
+                        idSystemObject={idSystemObject}
+                        retire={!retired}
+                        onComplete={() => { retireChangedRef.current = true; }}
+                        onClose={() => {
+                            setRetireModalOpen(false);
+                            if (retireChangedRef.current) {
+                                retireChangedRef.current = false;
+                                onRetireComplete?.();
+                            }
+                        }}
                     />
                 </>
             )}

--- a/client/src/pages/Repository/components/DetailsView/RetireActionModal.tsx
+++ b/client/src/pages/Repository/components/DetailsView/RetireActionModal.tsx
@@ -1,0 +1,264 @@
+/* eslint-disable react/jsx-max-props-per-line */
+/**
+ * RetireActionModal
+ *
+ * Two-phase modal for retiring/reinstating an object and its dependents. It first previews the
+ * objects that will be touched (from `describe`), highlighting scenes that will be unpublished from
+ * EDAN and any scope-guard blockers, then executes and shows a per-object result. On a partial EDAN
+ * failure the operation aborts (nothing retired) and can be retried.
+ *
+ * The preview lists objects (Scene/Model/…); their attached asset files are retired with them but
+ * summarized as a count rather than listed, to keep the list legible.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Typography, Chip, Tooltip, CircularProgress,
+    Table, TableHead, TableBody, TableRow, TableCell } from '@material-ui/core';
+import { toast } from 'react-toastify';
+import API from '../../../../api';
+
+type ItemStatus = 'succeeded' | 'failed' | 'skipped' | 'notApplied';
+
+export type ObjectActionSummary = {
+    idSystemObject: number;
+    objectType: string;
+    name: string | null;
+    kind: 'object' | 'asset';
+    depth?: number;
+    retired?: boolean;
+    unit?: string | null;
+    project?: string | null;
+    subject?: string | null;
+    publishedState?: string;
+    edanUUID?: string | null;
+    status?: ItemStatus;
+    unpublishedFromEdan?: boolean;
+    error?: string;
+    blockerReason?: string;
+};
+
+type Phase = 'loading' | 'preview' | 'executing' | 'results';
+
+interface RetireActionModalProps {
+    open: boolean;
+    idSystemObject: number;
+    retire: boolean;                 // true = retire, false = reinstate
+    onClose: () => void;
+    onComplete: () => void;          // fired after a successful apply so the caller can refetch
+}
+
+const PUBLISHED = (s?: string): boolean => !!s && s !== 'Not Published';
+
+function statusColor(status?: ItemStatus): string {
+    switch (status) {
+        case 'succeeded': return '#2e7d32';
+        case 'failed':    return '#c62828';
+        case 'skipped':   return '#757575';
+        case 'notApplied':return '#ed6c02';
+        default:          return '#757575';
+    }
+}
+
+function RetireActionModal(props: RetireActionModalProps): React.ReactElement {
+    const { open, idSystemObject, retire, onClose, onComplete } = props;
+    const verb: string = retire ? 'Retire' : 'Reinstate';
+
+    const [phase, setPhase] = useState<Phase>('loading');
+    const [objects, setObjects] = useState<ObjectActionSummary[]>([]);
+    const [blockers, setBlockers] = useState<ObjectActionSummary[]>([]);
+    const [applied, setApplied] = useState<boolean>(false);
+    const [message, setMessage] = useState<string>('');
+    const [loadError, setLoadError] = useState<string>('');
+
+    const loadPreview = useCallback(async () => {
+        setPhase('loading');
+        setLoadError('');
+        const res = await API.objectAction(idSystemObject, 'describe');
+        if (!res?.success || !res.data) {
+            setLoadError(res?.message ?? 'Unable to load preview');
+            setPhase('preview');
+            return;
+        }
+        setObjects(res.data.objects ?? []);
+        setBlockers(res.data.blockers ?? []);
+        setPhase('preview');
+    }, [idSystemObject]);
+
+    useEffect(() => {
+        if (open) {
+            setObjects([]);
+            setBlockers([]);
+            setApplied(false);
+            setMessage('');
+            loadPreview();
+        }
+    }, [open, loadPreview]);
+
+    const execute = async () => {
+        setPhase('executing');
+        const res = await API.objectAction(idSystemObject, retire ? 'retire' : 'reinstate');
+        const resultObjects: ObjectActionSummary[] = res?.data?.objects ?? [];
+        const statusById: Map<number, ObjectActionSummary> = new Map(resultObjects.map(o => [o.idSystemObject, o]));
+
+        setObjects(prev => prev.map(o => {
+            const r = statusById.get(o.idSystemObject);
+            return r ? { ...o, status: r.status, error: r.error, unpublishedFromEdan: r.unpublishedFromEdan } : o;
+        }));
+        setApplied(!!res?.data?.applied);
+        setMessage(res?.message ?? '');
+        setPhase('results');
+
+        if (res?.data?.applied) {
+            toast.success(res.message ?? `${verb} succeeded`);
+            onComplete();
+        } else
+            toast.error(res?.message ?? `${verb} failed`);
+    };
+
+    const showStatus: boolean = phase === 'results';
+    const objectCount: number = objects.filter(o => o.kind === 'object').length;
+    const assetCount: number = objects.filter(o => o.kind === 'asset').length;
+    const sceneUnpublishCount: number = objects.filter(o => PUBLISHED(o.publishedState)).length;
+    const succeededCount: number = objects.filter(o => o.status === 'succeeded').length;
+    const errorCount: number = objects.filter(o => o.status === 'failed').length;
+
+    // Show the full tree in the server's depth-first order; indentation (by depth) nests assets and
+    // derived objects under their parent.
+    const rows: ObjectActionSummary[] = objects;
+
+    // Names shared by more than one row get a * so the user knows to hover for distinguishing context.
+    const nameCounts: Map<string, number> = new Map<string, number>();
+    rows.forEach(o => { const n = o.name ?? ''; nameCounts.set(n, (nameCounts.get(n) ?? 0) + 1); });
+    const duplicateName = (name: string | null): boolean => !!name && (nameCounts.get(name) ?? 0) > 1;
+    const hasDuplicates: boolean = Array.from(nameCounts.values()).some(c => c > 1);
+
+    const renderState = (o: ObjectActionSummary): React.ReactElement | null => {
+        if (showStatus) {
+            return (
+                <Box display='flex' alignItems='center' style={{ gap: 6 }}>
+                    {o.status && (
+                        <Tooltip arrow title={o.error ?? ''}>
+                            <Chip label={o.status} size='small' style={{ color: '#fff', backgroundColor: statusColor(o.status) }} />
+                        </Tooltip>
+                    )}
+                    {o.unpublishedFromEdan && o.status === 'notApplied' && (
+                        <Tooltip arrow title='Unpublished from EDAN but not retired (operation aborted); rerun to finish.'>
+                            <Chip label='EDAN unpublished' size='small' variant='outlined' />
+                        </Tooltip>
+                    )}
+                </Box>
+            );
+        }
+        if (retire && PUBLISHED(o.publishedState))
+            return <Chip label={`Unpublish from EDAN (${o.publishedState})`} size='small' style={{ backgroundColor: '#fff3e0', color: '#ed6c02' }} />;
+        if (o.publishedState)
+            return <Typography variant='caption' style={{ color: '#757575' }}>{o.publishedState}</Typography>;
+        return null;
+    };
+
+    return (
+        <Dialog open={open} onClose={phase === 'executing' ? undefined : onClose} maxWidth='md' fullWidth>
+            <DialogTitle>{verb} object and dependents</DialogTitle>
+            <DialogContent dividers>
+                {phase === 'loading' && (
+                    <Box display='flex' alignItems='center' justifyContent='center' py={3} style={{ gap: 10 }}>
+                        <CircularProgress size={22} /><Typography>Computing affected objects…</Typography>
+                    </Box>
+                )}
+
+                {phase !== 'loading' && (
+                    <>
+                        {loadError && <Typography color='error' style={{ marginBottom: 8 }}>{loadError}</Typography>}
+
+                        {/* Header: preview counts, or completion status */}
+                        {showStatus ? (
+                            <Typography variant='subtitle1' style={{ fontWeight: 600, color: applied ? '#2e7d32' : '#c62828', marginBottom: 4 }}>
+                                {applied
+                                    ? `✓ ${verb} complete — ${succeededCount} object(s) ${retire ? 'retired' : 'reinstated'}`
+                                    : `✕ ${verb} failed — ${errorCount} error(s); no objects were ${retire ? 'retired' : 'reinstated'}`}
+                            </Typography>
+                        ) : (
+                            <Typography variant='body2' style={{ marginBottom: 4 }}>
+                                {verb} will affect {objectCount} object(s){assetCount > 0 ? ` and ${assetCount} asset(s)` : ''}.
+                            </Typography>
+                        )}
+
+                        {message && showStatus && <Typography variant='caption' style={{ color: '#757575' }}>{message}</Typography>}
+
+                        {retire && sceneUnpublishCount > 0 && !showStatus && (
+                            <Typography variant='body2' style={{ color: '#ed6c02', marginBottom: 4 }}>
+                                {sceneUnpublishCount} published scene(s) will be unpublished from EDAN.
+                            </Typography>
+                        )}
+
+                        {blockers.length > 0 && (
+                            <Box style={{ backgroundColor: '#fdecea', padding: 8, borderRadius: 4, margin: '8px 0' }}>
+                                <Typography variant='body2' color='error' style={{ fontWeight: 600 }}>
+                                    {blockers.length} container object(s) reached through an unexpected relationship — NOT retired:
+                                </Typography>
+                                {blockers.map(b => (
+                                    <Typography key={b.idSystemObject} variant='caption' style={{ display: 'block' }}>
+                                        {b.name ?? `SystemObject ${b.idSystemObject}`} ({b.objectType})
+                                    </Typography>
+                                ))}
+                            </Box>
+                        )}
+
+                        <Box style={{ maxHeight: 380, overflowY: 'auto', marginTop: 8 }}>
+                            <Table size='small' stickyHeader>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Object</TableCell>
+                                        <TableCell style={{ width: 120 }}>Type</TableCell>
+                                        <TableCell style={{ width: 240 }}>{showStatus ? 'Result' : 'State'}</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {rows.map(o => {
+                                        const depth: number = o.depth ?? 0;
+                                        const ancestry: string = [o.subject, o.project, o.unit].filter(Boolean).join(' • ');
+                                        const label: string = `${o.name ?? `SystemObject ${o.idSystemObject}`}${duplicateName(o.name) ? ' *' : ''}`;
+                                        const nameEl = <Typography variant='body2' style={{ fontWeight: 500, wordBreak: 'break-word' }}>{label}</Typography>;
+                                        return (
+                                            <TableRow key={o.idSystemObject}>
+                                                <TableCell>
+                                                    <Box style={{ paddingLeft: depth * 16, display: 'flex', alignItems: 'flex-start' }}>
+                                                        {depth > 1 && (
+                                                            <Typography variant='body2' style={{ color: '#9e9e9e', marginRight: 6, userSelect: 'none', whiteSpace: 'nowrap' }}>└─</Typography>
+                                                        )}
+                                                        {ancestry ? <Tooltip arrow title={ancestry}>{nameEl}</Tooltip> : nameEl}
+                                                    </Box>
+                                                </TableCell>
+                                                <TableCell>{o.objectType}</TableCell>
+                                                <TableCell>{renderState(o)}</TableCell>
+                                            </TableRow>
+                                        );
+                                    })}
+                                </TableBody>
+                            </Table>
+                        </Box>
+                        {rows.length > 0 && (
+                            <Typography variant='caption' style={{ color: '#757575', display: 'block', marginTop: 6 }}>
+                                Hover an object name to see its Subject • Project • Unit.{hasDuplicates ? ' * marks objects that share a name.' : ''}
+                            </Typography>
+                        )}
+                    </>
+                )}
+            </DialogContent>
+            <DialogActions>
+                {phase === 'executing' && <CircularProgress size={20} style={{ marginRight: 8 }} />}
+                {phase !== 'results' && (
+                    <Button onClick={onClose} disabled={phase === 'executing'}>Cancel</Button>
+                )}
+                {phase === 'preview' && !loadError && (
+                    <Button onClick={execute} variant='contained' color='primary' style={{ color: '#fff' }}>{verb}</Button>
+                )}
+                {phase === 'results' && !applied && (
+                    <Button onClick={execute} variant='contained' color='primary' style={{ color: '#fff' }}>Retry</Button>
+                )}
+                {phase === 'results' && <Button onClick={onClose} color='primary'>Close</Button>}
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default RetireActionModal;

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -1011,6 +1011,11 @@ function DetailsView(): React.ReactElement {
                         hideRetired={hideRetired}
                         objectType={objectType}
                         onRetiredUpdate={onRetiredUpdate}
+                        onRetireComplete={() => {
+                            refetch();
+                            fetchDetailTabDataAndSetState();
+                            setRefreshTick(t => t + 1);
+                        }}
                         onLicenseUpdate={onLicenseUpdate}
                         onPublishUpdate={onPublishUpdate}
                         onLicenseChange={onDetailUpdate}

--- a/client/src/store/serviceStatus.ts
+++ b/client/src/store/serviceStatus.ts
@@ -14,8 +14,15 @@ interface ServiceStatusState {
     edan: boolean;
 }
 
+// Server-side feature gates mirrored into the client so the UI only offers what the
+// server will accept. Defaults are conservative (off) until the first status poll.
+interface ServiceFeatures {
+    volumetricIngest: boolean;
+}
+
 type ServiceStatusStore = {
     status: ServiceStatusState;
+    features: ServiceFeatures;
     initialized: boolean;
     checkStatus: () => Promise<void>;
     startPolling: () => void;
@@ -27,6 +34,7 @@ const POLL_INTERVAL = 60000; // 60 seconds
 
 export const useServiceStatusStore = create<ServiceStatusStore>((set: SetState<ServiceStatusStore>, get: GetState<ServiceStatusStore>) => ({
     status: { database: true, solr: true, edan: true },
+    features: { volumetricIngest: false },
     initialized: false,
     _intervalId: null,
     checkStatus: async (): Promise<void> => {
@@ -63,7 +71,11 @@ export const useServiceStatusStore = create<ServiceStatusStore>((set: SetState<S
                 toast.success('EDAN publishing service restored.', { toastId: 'edan-up' });
             }
 
-            set({ status: next, initialized: true });
+            const features: ServiceFeatures = {
+                volumetricIngest: result.features?.volumetricIngest ?? false,
+            };
+
+            set({ status: next, features, initialized: true });
         } catch {
             // If the status endpoint itself fails, assume everything is down
             const prev = get().status;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -393,6 +393,59 @@ export enum eSystemObjectType {
     eStakeholder = 13,
 }
 
+/**
+ * Containment tier per SystemObject type, ordered top-level container (low) to leaf (high). Used to
+ * detect an inverted edge — a structural container placed beneath a lower-tier object — which the
+ * xref wiring and the retire cascade must never follow. Ancillary types that attach at varying points
+ * (Actor, Stakeholder, ProjectDocumentation) are deliberately left unranked so the guard forms no
+ * opinion on them.
+ */
+const eSystemObjectContainmentRank: Map<eSystemObjectType, number> = new Map<eSystemObjectType, number>([
+    [eSystemObjectType.eUnit, 0],
+    [eSystemObjectType.eProject, 1],
+    [eSystemObjectType.eSubject, 2],
+    [eSystemObjectType.eItem, 3],
+    [eSystemObjectType.eCaptureData, 4],
+    [eSystemObjectType.eModel, 4],
+    [eSystemObjectType.eScene, 4],
+    [eSystemObjectType.eIntermediaryFile, 4],
+    [eSystemObjectType.eAsset, 5],
+    [eSystemObjectType.eAssetVersion, 6],
+]);
+
+/** Structural container types whose accidental retirement or inverted wiring is catastrophic. */
+const eSystemObjectContainerTypes: Set<eSystemObjectType> = new Set<eSystemObjectType>([
+    eSystemObjectType.eUnit,
+    eSystemObjectType.eProject,
+    eSystemObjectType.eSubject,
+    eSystemObjectType.eItem,
+]);
+
+/** Containment rank for a type, or undefined for unranked ancillary types. */
+export function containmentRank(eType: eSystemObjectType): number | undefined {
+    return eSystemObjectContainmentRank.get(eType);
+}
+
+/** True when the type is a structural container (Unit, Project, Subject, Item). */
+export function isContainerType(eType: eSystemObjectType): boolean {
+    return eSystemObjectContainerTypes.has(eType);
+}
+
+/**
+ * True when placing eDerivedType beneath eMasterType inverts the containment hierarchy — the derived
+ * is a structural container ranked above the master. Returns false when either rank is unknown, so the
+ * guard never blocks a relationship it has no opinion on (e.g. an ancillary master or derived).
+ */
+export function isInvertedContainmentEdge(eMasterType: eSystemObjectType, eDerivedType: eSystemObjectType): boolean {
+    if (!isContainerType(eDerivedType))
+        return false;
+    const masterRank: number | undefined = containmentRank(eMasterType);
+    const derivedRank: number | undefined = containmentRank(eDerivedType);
+    if (masterRank === undefined || derivedRank === undefined)
+        return false;
+    return derivedRank < masterRank;
+}
+
 export enum eLicense {
     eViewDownloadCC0 = 1,           // CC0, Publishable w/ Downloads
     eViewDownloadRestriction = 2,   // SI ToU, Publishable w/ Downloads

--- a/server/db/api/ObjectType.ts
+++ b/server/db/api/ObjectType.ts
@@ -109,6 +109,33 @@ export function SystemObjectNameToType(objectTypeName: string | null): COMMON.eS
     }
 }
 
+/** Structural view of a SystemObject row: exactly one id field is populated. Typed here rather than
+ *  importing the SystemObject class to avoid a circular dependency. */
+type SystemObjectIDFields = {
+    idUnit: number | null; idProject: number | null; idSubject: number | null; idItem: number | null;
+    idCaptureData: number | null; idModel: number | null; idScene: number | null; idIntermediaryFile: number | null;
+    idProjectDocumentation: number | null; idAsset: number | null; idAssetVersion: number | null;
+    idActor: number | null; idStakeholder: number | null;
+};
+
+/** Derives the eSystemObjectType of a SystemObject row from its populated foreign key. */
+export function SystemObjectTypeFromSystemObject(SO: SystemObjectIDFields): COMMON.eSystemObjectType {
+    if (SO.idUnit)                  return COMMON.eSystemObjectType.eUnit;
+    if (SO.idProject)               return COMMON.eSystemObjectType.eProject;
+    if (SO.idSubject)               return COMMON.eSystemObjectType.eSubject;
+    if (SO.idItem)                  return COMMON.eSystemObjectType.eItem;
+    if (SO.idCaptureData)           return COMMON.eSystemObjectType.eCaptureData;
+    if (SO.idModel)                 return COMMON.eSystemObjectType.eModel;
+    if (SO.idScene)                 return COMMON.eSystemObjectType.eScene;
+    if (SO.idIntermediaryFile)      return COMMON.eSystemObjectType.eIntermediaryFile;
+    if (SO.idProjectDocumentation)  return COMMON.eSystemObjectType.eProjectDocumentation;
+    if (SO.idAsset)                 return COMMON.eSystemObjectType.eAsset;
+    if (SO.idAssetVersion)          return COMMON.eSystemObjectType.eAssetVersion;
+    if (SO.idActor)                 return COMMON.eSystemObjectType.eActor;
+    if (SO.idStakeholder)           return COMMON.eSystemObjectType.eStakeholder;
+    return COMMON.eSystemObjectType.eUnknown;
+}
+
 export function DBObjectTypeToName(dbType: eDBObjectType | null): string {
     switch (dbType) {
         case COMMON.eSystemObjectType.eUnit:

--- a/server/db/api/Scene.ts
+++ b/server/db/api/Scene.ts
@@ -8,6 +8,17 @@ import { AuditFactory } from '../../audit/interface/AuditFactory';
 import { eAuditType } from './ObjectType';
 import * as COMMON from '@dpo-packrat/common';
 
+/** One scene whose latest version is in a published EDAN state; `Retired` true marks an orphan
+ *  (retired in Packrat but still live in EDAN) that needs reconciliation. */
+export type EdanPublishedSceneRow = {
+    idScene: number;
+    idSystemObject: number;
+    Name: string;
+    EdanUUID: string | null;
+    PublishedState: number;
+    Retired: boolean;
+};
+
 export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemObjectBased {
     idScene!: number;
     Name!: string;
@@ -244,6 +255,38 @@ export class Scene extends DBC.DBObject<SceneBase> implements SceneBase, SystemO
         } catch (error) /* istanbul ignore next */ {
             RK.logError(RK.LogSection.eDB,'fetch derived from Items failed',H.Helpers.getErrorString(error),{ idItem },'DB.Scene');
             return null;
+        }
+    }
+
+    /**
+     * Scenes whose latest SystemObjectVersion is in a published EDAN state (Published / API Only /
+     * Internal). Ordered retired-first so orphans (retired in Packrat but still live in EDAN) surface
+     * at the top. PublishedState lives only on the latest SystemObjectVersion, so the join selects the
+     * MAX(idSystemObjectVersion) per SystemObject.
+     */
+    static async fetchEdanPublished(): Promise<EdanPublishedSceneRow[]> {
+        type RawRow = { idScene: number | bigint; idSystemObject: number | bigint; Name: string; EdanUUID: string | null; PublishedState: number | bigint; Retired: number | bigint };
+        try {
+            const rows: RawRow[] = await DBC.DBConnection.prisma.$queryRaw<RawRow[]>`
+                SELECT scn.idScene, so.idSystemObject, scn.Name, scn.EdanUUID, sov.PublishedState,
+                       CAST(so.Retired AS UNSIGNED) AS Retired
+                FROM Scene AS scn
+                JOIN SystemObject AS so ON (scn.idScene = so.idScene)
+                JOIN SystemObjectVersion AS sov ON (sov.idSystemObjectVersion =
+                    (SELECT MAX(sov2.idSystemObjectVersion) FROM SystemObjectVersion AS sov2 WHERE sov2.idSystemObject = so.idSystemObject))
+                WHERE sov.PublishedState <> 0
+                ORDER BY so.Retired DESC, scn.Name`;
+            return rows.map(r => ({
+                idScene: Number(r.idScene),
+                idSystemObject: Number(r.idSystemObject),
+                Name: r.Name,
+                EdanUUID: r.EdanUUID,
+                PublishedState: Number(r.PublishedState),
+                Retired: Number(r.Retired) !== 0,
+            }));
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB,'fetch EDAN published scenes failed',H.Helpers.getErrorString(error),undefined,'DB.Scene');
+            return [];
         }
     }
 

--- a/server/db/api/SystemObjectXref.ts
+++ b/server/db/api/SystemObjectXref.ts
@@ -3,6 +3,8 @@ import { SystemObjectXref as SystemObjectXrefBase } from '@prisma/client';
 import { SystemObjectBased, SystemObject } from '..';
 import * as DBC from '../connection';
 import * as H from '../../utils/helpers';
+import * as COMMON from '@dpo-packrat/common';
+import { SystemObjectTypeFromSystemObject } from './ObjectType';
 import { RecordKeeper as RK } from '../../records/recordKeeper';
 
 export class SystemObjectXref extends DBC.DBObject<SystemObjectXrefBase> implements SystemObjectXrefBase {
@@ -187,6 +189,21 @@ export class SystemObjectXref extends DBC.DBObject<SystemObjectXrefBase> impleme
             await SystemObject.fetch(derivedID!) ; /* istanbul ignore next */ // eslint-disable-line @typescript-eslint/no-non-null-assertion
         if (!SODerived) {
             RK.logError(RK.LogSection.eDB,'wire objects if needed failed',`Unable to compute SystemObject derived: ${derivedID}`,{ derived },'DB.SystemObject.Xref');
+            return null;
+        }
+
+        // Reject an inverted containment edge: wiring a structural container (Unit/Project/Subject/
+        // Item) beneath a lower-tier object would let a retire cascade or graph traversal reach a
+        // container from below. This never occurs for valid relationships (downward container edges
+        // such as Unit->Project rank the derived below the master and are permitted); an inverted
+        // edge indicates bad data or a caller bug, so it is refused and logged.
+        const eMasterType: COMMON.eSystemObjectType = SystemObjectTypeFromSystemObject(SOMaster);
+        const eDerivedType: COMMON.eSystemObjectType = SystemObjectTypeFromSystemObject(SODerived);
+        if (COMMON.isInvertedContainmentEdge(eMasterType, eDerivedType)) {
+            RK.logError(RK.LogSection.eDB,'wire objects if needed failed','refusing inverted containment edge',
+                { master: { idSystemObject: SOMaster.idSystemObject, type: COMMON.eSystemObjectType[eMasterType] },
+                    derived: { idSystemObject: SODerived.idSystemObject, type: COMMON.eSystemObjectType[eDerivedType] } },
+                'DB.SystemObject.Xref');
             return null;
         }
 

--- a/server/db/api/composite/RetireCandidateResolver.ts
+++ b/server/db/api/composite/RetireCandidateResolver.ts
@@ -13,6 +13,7 @@ export type ResolvedNode = {
     retired: boolean;
     depth: number;
     kind: ResolvedNodeKind;
+    idParent?: number;               // owning object (assets) or discovering parent (derived objects)
 };
 
 /** A descendant that the scope guard refused to include: a structural container (Unit/Project/
@@ -46,43 +47,69 @@ export interface RetireGraphSource {
  */
 export async function resolveRetireCandidates(root: ResolvedNode, source: RetireGraphSource): Promise<RetireResolution> {
     const visited: Set<number> = new Set<number>([root.idSystemObject]);
-    const objectNodes: ResolvedNode[] = [root];
     const blockers: ScopeBlocker[] = [];
 
-    // Breadth-first over derived objects.
+    // Breadth-first discovery of derived objects, recording the object children of each node. The
+    // visited-set makes cycles/diamonds terminate and pins each object under the first parent that
+    // reaches it, so `childrenOf` forms a tree.
+    const objectOrder: ResolvedNode[] = [root];
+    const childrenOf: Map<number, ResolvedNode[]> = new Map<number, ResolvedNode[]>();
     const queue: ResolvedNode[] = [root];
     while (queue.length > 0) {
         const node: ResolvedNode = queue.shift()!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
         const children: ResolvedNode[] = await source.getChildren(node.idSystemObject);
+        const kept: ResolvedNode[] = [];
         for (const child of children) {
             if (visited.has(child.idSystemObject))
                 continue;
             visited.add(child.idSystemObject);
 
             if (COMMON.isInvertedContainmentEdge(root.eObjectType, child.eObjectType)) {
-                blockers.push({ node: { ...child, depth: node.depth + 1 }, reason: 'containerBelowRoot' });
+                blockers.push({ node: { ...child, depth: node.depth + 1, idParent: node.idSystemObject }, reason: 'containerBelowRoot' });
                 continue; // do not descend into a container's subtree
             }
 
-            const descendant: ResolvedNode = { ...child, depth: node.depth + 1 };
-            objectNodes.push(descendant);
+            const descendant: ResolvedNode = { ...child, depth: node.depth + 1, idParent: node.idSystemObject };
+            kept.push(descendant);
+            objectOrder.push(descendant);
             queue.push(descendant);
         }
+        childrenOf.set(node.idSystemObject, kept);
     }
 
-    // Collect assets for each object node, deduped against everything already seen.
-    const assetNodes: ResolvedNode[] = [];
-    for (const node of objectNodes) {
+    // Collect assets, deduped against everything already seen, and attribute each to its true owner
+    // object (asset.idParent) when that owner is in the crawl — so a model's file nests under the
+    // model even though the scene's comprehensive fetch surfaced it. Assets whose owner is not a
+    // discovered object fall back to the object that surfaced them. Each asset sits one level below
+    // its owner so the tree renders it indented under its parent.
+    const objectById: Map<number, ResolvedNode> = new Map<number, ResolvedNode>(objectOrder.map(o => [o.idSystemObject, o]));
+    const assetsOf: Map<number, ResolvedNode[]> = new Map<number, ResolvedNode[]>();
+    for (const node of objectOrder) {
         const assets: ResolvedNode[] = await source.getAssets(node);
         for (const asset of assets) {
             if (visited.has(asset.idSystemObject))
                 continue;
             visited.add(asset.idSystemObject);
-            assetNodes.push({ ...asset, depth: node.depth });
+            const ownerId: number = (asset.idParent !== undefined && objectById.has(asset.idParent)) ? asset.idParent : node.idSystemObject;
+            const owner: ResolvedNode = objectById.get(ownerId) ?? node;
+            const list: ResolvedNode[] = assetsOf.get(ownerId) ?? [];
+            list.push({ ...asset, depth: owner.depth + 1, idParent: ownerId });
+            assetsOf.set(ownerId, list);
         }
     }
 
-    return { candidates: [...objectNodes, ...assetNodes], blockers };
+    // Depth-first assembly: each object, then its assets, then its object children.
+    const candidates: ResolvedNode[] = [];
+    const emit = (node: ResolvedNode): void => {
+        candidates.push(node);
+        for (const asset of assetsOf.get(node.idSystemObject) ?? [])
+            candidates.push(asset);
+        for (const child of childrenOf.get(node.idSystemObject) ?? [])
+            emit(child);
+    };
+    emit(root);
+
+    return { candidates, blockers };
 }
 
 /**
@@ -113,51 +140,56 @@ export class DBRetireGraphSource implements RetireGraphSource {
     }
 
     async getAssets(node: ResolvedNode): Promise<ResolvedNode[]> {
-        const assetSOIds: number[] = (node.eObjectType === COMMON.eSystemObjectType.eScene)
-            ? await this.fetchSceneAssetSOIds(node.idSystemObject)
-            : await this.fetchObjectAssetSOIds(node.idSystemObject);
+        // { assetSO: the asset's own SystemObject; ownerSO: the object the asset is attached to }
+        const pairs: { assetSO: number; ownerSO: number }[] = (node.eObjectType === COMMON.eSystemObjectType.eScene)
+            ? await this.fetchSceneAssets(node.idSystemObject)
+            : await this.fetchObjectAssets(node.idSystemObject);
 
         const nodes: ResolvedNode[] = [];
-        for (const idSystemObject of assetSOIds) {
-            const SO: DBAPI.SystemObject | null = await this.fetchSO(idSystemObject);
+        for (const { assetSO, ownerSO } of pairs) {
+            const SO: DBAPI.SystemObject | null = await this.fetchSO(assetSO);
             if (!SO) {
                 RK.logError(RK.LogSection.eDB, 'resolve retire candidates', 'unable to fetch asset SystemObject',
-                    { idSystemObject, owner: node.idSystemObject }, 'DB.Composite.RetireResolver');
+                    { idSystemObject: assetSO, owner: node.idSystemObject }, 'DB.Composite.RetireResolver');
                 continue;
             }
-            nodes.push({ idSystemObject, eObjectType: SystemObjectTypeFromSystemObject(SO), retired: SO.Retired,
-                depth: node.depth, kind: 'asset' });
+            nodes.push({ idSystemObject: assetSO, eObjectType: SystemObjectTypeFromSystemObject(SO), retired: SO.Retired,
+                depth: node.depth, kind: 'asset', idParent: ownerSO });
         }
         return nodes;
     }
 
-    private async fetchSceneAssetSOIds(idSystemObject: number): Promise<number[]> {
+    private async fetchSceneAssets(idSystemObject: number): Promise<{ assetSO: number; ownerSO: number }[]> {
         const SO: DBAPI.SystemObject | null = await this.fetchSO(idSystemObject);
         if (!SO || !SO.idScene)
             return [];
         const assetVersions: DBAPI.AssetVersion[] | null = await DBAPI.AssetVersion.fetchFromSceneByVersion(SO.idScene);
         if (!assetVersions)
             return [];
-        const soIds: Set<number> = new Set<number>();
+        const pairs: { assetSO: number; ownerSO: number }[] = [];
+        const seen: Set<number> = new Set<number>();
         for (const av of assetVersions) {
+            const asset: DBAPI.Asset | null = await DBAPI.Asset.fetch(av.idAsset);
             const assetSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromAssetID(av.idAsset);
-            if (assetSO)
-                soIds.add(assetSO.idSystemObject);
+            if (!asset || !assetSO || seen.has(assetSO.idSystemObject))
+                continue;
+            seen.add(assetSO.idSystemObject);
+            pairs.push({ assetSO: assetSO.idSystemObject, ownerSO: asset.idSystemObject ?? 0 });
         }
-        return [...soIds];
+        return pairs;
     }
 
-    private async fetchObjectAssetSOIds(idSystemObject: number): Promise<number[]> {
+    private async fetchObjectAssets(idSystemObject: number): Promise<{ assetSO: number; ownerSO: number }[]> {
         const assets: DBAPI.Asset[] | null = await DBAPI.Asset.fetchFromSystemObject(idSystemObject);
         if (!assets)
             return [];
-        const soIds: number[] = [];
+        const pairs: { assetSO: number; ownerSO: number }[] = [];
         for (const asset of assets) {
             const assetSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromAssetID(asset.idAsset);
             if (assetSO)
-                soIds.push(assetSO.idSystemObject);
+                pairs.push({ assetSO: assetSO.idSystemObject, ownerSO: asset.idSystemObject ?? idSystemObject });
         }
-        return soIds;
+        return pairs;
     }
 
     private async fetchSO(idSystemObject: number): Promise<DBAPI.SystemObject | null> {

--- a/server/db/api/composite/RetireCandidateResolver.ts
+++ b/server/db/api/composite/RetireCandidateResolver.ts
@@ -1,0 +1,184 @@
+import * as DBAPI from '../..';
+import * as COMMON from '@dpo-packrat/common';
+import { SystemObjectTypeFromSystemObject } from '../ObjectType';
+import { RecordKeeper as RK } from '../../../records/recordKeeper';
+
+export type ResolvedNodeKind = 'object' | 'asset';
+
+/** A single object slated for retire/reinstate. `depth` is 0 for the root and increments per level
+ *  down the derived graph; assets carry the depth of the object that owns them. */
+export type ResolvedNode = {
+    idSystemObject: number;
+    eObjectType: COMMON.eSystemObjectType;
+    retired: boolean;
+    depth: number;
+    kind: ResolvedNodeKind;
+};
+
+/** A descendant that the scope guard refused to include: a structural container (Unit/Project/
+ *  Subject/Item) reached below the root, which indicates an inverted xref edge (bad data or a bug).
+ *  Its subtree is not traversed, so a container's contents can never be swept into a retire. */
+export type ScopeBlocker = {
+    node: ResolvedNode;
+    reason: 'containerBelowRoot';
+};
+
+export type RetireResolution = {
+    candidates: ResolvedNode[];   // root first, then derived objects, then their assets; deduped
+    blockers: ScopeBlocker[];
+};
+
+/** Graph access the resolver needs, injected so the traversal can be unit-tested with in-memory
+ *  fixtures (including cycles) independently of the database. */
+export interface RetireGraphSource {
+    /** Derived (child) objects of the given SystemObject. */
+    getChildren(idSystemObject: number): Promise<ResolvedNode[]>;
+    /** Asset objects owned by the given node (scene-aware). */
+    getAssets(node: ResolvedNode): Promise<ResolvedNode[]>;
+}
+
+/**
+ * Walks the derived graph beneath `root` and returns the flat, deduped set of objects (and their
+ * assets) that a retire/reinstate would touch, plus any scope blockers. Traversal is breadth-first
+ * and guarded by a visited-set, so cycles and diamonds terminate and each object appears once. A
+ * descendant that is a structural container ranked above the root is recorded as a blocker and its
+ * subtree is skipped.
+ */
+export async function resolveRetireCandidates(root: ResolvedNode, source: RetireGraphSource): Promise<RetireResolution> {
+    const visited: Set<number> = new Set<number>([root.idSystemObject]);
+    const objectNodes: ResolvedNode[] = [root];
+    const blockers: ScopeBlocker[] = [];
+
+    // Breadth-first over derived objects.
+    const queue: ResolvedNode[] = [root];
+    while (queue.length > 0) {
+        const node: ResolvedNode = queue.shift()!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+        const children: ResolvedNode[] = await source.getChildren(node.idSystemObject);
+        for (const child of children) {
+            if (visited.has(child.idSystemObject))
+                continue;
+            visited.add(child.idSystemObject);
+
+            if (COMMON.isInvertedContainmentEdge(root.eObjectType, child.eObjectType)) {
+                blockers.push({ node: { ...child, depth: node.depth + 1 }, reason: 'containerBelowRoot' });
+                continue; // do not descend into a container's subtree
+            }
+
+            const descendant: ResolvedNode = { ...child, depth: node.depth + 1 };
+            objectNodes.push(descendant);
+            queue.push(descendant);
+        }
+    }
+
+    // Collect assets for each object node, deduped against everything already seen.
+    const assetNodes: ResolvedNode[] = [];
+    for (const node of objectNodes) {
+        const assets: ResolvedNode[] = await source.getAssets(node);
+        for (const asset of assets) {
+            if (visited.has(asset.idSystemObject))
+                continue;
+            visited.add(asset.idSystemObject);
+            assetNodes.push({ ...asset, depth: node.depth });
+        }
+    }
+
+    return { candidates: [...objectNodes, ...assetNodes], blockers };
+}
+
+/**
+ * Database-backed RetireGraphSource. Caches fetched SystemObject rows so asset lookup can reach a
+ * scene's underlying idScene without a second round trip.
+ */
+export class DBRetireGraphSource implements RetireGraphSource {
+    private soCache: Map<number, DBAPI.SystemObject> = new Map<number, DBAPI.SystemObject>();
+
+    async loadNode(idSystemObject: number, depth: number, kind: ResolvedNodeKind): Promise<ResolvedNode | null> {
+        const SO: DBAPI.SystemObject | null = await this.fetchSO(idSystemObject);
+        if (!SO)
+            return null;
+        return { idSystemObject, eObjectType: SystemObjectTypeFromSystemObject(SO), retired: SO.Retired, depth, kind };
+    }
+
+    async getChildren(idSystemObject: number): Promise<ResolvedNode[]> {
+        const derived: DBAPI.SystemObject[] | null = await DBAPI.SystemObject.fetchDerivedFromXref(idSystemObject);
+        if (!derived)
+            return [];
+        const nodes: ResolvedNode[] = [];
+        for (const SO of derived) {
+            this.soCache.set(SO.idSystemObject, SO);
+            nodes.push({ idSystemObject: SO.idSystemObject, eObjectType: SystemObjectTypeFromSystemObject(SO),
+                retired: SO.Retired, depth: 0, kind: 'object' });
+        }
+        return nodes;
+    }
+
+    async getAssets(node: ResolvedNode): Promise<ResolvedNode[]> {
+        const assetSOIds: number[] = (node.eObjectType === COMMON.eSystemObjectType.eScene)
+            ? await this.fetchSceneAssetSOIds(node.idSystemObject)
+            : await this.fetchObjectAssetSOIds(node.idSystemObject);
+
+        const nodes: ResolvedNode[] = [];
+        for (const idSystemObject of assetSOIds) {
+            const SO: DBAPI.SystemObject | null = await this.fetchSO(idSystemObject);
+            if (!SO) {
+                RK.logError(RK.LogSection.eDB, 'resolve retire candidates', 'unable to fetch asset SystemObject',
+                    { idSystemObject, owner: node.idSystemObject }, 'DB.Composite.RetireResolver');
+                continue;
+            }
+            nodes.push({ idSystemObject, eObjectType: SystemObjectTypeFromSystemObject(SO), retired: SO.Retired,
+                depth: node.depth, kind: 'asset' });
+        }
+        return nodes;
+    }
+
+    private async fetchSceneAssetSOIds(idSystemObject: number): Promise<number[]> {
+        const SO: DBAPI.SystemObject | null = await this.fetchSO(idSystemObject);
+        if (!SO || !SO.idScene)
+            return [];
+        const assetVersions: DBAPI.AssetVersion[] | null = await DBAPI.AssetVersion.fetchFromSceneByVersion(SO.idScene);
+        if (!assetVersions)
+            return [];
+        const soIds: Set<number> = new Set<number>();
+        for (const av of assetVersions) {
+            const assetSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromAssetID(av.idAsset);
+            if (assetSO)
+                soIds.add(assetSO.idSystemObject);
+        }
+        return [...soIds];
+    }
+
+    private async fetchObjectAssetSOIds(idSystemObject: number): Promise<number[]> {
+        const assets: DBAPI.Asset[] | null = await DBAPI.Asset.fetchFromSystemObject(idSystemObject);
+        if (!assets)
+            return [];
+        const soIds: number[] = [];
+        for (const asset of assets) {
+            const assetSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromAssetID(asset.idAsset);
+            if (assetSO)
+                soIds.push(assetSO.idSystemObject);
+        }
+        return soIds;
+    }
+
+    private async fetchSO(idSystemObject: number): Promise<DBAPI.SystemObject | null> {
+        const cached: DBAPI.SystemObject | undefined = this.soCache.get(idSystemObject);
+        if (cached)
+            return cached;
+        const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObject);
+        if (SO)
+            this.soCache.set(idSystemObject, SO);
+        return SO;
+    }
+}
+
+/** Resolves the retire/reinstate candidate set for a root SystemObject against the live database. */
+export async function resolveRetireCandidatesFromSystemObject(idSystemObject: number): Promise<RetireResolution | null> {
+    const source: DBRetireGraphSource = new DBRetireGraphSource();
+    const root: ResolvedNode | null = await source.loadNode(idSystemObject, 0, 'object');
+    if (!root) {
+        RK.logError(RK.LogSection.eDB, 'resolve retire candidates', 'unable to fetch root SystemObject',
+            { idSystemObject }, 'DB.Composite.RetireResolver');
+        return null;
+    }
+    return resolveRetireCandidates(root, source);
+}

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -75,6 +75,7 @@ export * from './api/composite/ObjectAncestors';
 export * from './api/composite/ObjectGraph';
 export * from './api/composite/ObjectGraphDatabase';
 export * from './api/composite/ObjectGraphDataEntry';
+export * from './api/composite/RetireCandidateResolver';
 export * from './api/composite/SceneConstellation';
 export * from './api/composite/SubjectUnitIdentifier';
 export * from './api/composite/WorkflowListResult';

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
@@ -667,11 +667,16 @@ function computeNewName(oldName: string, oldTitle: string | null, newTitle: stri
  * 2. Retire direct Assets
  * For Scenes, uses fetchFromSceneByVersion to get all assets including model assets.
  */
-async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean, parentAuditId: number | null = null): Promise<H.IOResults> {
+async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean, parentAuditId: number | null = null, visited: Set<number> = new Set<number>()): Promise<H.IOResults> {
     const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObject);
     if (!SO) {
         return { success: false, error: `Unable to fetch SystemObject ${idSystemObject}` };
     }
+
+    // Guard against cyclic/diamond xref edges: never process the same SystemObject twice in one
+    // cascade. In-memory tracking is authoritative here — the Retired flip is not visible to sibling
+    // re-fetches within the same transaction, so the Retired-flag check alone cannot dedupe.
+    visited.add(idSystemObject);
 
     // Cascade to derived/child objects (Scenes first, then Models)
     const derivedObjects: DBAPI.SystemObject[] | null = await DBAPI.SystemObject.fetchDerivedFromXref(idSystemObject);
@@ -694,12 +699,15 @@ async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean
         // Process in order: Scenes, then Models, then others
         const orderedDerived = [...scenes, ...models, ...others];
         for (const derivedSO of orderedDerived) {
+            if (visited.has(derivedSO.idSystemObject))
+                continue;
+            visited.add(derivedSO.idSystemObject);
             if (retire) {
                 if (!derivedSO.Retired) {
                     const res = await derivedSO.retireObjectWithContext({ parentAuditId });
                     if (!res.success)
                         return { success: false, error: `Failed to retire derived object SO ${derivedSO.idSystemObject}` };
-                    const cascadeResult = await cascadeRetirementToAssets(derivedSO.idSystemObject, retire, parentAuditId);
+                    const cascadeResult = await cascadeRetirementToAssets(derivedSO.idSystemObject, retire, parentAuditId, visited);
                     if (!cascadeResult.success) {
                         return cascadeResult;
                     }
@@ -710,7 +718,7 @@ async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean
                     const res = await derivedSO.reinstateObjectWithContext({ parentAuditId });
                     if (!res.success)
                         return { success: false, error: `Failed to reinstate derived object SO ${derivedSO.idSystemObject}` };
-                    const cascadeResult = await cascadeRetirementToAssets(derivedSO.idSystemObject, retire, parentAuditId);
+                    const cascadeResult = await cascadeRetirementToAssets(derivedSO.idSystemObject, retire, parentAuditId, visited);
                     if (!cascadeResult.success) {
                         return cascadeResult;
                     }
@@ -737,6 +745,9 @@ async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean
                     RK.logError(RK.LogSection.eGQL, 'cascade retirement failed', `Unable to fetch SystemObject for Asset ${idAsset}`, { idSystemObject, retire }, 'GraphQL.SystemObject.ObjectDetails');
                     continue;
                 }
+                if (visited.has(assetSO.idSystemObject))
+                    continue;
+                visited.add(assetSO.idSystemObject);
 
                 const result = await retireOrReinstateObject(assetSO, retire, `Asset ${idAsset}`, idSystemObject, parentAuditId);
                 if (!result.success) {
@@ -754,6 +765,9 @@ async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean
                     RK.logError(RK.LogSection.eGQL, 'cascade retirement failed', `Unable to fetch SystemObject for Asset ${asset.idAsset}`, { idSystemObject, retire }, 'GraphQL.SystemObject.ObjectDetails');
                     continue;
                 }
+                if (visited.has(assetSO.idSystemObject))
+                    continue;
+                visited.add(assetSO.idSystemObject);
 
                 const result = await retireOrReinstateObject(assetSO, retire, `Asset ${asset.idAsset}`, idSystemObject, parentAuditId);
                 if (!result.success) {

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
@@ -14,6 +14,7 @@ import { NameHelpers } from '../../../../../utils/nameHelpers';
 import { RecordKeeper as RK } from '../../../../../records/recordKeeper';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
+import { retireSystemObjectTree } from '../../../../../objectAction/RetireExecutorDeps';
 
 type PendingSceneUpdate = {
     idScene: number;
@@ -36,6 +37,10 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
     // Capture-by-reference for handleSceneUpdates to fire post-commit for the
     // Scene case. Cook download generation/removal must NOT run inside the tx.
     let pendingSceneUpdate: PendingSceneUpdate | null = null;
+    // Retire/reinstate is applied post-commit by the shared executor (outside this tx, since it
+    // performs EDAN unpublish for published scenes). Capture the intended transition here; null =
+    // no change requested.
+    let pendingRetire: boolean | null = null;
 
     const txResult = await withAuditTransaction(async (): Promise<UpdateObjectDetailsResult> => {
         if (!data.Name || isUndefined(data.Retired) || isNull(data.Retired))
@@ -45,24 +50,12 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
         if (!SO)
             return sendResult(false,'update object details failed',`Error fetching object ${idSystemObject}; update failed`);
 
-        if (!SO.Retired && data.Retired) {
-        // Root retire emits a semantic eActionRetire row; its idAudit threads
-        // into cascade children as parentRetirement.idAudit so the full
-        // retirement tree can be reconstructed from the Audit table.
-            const rootResult = await SO.retireObjectWithContext({ reason: null });
-            if (!rootResult.success)
-                return sendResult(false,'update object details failed','Error retiring object; update failed');
-            const cascadeResult = await cascadeRetirementToAssets(idSystemObject, true, rootResult.idAudit);
-            if (!cascadeResult.success)
-                return sendResult(false,'update object details failed',cascadeResult.error ?? 'Error retiring child assets');
-        } else if (SO.Retired && !data.Retired) {
-            const rootResult = await SO.reinstateObjectWithContext({ reason: null });
-            if (!rootResult.success)
-                return sendResult(false,'update object details failed','Error reinstating object; update failed');
-            const cascadeResult = await cascadeRetirementToAssets(idSystemObject, false, rootResult.idAudit);
-            if (!cascadeResult.success)
-                return sendResult(false,'update object details failed',cascadeResult.error ?? 'Error reinstating child assets');
-        }
+        // Decide the retire/reinstate transition; the flip + cascade + EDAN unpublish run
+        // post-commit via the shared executor (deduped resolver replaces the legacy inline cascade).
+        if (!SO.Retired && data.Retired)
+            pendingRetire = true;
+        else if (SO.Retired && !data.Retired)
+            pendingRetire = false;
 
         let identifierPreferred: null | number = null;
         if (data?.Identifiers && data?.Identifiers.length) {
@@ -586,6 +579,15 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
     if (!txResult.success)
         return txResult;
 
+    // Post-commit: apply retire/reinstate via the shared executor. Runs outside the tx because it
+    // performs EDAN unpublish (external HTTP) for published scenes and manages its own audit
+    // transaction. Idempotent — a no-op transition (already in state) is skipped internally.
+    if (pendingRetire !== null) {
+        const retireResult = await retireSystemObjectTree(idSystemObject, pendingRetire);
+        if (!retireResult.applied)
+            return sendResult(false, 'update object details failed', retireResult.message);
+    }
+
     // Post-commit: fire Cook download generation/removal for the Scene case.
     // Stays outside the tx so the workflow trigger does not extend the lock.
     if (pendingSceneUpdate) {
@@ -658,146 +660,4 @@ function computeNewName(oldName: string, oldTitle: string | null, newTitle: stri
     // LOG.info(`updateObjectDetails computeNewName(${oldName}, ${oldTitle}, ${newTitle}) = ${newName} (oldBaseName = ${oldBaseName})`, LOG.LS.eGQL);
 
     return newName;
-}
-
-/**
- * Cascades retirement/reinstatement to related objects and assets.
- * Order of operations for retirement:
- * 1. Retire derived/child objects (Scenes first, then Models)
- * 2. Retire direct Assets
- * For Scenes, uses fetchFromSceneByVersion to get all assets including model assets.
- */
-async function cascadeRetirementToAssets(idSystemObject: number, retire: boolean, parentAuditId: number | null = null, visited: Set<number> = new Set<number>()): Promise<H.IOResults> {
-    const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObject);
-    if (!SO) {
-        return { success: false, error: `Unable to fetch SystemObject ${idSystemObject}` };
-    }
-
-    // Guard against cyclic/diamond xref edges: never process the same SystemObject twice in one
-    // cascade. In-memory tracking is authoritative here — the Retired flip is not visible to sibling
-    // re-fetches within the same transaction, so the Retired-flag check alone cannot dedupe.
-    visited.add(idSystemObject);
-
-    // Cascade to derived/child objects (Scenes first, then Models)
-    const derivedObjects: DBAPI.SystemObject[] | null = await DBAPI.SystemObject.fetchDerivedFromXref(idSystemObject);
-    if (derivedObjects && derivedObjects.length > 0) {
-        // Sort: Scenes first, then Models, then others
-        const scenes: DBAPI.SystemObject[] = [];
-        const models: DBAPI.SystemObject[] = [];
-        const others: DBAPI.SystemObject[] = [];
-
-        for (const derived of derivedObjects) {
-            if (derived.idScene) {
-                scenes.push(derived);
-            } else if (derived.idModel) {
-                models.push(derived);
-            } else {
-                others.push(derived);
-            }
-        }
-
-        // Process in order: Scenes, then Models, then others
-        const orderedDerived = [...scenes, ...models, ...others];
-        for (const derivedSO of orderedDerived) {
-            if (visited.has(derivedSO.idSystemObject))
-                continue;
-            visited.add(derivedSO.idSystemObject);
-            if (retire) {
-                if (!derivedSO.Retired) {
-                    const res = await derivedSO.retireObjectWithContext({ parentAuditId });
-                    if (!res.success)
-                        return { success: false, error: `Failed to retire derived object SO ${derivedSO.idSystemObject}` };
-                    const cascadeResult = await cascadeRetirementToAssets(derivedSO.idSystemObject, retire, parentAuditId, visited);
-                    if (!cascadeResult.success) {
-                        return cascadeResult;
-                    }
-                    RK.logInfo(RK.LogSection.eGQL, 'cascade retirement', `Retired derived object (SO ${derivedSO.idSystemObject})`, { idSystemObject }, 'GraphQL.SystemObject.ObjectDetails');
-                }
-            } else {
-                if (derivedSO.Retired) {
-                    const res = await derivedSO.reinstateObjectWithContext({ parentAuditId });
-                    if (!res.success)
-                        return { success: false, error: `Failed to reinstate derived object SO ${derivedSO.idSystemObject}` };
-                    const cascadeResult = await cascadeRetirementToAssets(derivedSO.idSystemObject, retire, parentAuditId, visited);
-                    if (!cascadeResult.success) {
-                        return cascadeResult;
-                    }
-                    RK.logInfo(RK.LogSection.eGQL, 'cascade reinstatement', `Reinstated derived object (SO ${derivedSO.idSystemObject})`, { idSystemObject }, 'GraphQL.SystemObject.ObjectDetails');
-                }
-            }
-        }
-    }
-
-    // Retire assets - use fetchFromSceneByVersion for Scenes to get all assets including model assets
-    if (SO.idScene) {
-        // For Scenes, use the comprehensive fetch that includes model assets
-        const assetVersions: DBAPI.AssetVersion[] | null = await DBAPI.AssetVersion.fetchFromSceneByVersion(SO.idScene);
-        if (assetVersions && assetVersions.length > 0) {
-            // Get unique Assets from the AssetVersions
-            const assetIdSet = new Set<number>();
-            for (const av of assetVersions) {
-                assetIdSet.add(av.idAsset);
-            }
-
-            for (const idAsset of assetIdSet) {
-                const assetSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromAssetID(idAsset);
-                if (!assetSO) {
-                    RK.logError(RK.LogSection.eGQL, 'cascade retirement failed', `Unable to fetch SystemObject for Asset ${idAsset}`, { idSystemObject, retire }, 'GraphQL.SystemObject.ObjectDetails');
-                    continue;
-                }
-                if (visited.has(assetSO.idSystemObject))
-                    continue;
-                visited.add(assetSO.idSystemObject);
-
-                const result = await retireOrReinstateObject(assetSO, retire, `Asset ${idAsset}`, idSystemObject, parentAuditId);
-                if (!result.success) {
-                    return result;
-                }
-            }
-        }
-    } else {
-        // For non-Scene objects, use fetchFromSystemObject
-        const assets: DBAPI.Asset[] | null = await DBAPI.Asset.fetchFromSystemObject(idSystemObject);
-        if (assets && assets.length > 0) {
-            for (const asset of assets) {
-                const assetSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromAssetID(asset.idAsset);
-                if (!assetSO) {
-                    RK.logError(RK.LogSection.eGQL, 'cascade retirement failed', `Unable to fetch SystemObject for Asset ${asset.idAsset}`, { idSystemObject, retire }, 'GraphQL.SystemObject.ObjectDetails');
-                    continue;
-                }
-                if (visited.has(assetSO.idSystemObject))
-                    continue;
-                visited.add(assetSO.idSystemObject);
-
-                const result = await retireOrReinstateObject(assetSO, retire, `Asset ${asset.idAsset}`, idSystemObject, parentAuditId);
-                if (!result.success) {
-                    return result;
-                }
-            }
-        }
-    }
-
-    return { success: true };
-}
-
-/**
- * Helper to retire or reinstate a single SystemObject with logging.
- */
-async function retireOrReinstateObject(so: DBAPI.SystemObject, retire: boolean, objectDesc: string, parentIdSystemObject: number, parentAuditId: number | null = null): Promise<H.IOResults> {
-    if (retire) {
-        if (!so.Retired) {
-            const res = await so.retireObjectWithContext({ parentAuditId });
-            if (!res.success)
-                return { success: false, error: `Failed to retire ${objectDesc}` };
-            RK.logInfo(RK.LogSection.eGQL, 'cascade retirement', `Retired ${objectDesc} (SO ${so.idSystemObject})`, { parentIdSystemObject }, 'GraphQL.SystemObject.ObjectDetails');
-        }
-    } else {
-        if (so.Retired) {
-            const res = await so.reinstateObjectWithContext({ parentAuditId });
-            if (!res.success)
-                return { success: false, error: `Failed to reinstate ${objectDesc}` };
-            RK.logInfo(RK.LogSection.eGQL, 'cascade reinstatement', `Reinstated ${objectDesc} (SO ${so.idSystemObject})`, { parentIdSystemObject }, 'GraphQL.SystemObject.ObjectDetails');
-        }
-    }
-    return { success: true };
 }

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -29,6 +29,7 @@ import { getProjects, getProjectScenes } from './routes/api/project';
 import { createReport, getReportList, getReportFile } from './routes/api/report';
 import { getObjectStatus, patchObject } from './routes/api/object';
 import { objectAction } from './routes/api/objectAction';
+import { getPublishedScenes } from './routes/api/publishedScenes';
 import { getContact, updateContact, createContact } from './routes/api/object';
 import { getUnit } from './routes/api/object';
 import { getExternalSources, createExternalSource, updateExternalSource } from './routes/api/object';
@@ -231,6 +232,7 @@ export class HttpServer {
 
         this.app.get('/api/scene/gen-downloads', generateDownloads);
         this.app.post('/api/scene/gen-downloads', generateDownloads);
+        this.app.get('/api/scene/published', getPublishedScenes);   // scenes still in a published EDAN state (orphan reconciliation)
         this.app.post('/api/scene/:id/webdav-token', createWebDAVToken);
 
         // External deep-link endpoints

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -28,6 +28,7 @@ import { generateScene } from './routes/api/generateVoyagerScene';
 import { getProjects, getProjectScenes } from './routes/api/project';
 import { createReport, getReportList, getReportFile } from './routes/api/report';
 import { getObjectStatus, patchObject } from './routes/api/object';
+import { objectAction } from './routes/api/objectAction';
 import { getContact, updateContact, createContact } from './routes/api/object';
 import { getUnit } from './routes/api/object';
 import { getExternalSources, createExternalSource, updateExternalSource } from './routes/api/object';
@@ -238,6 +239,7 @@ export class HttpServer {
 
         this.app.get('/api/object/:id/status', getObjectStatus);
         this.app.patch('/api/object/:id', patchObject);
+        this.app.post('/api/object/action', objectAction);          // describe | retire | reinstate an object + dependents
 
         this.app.get('/api/audit/lifeline/:id', getAuditLifeline);  // admin-only: per-SystemObject audit history
 

--- a/server/http/routes/api/objectAction.ts
+++ b/server/http/routes/api/objectAction.ts
@@ -1,0 +1,85 @@
+import * as DBAPI from '../../../db';
+import { ASL, LocalStore } from '../../../utils/localStore';
+import { isAuthenticated } from '../../auth';
+import { Authorization, AUTH_ERROR } from '../../../auth/Authorization';
+import { RecordKeeper as RK } from '../../../records/recordKeeper';
+import { retireSystemObjectTree } from '../../../objectAction/RetireExecutorDeps';
+import { describeSummaries, resultSummaries, blockerSummaries } from '../../../objectAction/ObjectSummary';
+import { RetireExecutionResult } from '../../../objectAction/RetireExecutor';
+import { Request, Response } from 'express';
+
+type ObjectActionName = 'describe' | 'retire' | 'reinstate';
+const ACTIONS: ObjectActionName[] = ['describe', 'retire', 'reinstate'];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function respond(res: Response, success: boolean, message: string | undefined, data?: any): void {
+    res.status(200).send(JSON.stringify({ success, message, data }));
+}
+
+/**
+ * POST /api/object/action — generic "act on an object" endpoint.
+ * Body: { idSystemObject, action: 'describe'|'retire'|'reinstate', options? }.
+ *   describe            — read-only preview of the objects a retire/reinstate would touch.
+ *   retire | reinstate  — apply the action to the object and its resolved dependents/assets.
+ */
+export async function objectAction(req: Request, res: Response): Promise<void> {
+    if (!isAuthenticated(req)) {
+        respond(res, false, 'objectAction: not authenticated');
+        return;
+    }
+    const LS: LocalStore | undefined = ASL.getStore();
+    if (!LS || !LS.idUser) {
+        respond(res, false, 'objectAction: missing local store/user');
+        return;
+    }
+
+    const { idSystemObject, action } = req.body ?? {};
+    const idSO: number = Number(idSystemObject);
+    if (!Number.isInteger(idSO) || idSO <= 0) {
+        respond(res, false, 'objectAction: valid idSystemObject required');
+        return;
+    }
+    if (!ACTIONS.includes(action)) {
+        respond(res, false, `objectAction: action must be one of ${ACTIONS.join(', ')}`);
+        return;
+    }
+
+    // Authorization: fail-closed on access to the target SystemObject.
+    const ctx = Authorization.getContext();
+    if (!ctx || !await Authorization.canAccessSystemObject(ctx, idSO)) {
+        respond(res, false, AUTH_ERROR.ACCESS_DENIED);
+        return;
+    }
+
+    try {
+        if (action === 'describe') {
+            const resolution: DBAPI.RetireResolution | null = await DBAPI.resolveRetireCandidatesFromSystemObject(idSO);
+            if (!resolution) {
+                respond(res, false, `objectAction: unable to resolve objects for ${idSO}`);
+                return;
+            }
+            respond(res, true, undefined, {
+                action,
+                idSystemObject: idSO,
+                objects: await describeSummaries(resolution.candidates),
+                blockers: await blockerSummaries(resolution.blockers),
+            });
+            return;
+        }
+
+        const retire: boolean = action === 'retire';
+        const result: RetireExecutionResult = await retireSystemObjectTree(idSO, retire);
+        respond(res, result.applied, result.message, {
+            action,
+            idSystemObject: idSO,
+            applied: result.applied,
+            edanFailures: result.edanFailures,
+            objects: await resultSummaries(result.items),
+            blockers: await blockerSummaries(result.blockers),
+        });
+    } catch (error) {
+        RK.logError(RK.LogSection.eHTTP, 'objectAction failed',
+            error instanceof Error ? error.message : String(error), { idSystemObject: idSO, action }, 'HTTP.Route.ObjectAction');
+        respond(res, false, `objectAction: ${error instanceof Error ? error.message : 'unexpected error'}`);
+    }
+}

--- a/server/http/routes/api/publishedScenes.ts
+++ b/server/http/routes/api/publishedScenes.ts
@@ -1,0 +1,52 @@
+import * as DBAPI from '../../../db';
+import * as COMMON from '@dpo-packrat/common';
+import { ASL, LocalStore } from '../../../utils/localStore';
+import { isAuthenticated } from '../../auth';
+import { Config } from '../../../config';
+import { RecordKeeper as RK } from '../../../records/recordKeeper';
+import { Request, Response } from 'express';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function respond(res: Response, success: boolean, message: string | undefined, data?: any): void {
+    res.status(200).send(JSON.stringify({ success, message, data }));
+}
+
+/**
+ * GET /api/scene/published — scenes whose latest version is in a published EDAN state, ordered
+ * retired-first. Retired-and-published scenes are orphans (retired in Packrat but still live in
+ * EDAN) that need reconciliation; each row carries its EdanUUID for that purpose. Admin/tools only.
+ */
+export async function getPublishedScenes(req: Request, res: Response): Promise<void> {
+    if (!isAuthenticated(req)) {
+        respond(res, false, 'getPublishedScenes: not authenticated');
+        return;
+    }
+    const LS: LocalStore | undefined = ASL.getStore();
+    if (!LS || !LS.idUser) {
+        respond(res, false, 'getPublishedScenes: missing local store/user');
+        return;
+    }
+    const authorized: number[] = [...new Set([...Config.auth.users.admin, ...Config.auth.users.tools])];
+    if (!authorized.includes(LS.idUser)) {
+        respond(res, false, 'getPublishedScenes: not authorized');
+        return;
+    }
+
+    try {
+        const rows: DBAPI.EdanPublishedSceneRow[] = await DBAPI.Scene.fetchEdanPublished();
+        const scenes = rows.map(r => ({
+            idScene: r.idScene,
+            idSystemObject: r.idSystemObject,
+            name: r.Name,
+            edanUUID: r.EdanUUID,
+            publishedState: COMMON.PublishedStateEnumToString(r.PublishedState),
+            retired: r.Retired,
+        }));
+        const orphanCount: number = scenes.filter(s => s.retired).length;
+        respond(res, true, undefined, { total: scenes.length, orphanCount, scenes });
+    } catch (error) {
+        RK.logError(RK.LogSection.eHTTP, 'getPublishedScenes failed',
+            error instanceof Error ? error.message : String(error), undefined, 'HTTP.Route.PublishedScenes');
+        respond(res, false, `getPublishedScenes: ${error instanceof Error ? error.message : 'unexpected error'}`);
+    }
+}

--- a/server/http/routes/api/status.ts
+++ b/server/http/routes/api/status.ts
@@ -9,6 +9,9 @@ interface ServiceStatus {
     database: boolean;
     solr: boolean;
     edan: boolean;
+    features: {
+        volumetricIngest: boolean;
+    };
 }
 
 export async function getServiceStatus(_: Request, response: Response): Promise<void> {
@@ -16,6 +19,10 @@ export async function getServiceStatus(_: Request, response: Response): Promise<
         database: false,
         solr: false,
         edan: false,
+        // Server-side feature gates the client needs to mirror in the UI.
+        features: {
+            volumetricIngest: Config.features.volumetricIngest,
+        },
     };
 
     // Check database

--- a/server/objectAction/ObjectSummary.ts
+++ b/server/objectAction/ObjectSummary.ts
@@ -1,0 +1,129 @@
+import * as DBAPI from '../db';
+import * as CACHE from '../cache';
+import * as COMMON from '@dpo-packrat/common';
+import { SystemObjectTypeToName } from '../db/api/ObjectType';
+import { RecordKeeper as RK } from '../records/recordKeeper';
+import type { ResolvedNode, ResolvedNodeKind, ScopeBlocker } from '../db';
+import type { RetireItemResult, RetireItemStatus } from './RetireExecutor';
+
+/**
+ * Presentation view of one object in an action response. `describe` populates the full set; action
+ * responses (retire/reinstate) carry the lightweight identity fields plus `status`/`error` and let
+ * the client merge them onto the preview rows it already holds.
+ */
+export type ObjectSummary = {
+    idSystemObject: number;
+    eObjectType: COMMON.eSystemObjectType;
+    objectType: string;                  // human-readable type name
+    name: string | null;
+    kind: ResolvedNodeKind;
+    depth?: number;
+    retired?: boolean;
+    unit?: string | null;
+    project?: string | null;
+    subject?: string | null;
+    publishedState?: string;             // scenes only
+    edanUUID?: string | null;            // scenes only
+    status?: RetireItemStatus;           // action responses only
+    unpublishedFromEdan?: boolean;
+    error?: string;
+    blockerReason?: ScopeBlocker['reason'];
+};
+
+async function objectName(idSystemObject: number): Promise<string | null> {
+    return (await CACHE.SystemObjectCache.getObjectNameByID(idSystemObject)) ?? null;
+}
+
+/** Ancestry (unit/project/subject names) for an object node, best-effort. */
+async function ancestry(idSystemObject: number): Promise<{ unit: string | null; project: string | null; subject: string | null }> {
+    const empty = { unit: null, project: null, subject: null };
+    const OG: DBAPI.ObjectGraph = new DBAPI.ObjectGraph(idSystemObject, DBAPI.eObjectGraphMode.eAncestors);
+    if (!await OG.fetch()) {
+        RK.logError(RK.LogSection.eDB, 'object summary', 'unable to compute ancestry',
+            { idSystemObject }, 'ObjectAction.Summary');
+        return empty;
+    }
+    return {
+        unit: OG.unit?.[0]?.Name ?? null,
+        project: OG.project?.[0]?.Name ?? null,
+        subject: OG.subject?.[0]?.Name ?? null,
+    };
+}
+
+/** Published state + EdanUUID for a scene node. */
+async function sceneState(idSystemObject: number): Promise<{ publishedState: string; edanUUID: string | null }> {
+    const SOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+    const publishedState: string = COMMON.PublishedStateEnumToString(SOV ? SOV.publishedStateEnum() : COMMON.ePublishedState.eNotPublished);
+
+    let edanUUID: string | null = null;
+    const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObject);
+    if (SO?.idScene) {
+        const scene: DBAPI.Scene | null = await DBAPI.Scene.fetch(SO.idScene);
+        edanUUID = scene?.EdanUUID ?? null;
+    }
+    return { publishedState, edanUUID };
+}
+
+/** Full enrichment for the preview (`describe`): name, ancestry, and scene publish state. */
+export async function describeSummaries(nodes: ResolvedNode[]): Promise<ObjectSummary[]> {
+    const summaries: ObjectSummary[] = [];
+    for (const node of nodes) {
+        const summary: ObjectSummary = {
+            idSystemObject: node.idSystemObject,
+            eObjectType: node.eObjectType,
+            objectType: SystemObjectTypeToName(node.eObjectType),
+            name: await objectName(node.idSystemObject),
+            kind: node.kind,
+            depth: node.depth,
+            retired: node.retired,
+        };
+        if (node.kind === 'object') {
+            const anc = await ancestry(node.idSystemObject);
+            summary.unit = anc.unit;
+            summary.project = anc.project;
+            summary.subject = anc.subject;
+        }
+        if (node.eObjectType === COMMON.eSystemObjectType.eScene) {
+            const state = await sceneState(node.idSystemObject);
+            summary.publishedState = state.publishedState;
+            summary.edanUUID = state.edanUUID;
+        }
+        summaries.push(summary);
+    }
+    return summaries;
+}
+
+/** Lightweight enrichment for action results: identity + per-item outcome. */
+export async function resultSummaries(items: RetireItemResult[]): Promise<ObjectSummary[]> {
+    const summaries: ObjectSummary[] = [];
+    for (const item of items) {
+        summaries.push({
+            idSystemObject: item.idSystemObject,
+            eObjectType: item.eObjectType,
+            objectType: SystemObjectTypeToName(item.eObjectType),
+            name: await objectName(item.idSystemObject),
+            kind: item.kind,
+            status: item.status,
+            unpublishedFromEdan: item.unpublishedFromEdan,
+            error: item.error,
+        });
+    }
+    return summaries;
+}
+
+/** Summaries for scope blockers (containers refused by the guard), tagged with the reason. */
+export async function blockerSummaries(blockers: ScopeBlocker[]): Promise<ObjectSummary[]> {
+    const summaries: ObjectSummary[] = [];
+    for (const blocker of blockers) {
+        summaries.push({
+            idSystemObject: blocker.node.idSystemObject,
+            eObjectType: blocker.node.eObjectType,
+            objectType: SystemObjectTypeToName(blocker.node.eObjectType),
+            name: await objectName(blocker.node.idSystemObject),
+            kind: blocker.node.kind,
+            depth: blocker.node.depth,
+            blockerReason: blocker.reason,
+        });
+    }
+    return summaries;
+}

--- a/server/objectAction/RetireExecutor.ts
+++ b/server/objectAction/RetireExecutor.ts
@@ -1,0 +1,109 @@
+import type { eSystemObjectType } from '@dpo-packrat/common';
+import type { ResolvedNode, ResolvedNodeKind, RetireResolution, ScopeBlocker } from '../db';
+
+export type RetireItemStatus =
+    | 'succeeded'    // flag was flipped by this operation
+    | 'failed'       // this object's EDAN unpublish or flag write failed
+    | 'skipped'      // already in the requested state (no-op)
+    | 'notApplied';  // in scope, but the operation aborted before touching it
+
+export type RetireItemResult = {
+    idSystemObject: number;
+    eObjectType: eSystemObjectType;
+    kind: ResolvedNodeKind;
+    status: RetireItemStatus;
+    unpublishedFromEdan?: boolean;   // set when this scene's EDAN package was unpublished by this op
+    error?: string;
+};
+
+export type RetireExecutionResult = {
+    applied: boolean;                // true only when the flag-flip phase ran
+    retire: boolean;                 // requested direction
+    items: RetireItemResult[];
+    blockers: ScopeBlocker[];        // scope-guard anomalies surfaced by the resolver (never acted on)
+    edanFailures: number;
+    message: string;
+};
+
+/** Result of unpublishing one scene from EDAN. */
+export type UnpublishResult = { success: boolean; error?: string };
+
+/**
+ * Side-effecting operations the executor orchestrates, injected so the abort-all sequencing can be
+ * unit-tested with fakes independently of the database and EDAN.
+ */
+export interface RetireExecutorDeps {
+    /** Resolve the candidate set (root + derived + assets) and scope blockers. */
+    resolve(idSystemObject: number): Promise<RetireResolution | null>;
+    /** idSystemObject of candidates that are scenes currently published to EDAN. */
+    findPublishedScenes(candidates: ResolvedNode[]): Promise<number[]>;
+    /** Unpublish one scene from EDAN. Runs outside any DB transaction (external HTTP). */
+    unpublishScene(idSystemObject: number): Promise<UnpublishResult>;
+    /** Flip the Retired flag for every candidate in one transaction; returns a per-item outcome. */
+    applyFlags(candidates: ResolvedNode[], retire: boolean): Promise<RetireItemResult[]>;
+}
+
+function summarize(retire: boolean, items: RetireItemResult[], unpublished: number): string {
+    const changed: number = items.filter(i => i.status === 'succeeded').length;
+    const skipped: number = items.filter(i => i.status === 'skipped').length;
+    const verb: string = retire ? 'Retired' : 'Reinstated';
+    const suffix: string = (retire && unpublished > 0) ? `; unpublished ${unpublished} scene(s) from EDAN` : '';
+    return `${verb} ${changed} object(s)${skipped > 0 ? `, ${skipped} already in state` : ''}${suffix}`;
+}
+
+/**
+ * Retire or reinstate a resolved object tree.
+ *
+ * Retire is phased so that a published scene never survives in EDAN behind a retired Packrat object:
+ *   1. Unpublish every affected published scene from EDAN (external, outside any tx).
+ *   2. If any unpublish fails, ABORT — no Retired flags are flipped — and report the failures. The
+ *      DB is untouched and the operation is retriable; already-succeeded unpublishes are not rolled
+ *      back (a scene left unpublished-but-not-retired is benign and self-heals on retry).
+ *   3. Only when every unpublish succeeds are the Retired flags flipped, in one transaction.
+ *
+ * Reinstate flips flags only — it never republishes to EDAN.
+ */
+export async function executeRetire(idSystemObject: number, retire: boolean, deps: RetireExecutorDeps): Promise<RetireExecutionResult> {
+    const resolution: RetireResolution | null = await deps.resolve(idSystemObject);
+    if (!resolution) {
+        return { applied: false, retire, items: [], blockers: [], edanFailures: 0,
+            message: `Unable to resolve retire candidates for SystemObject ${idSystemObject}` };
+    }
+    const { candidates, blockers } = resolution;
+
+    if (!retire) {
+        const items: RetireItemResult[] = await deps.applyFlags(candidates, false);
+        return { applied: true, retire: false, items, blockers, edanFailures: 0, message: summarize(false, items, 0) };
+    }
+
+    // Retire: unpublish affected published scenes from EDAN first, outside any transaction.
+    const publishedSceneIds: number[] = await deps.findPublishedScenes(candidates);
+    const edan: Map<number, UnpublishResult> = new Map<number, UnpublishResult>();
+    for (const id of publishedSceneIds)
+        edan.set(id, await deps.unpublishScene(id));
+
+    const failedIds: number[] = [...edan.entries()].filter(([, r]) => !r.success).map(([id]) => id);
+
+    if (failedIds.length > 0) {
+        // Abort-all: flip no flags. Report each candidate — failed scenes carry the error; everything
+        // else is notApplied. A scene that DID unpublish before the abort is flagged so the drift is
+        // visible rather than silent.
+        const items: RetireItemResult[] = candidates.map(c => {
+            const r: UnpublishResult | undefined = edan.get(c.idSystemObject);
+            if (r && !r.success)
+                return { idSystemObject: c.idSystemObject, eObjectType: c.eObjectType, kind: c.kind, status: 'failed', error: r.error };
+            return { idSystemObject: c.idSystemObject, eObjectType: c.eObjectType, kind: c.kind, status: 'notApplied',
+                unpublishedFromEdan: r?.success === true ? true : undefined };
+        });
+        return { applied: false, retire: true, items, blockers, edanFailures: failedIds.length,
+            message: `Aborted: ${failedIds.length} scene(s) could not be unpublished from EDAN; no objects were retired` };
+    }
+
+    // Every unpublish succeeded (or none were needed): flip flags.
+    const items: RetireItemResult[] = await deps.applyFlags(candidates, true);
+    for (const item of items)
+        if (edan.get(item.idSystemObject)?.success === true)
+            item.unpublishedFromEdan = true;
+
+    return { applied: true, retire: true, items, blockers, edanFailures: 0, message: summarize(true, items, edan.size) };
+}

--- a/server/objectAction/RetireExecutorDeps.ts
+++ b/server/objectAction/RetireExecutorDeps.ts
@@ -1,0 +1,108 @@
+import * as DBAPI from '../db';
+import * as COL from '../collections/interface';
+import * as COMMON from '@dpo-packrat/common';
+import * as H from '../utils/helpers';
+import { withAuditTransaction } from '../audit/withAuditTransaction';
+import { AuditFactory } from '../audit/interface/AuditFactory';
+import { eAuditType } from '../db/api/ObjectType';
+import { RecordKeeper as RK } from '../records/recordKeeper';
+import { executeRetire, RetireExecutorDeps, RetireExecutionResult, RetireItemResult, RetireItemStatus, UnpublishResult } from './RetireExecutor';
+
+function item(node: DBAPI.ResolvedNode, status: RetireItemStatus, error?: string): RetireItemResult {
+    return { idSystemObject: node.idSystemObject, eObjectType: node.eObjectType, kind: node.kind, status, error };
+}
+
+/** Scenes among the candidates whose latest version is currently published to EDAN. */
+async function findPublishedScenes(candidates: DBAPI.ResolvedNode[]): Promise<number[]> {
+    const ids: number[] = [];
+    for (const c of candidates) {
+        if (c.eObjectType !== COMMON.eSystemObjectType.eScene)
+            continue;
+        const SOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(c.idSystemObject);
+        if (SOV && SOV.publishedStateEnum() !== COMMON.ePublishedState.eNotPublished)
+            ids.push(c.idSystemObject);
+    }
+    return ids;
+}
+
+/** Unpublish one scene from EDAN by re-upserting its package with unpublished flags, then record a
+ *  semantic unpublish audit — mirroring the manual publish mutation. External HTTP; not in a tx. */
+async function unpublishScene(idSystemObject: number): Promise<UnpublishResult> {
+    const SOVPrior: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+    const prevState: COMMON.ePublishedState | null = SOVPrior ? SOVPrior.publishedStateEnum() : null;
+
+    const ICol: COL.ICollection = COL.CollectionFactory.getInstance();
+    let ok: boolean;
+    try {
+        ok = await ICol.publish(idSystemObject, COMMON.ePublishedState.eNotPublished);
+    } catch (error) {
+        RK.logError(RK.LogSection.eCOLL, 'retire unpublish', 'EDAN unpublish threw',
+            { idSystemObject, error: H.Helpers.getErrorString(error) }, 'ObjectAction.Retire');
+        return { success: false, error: H.Helpers.getErrorString(error) };
+    }
+    if (!ok)
+        return { success: false, error: 'EDAN unpublish failed' };
+
+    await withAuditTransaction(async () => {
+        await AuditFactory.emitSemantic({
+            action: eAuditType.eActionUnpublish,
+            idSystemObject,
+            payload: {
+                before: { eState: prevState, eStateName: prevState !== null ? COMMON.ePublishedState[prevState] : null },
+                after: { eState: COMMON.ePublishedState.eNotPublished, eStateName: COMMON.ePublishedState[COMMON.ePublishedState.eNotPublished] },
+                trigger: 'retire',
+            },
+        });
+    });
+    return { success: true };
+}
+
+/**
+ * Flip the Retired flag for every candidate in one audit transaction. The root (candidate 0) is
+ * written first with a semantic retire/reinstate row; its idAudit threads into every descendant as
+ * parentRetirement.idAudit so the retirement tree is reconstructable from the Audit table.
+ */
+async function applyRetireFlags(candidates: DBAPI.ResolvedNode[], retire: boolean): Promise<RetireItemResult[]> {
+    const results: RetireItemResult[] = [];
+    await withAuditTransaction(async () => {
+        let rootAuditId: number | null = null;
+        for (let i = 0; i < candidates.length; i++) {
+            const c: DBAPI.ResolvedNode = candidates[i];
+            const isRoot: boolean = i === 0;
+            const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(c.idSystemObject);
+            if (!SO) {
+                results.push(item(c, 'failed', 'unable to fetch SystemObject'));
+                continue;
+            }
+
+            const alreadyInState: boolean = retire ? SO.Retired : !SO.Retired;
+            if (alreadyInState) {
+                results.push(item(c, 'skipped'));
+                continue;
+            }
+
+            const ctx = isRoot ? { reason: null } : { parentAuditId: rootAuditId };
+            const res = retire ? await SO.retireObjectWithContext(ctx) : await SO.reinstateObjectWithContext(ctx);
+            if (res.success) {
+                if (isRoot)
+                    rootAuditId = res.idAudit;
+                results.push(item(c, 'succeeded'));
+            } else
+                results.push(item(c, 'failed', `${retire ? 'retire' : 'reinstate'} write failed`));
+        }
+    });
+    return results;
+}
+
+/** Production dependencies: resolve against the DB, unpublish via EDAN, flip flags transactionally. */
+export const dbRetireExecutorDeps: RetireExecutorDeps = {
+    resolve: (idSystemObject: number) => DBAPI.resolveRetireCandidatesFromSystemObject(idSystemObject),
+    findPublishedScenes,
+    unpublishScene,
+    applyFlags: applyRetireFlags,
+};
+
+/** Retire or reinstate an object and its resolved dependents/assets against the live DB and EDAN. */
+export async function retireSystemObjectTree(idSystemObject: number, retire: boolean): Promise<RetireExecutionResult> {
+    return executeRetire(idSystemObject, retire, dbRetireExecutorDeps);
+}

--- a/server/objectAction/RetireExecutorDeps.ts
+++ b/server/objectAction/RetireExecutorDeps.ts
@@ -6,6 +6,7 @@ import { withAuditTransaction } from '../audit/withAuditTransaction';
 import { AuditFactory } from '../audit/interface/AuditFactory';
 import { eAuditType } from '../db/api/ObjectType';
 import { RecordKeeper as RK } from '../records/recordKeeper';
+import { ASL } from '../utils/localStore';
 import { executeRetire, RetireExecutorDeps, RetireExecutionResult, RetireItemResult, RetireItemStatus, UnpublishResult } from './RetireExecutor';
 
 function item(node: DBAPI.ResolvedNode, status: RetireItemStatus, error?: string): RetireItemResult {
@@ -64,6 +65,9 @@ async function unpublishScene(idSystemObject: number): Promise<UnpublishResult> 
  */
 async function applyRetireFlags(candidates: DBAPI.ResolvedNode[], retire: boolean): Promise<RetireItemResult[]> {
     const results: RetireItemResult[] = [];
+    // Pass the acting Actor so a semantic eActionRetire/eActionReinstate row is emitted (not just the
+    // base eDBUpdate); the root's idAudit then threads into descendants as parentRetirement.idAudit.
+    const actor = ASL.getStore()?.getActor();
     await withAuditTransaction(async () => {
         let rootAuditId: number | null = null;
         for (let i = 0; i < candidates.length; i++) {
@@ -81,7 +85,7 @@ async function applyRetireFlags(candidates: DBAPI.ResolvedNode[], retire: boolea
                 continue;
             }
 
-            const ctx = isRoot ? { reason: null } : { parentAuditId: rootAuditId };
+            const ctx = { actor, reason: null, parentAuditId: isRoot ? null : rootAuditId };
             const res = retire ? await SO.retireObjectWithContext(ctx) : await SO.reinstateObjectWithContext(ctx);
             if (res.success) {
                 if (isRoot)

--- a/server/tests/db/composite/RetireCandidateResolver.test.ts
+++ b/server/tests/db/composite/RetireCandidateResolver.test.ts
@@ -101,6 +101,32 @@ describe('resolveRetireCandidates', () => {
         expect(ids(candidates)).toEqual([1, 2, 10]);
     });
 
+    test('attributes an asset to its owner object when idParent points to a crawled sibling', async () => {
+        const root = obj(1, eSystemObjectType.eScene);
+        const source = new MemSource(
+            new Map([[1, [obj(2, eSystemObjectType.eModel)]]]),
+            // the scene surfaces asset 10, but it is owned by model 2
+            new Map([[1, [{ ...asset(10), idParent: 2 }]]]),
+        );
+        const { candidates } = await resolveRetireCandidates(root, source);
+        const a10 = candidates.find(c => c.idSystemObject === 10);
+        expect(a10?.idParent).toBe(2);
+        // nested under model 2: appears immediately after it in depth-first order
+        const idx = candidates.findIndex(c => c.idSystemObject === 10);
+        expect(candidates[idx - 1].idSystemObject).toBe(2);
+    });
+
+    test('falls back to the surfacing object when the asset owner is not crawled', async () => {
+        const root = obj(1, eSystemObjectType.eScene);
+        const source = new MemSource(
+            new Map(),
+            // asset 10 claims owner 999 which is not in the graph → attributed to the scene
+            new Map([[1, [{ ...asset(10), idParent: 999 }]]]),
+        );
+        const { candidates } = await resolveRetireCandidates(root, source);
+        expect(candidates.find(c => c.idSystemObject === 10)?.idParent).toBe(1);
+    });
+
     test('records depth increasing down the graph', async () => {
         const root = obj(1, eSystemObjectType.eItem);
         const source = new MemSource(new Map([

--- a/server/tests/db/composite/RetireCandidateResolver.test.ts
+++ b/server/tests/db/composite/RetireCandidateResolver.test.ts
@@ -1,0 +1,116 @@
+import { eSystemObjectType } from '@dpo-packrat/common';
+import { resolveRetireCandidates, ResolvedNode, RetireGraphSource } from '../../../db/api/composite/RetireCandidateResolver';
+
+function obj(idSystemObject: number, eObjectType: eSystemObjectType, retired: boolean = false): ResolvedNode {
+    return { idSystemObject, eObjectType, retired, depth: 0, kind: 'object' };
+}
+function asset(idSystemObject: number): ResolvedNode {
+    return { idSystemObject, eObjectType: eSystemObjectType.eAsset, retired: false, depth: 0, kind: 'asset' };
+}
+
+class MemSource implements RetireGraphSource {
+    constructor(
+        private children: Map<number, ResolvedNode[]> = new Map<number, ResolvedNode[]>(),
+        private assets: Map<number, ResolvedNode[]> = new Map<number, ResolvedNode[]>(),
+    ) {}
+    async getChildren(idSystemObject: number): Promise<ResolvedNode[]> {
+        return (this.children.get(idSystemObject) ?? []).map(n => ({ ...n }));
+    }
+    async getAssets(node: ResolvedNode): Promise<ResolvedNode[]> {
+        return (this.assets.get(node.idSystemObject) ?? []).map(n => ({ ...n }));
+    }
+}
+
+const ids = (nodes: ResolvedNode[]): number[] => nodes.map(n => n.idSystemObject).sort((a, b) => a - b);
+
+describe('resolveRetireCandidates', () => {
+    test('collects root, derived objects, and their assets (deduped)', async () => {
+        const root = obj(1, eSystemObjectType.eItem);
+        const source = new MemSource(
+            new Map([
+                [1, [obj(2, eSystemObjectType.eModel), obj(3, eSystemObjectType.eScene)]],
+                [3, [obj(4, eSystemObjectType.eModel)]],
+            ]),
+            new Map([
+                [2, [asset(10)]],
+                [3, [asset(11)]],
+                [4, [asset(12)]],
+            ]),
+        );
+        const { candidates, blockers } = await resolveRetireCandidates(root, source);
+        expect(blockers).toHaveLength(0);
+        expect(ids(candidates)).toEqual([1, 2, 3, 4, 10, 11, 12]);
+    });
+
+    test('terminates on a cycle', async () => {
+        const root = obj(1, eSystemObjectType.eModel);
+        const source = new MemSource(new Map([
+            [1, [obj(2, eSystemObjectType.eModel)]],
+            [2, [obj(1, eSystemObjectType.eModel)]], // back-edge
+        ]));
+        const { candidates } = await resolveRetireCandidates(root, source);
+        expect(ids(candidates)).toEqual([1, 2]);
+    });
+
+    test('dedupes a diamond', async () => {
+        const root = obj(1, eSystemObjectType.eItem);
+        const source = new MemSource(new Map([
+            [1, [obj(2, eSystemObjectType.eModel), obj(3, eSystemObjectType.eModel)]],
+            [2, [obj(4, eSystemObjectType.eScene)]],
+            [3, [obj(4, eSystemObjectType.eScene)]], // same child reached twice
+        ]));
+        const { candidates } = await resolveRetireCandidates(root, source);
+        expect(ids(candidates)).toEqual([1, 2, 3, 4]);
+    });
+
+    test('scope guard blocks a container below the root and skips its subtree', async () => {
+        const root = obj(1, eSystemObjectType.eModel);
+        const source = new MemSource(new Map([
+            [1, [obj(2, eSystemObjectType.eSubject)]],  // inverted: container under a Model
+            [2, [obj(3, eSystemObjectType.eItem)]],     // must NOT be reached
+        ]));
+        const { candidates, blockers } = await resolveRetireCandidates(root, source);
+        expect(ids(candidates)).toEqual([1]);
+        expect(blockers).toHaveLength(1);
+        expect(blockers[0].node.idSystemObject).toBe(2);
+        expect(blockers[0].reason).toBe('containerBelowRoot');
+    });
+
+    test('permits legitimate downward container cascade (Unit root)', async () => {
+        const root = obj(1, eSystemObjectType.eUnit);
+        const source = new MemSource(new Map([
+            [1, [obj(2, eSystemObjectType.eSubject)]],
+            [2, [obj(3, eSystemObjectType.eItem)]],
+            [3, [obj(4, eSystemObjectType.eScene)]],
+        ]));
+        const { candidates, blockers } = await resolveRetireCandidates(root, source);
+        expect(blockers).toHaveLength(0);
+        expect(ids(candidates)).toEqual([1, 2, 3, 4]);
+    });
+
+    test('dedupes an asset shared across two owners', async () => {
+        const root = obj(1, eSystemObjectType.eScene);
+        const source = new MemSource(
+            new Map([[1, [obj(2, eSystemObjectType.eModel)]]]),
+            new Map([
+                [1, [asset(10)]],
+                [2, [asset(10)]], // same asset owned by scene and its model
+            ]),
+        );
+        const { candidates } = await resolveRetireCandidates(root, source);
+        expect(ids(candidates)).toEqual([1, 2, 10]);
+    });
+
+    test('records depth increasing down the graph', async () => {
+        const root = obj(1, eSystemObjectType.eItem);
+        const source = new MemSource(new Map([
+            [1, [obj(2, eSystemObjectType.eModel)]],
+            [2, [obj(3, eSystemObjectType.eScene)]],
+        ]));
+        const { candidates } = await resolveRetireCandidates(root, source);
+        const byId = new Map(candidates.map(n => [n.idSystemObject, n.depth]));
+        expect(byId.get(1)).toBe(0);
+        expect(byId.get(2)).toBe(1);
+        expect(byId.get(3)).toBe(2);
+    });
+});

--- a/server/tests/jest.config.js
+++ b/server/tests/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     // collectCoverage: true,
     testMatch: [
         // The complete test suite, on one line, to aid in quick commenting out
-        '**/tests/audit/**/*.test.ts', '**/tests/auth/**', '**/tests/cache/cache.test.ts', '**/tests/collections/*.test.ts', '**/tests/db/**/*.test.ts', '**/tests/graphql/graphql.test.ts', '**/tests/metadata/*.test.ts', '**/tests/job/**/*.test.ts', '**/tests/navigation/**/*.test.ts', '**/tests/storage/**/*.test.ts', '**/tests/utils/**/*.test.ts',
+        '**/tests/audit/**/*.test.ts', '**/tests/auth/**', '**/tests/cache/cache.test.ts', '**/tests/collections/*.test.ts', '**/tests/db/**/*.test.ts', '**/tests/graphql/graphql.test.ts', '**/tests/metadata/*.test.ts', '**/tests/job/**/*.test.ts', '**/tests/navigation/**/*.test.ts', '**/tests/objectAction/**/*.test.ts', '**/tests/storage/**/*.test.ts', '**/tests/utils/**/*.test.ts',
         // '**/tests/db/dbcreation.test.ts',
 
         // Larger test collections, left here to aid in quick, focused testing; these are the elements on the line above:

--- a/server/tests/objectAction/RetireExecutor.test.ts
+++ b/server/tests/objectAction/RetireExecutor.test.ts
@@ -1,0 +1,105 @@
+import { eSystemObjectType } from '@dpo-packrat/common';
+import type { ResolvedNode, RetireResolution } from '../../db/api/composite/RetireCandidateResolver';
+import { executeRetire, RetireExecutorDeps, RetireItemResult, UnpublishResult } from '../../objectAction/RetireExecutor';
+
+function obj(idSystemObject: number, eObjectType: eSystemObjectType): ResolvedNode {
+    return { idSystemObject, eObjectType, retired: false, depth: 0, kind: 'object' };
+}
+
+/** Deps whose behavior is scripted per test, with call tracking. */
+function makeDeps(opts: {
+    resolution: RetireResolution | null;
+    publishedScenes?: number[];
+    unpublish?: (id: number) => UnpublishResult;
+}): RetireExecutorDeps & { applyFlagsCalls: Array<{ retire: boolean }>; unpublishCalls: number[] } {
+    const applyFlagsCalls: Array<{ retire: boolean }> = [];
+    const unpublishCalls: number[] = [];
+    return {
+        applyFlagsCalls,
+        unpublishCalls,
+        resolve: async () => opts.resolution,
+        findPublishedScenes: async () => opts.publishedScenes ?? [],
+        unpublishScene: async (id: number): Promise<UnpublishResult> => {
+            unpublishCalls.push(id);
+            return opts.unpublish ? opts.unpublish(id) : { success: true };
+        },
+        applyFlags: async (candidates: ResolvedNode[], retire: boolean): Promise<RetireItemResult[]> => {
+            applyFlagsCalls.push({ retire });
+            return candidates.map(c => ({ idSystemObject: c.idSystemObject, eObjectType: c.eObjectType, kind: c.kind, status: 'succeeded' }));
+        },
+    };
+}
+
+const statusOf = (items: RetireItemResult[], id: number) => items.find(i => i.idSystemObject === id)?.status;
+
+describe('executeRetire', () => {
+    test('reinstate flips flags without touching EDAN', async () => {
+        const deps = makeDeps({ resolution: { candidates: [obj(1, eSystemObjectType.eScene)], blockers: [] } });
+        const res = await executeRetire(1, false, deps);
+        expect(res.applied).toBe(true);
+        expect(res.retire).toBe(false);
+        expect(deps.unpublishCalls).toHaveLength(0);
+        expect(deps.applyFlagsCalls).toEqual([{ retire: false }]);
+    });
+
+    test('retire with no published scenes flips flags directly', async () => {
+        const deps = makeDeps({
+            resolution: { candidates: [obj(1, eSystemObjectType.eItem), obj(2, eSystemObjectType.eModel)], blockers: [] },
+            publishedScenes: [],
+        });
+        const res = await executeRetire(1, true, deps);
+        expect(res.applied).toBe(true);
+        expect(deps.unpublishCalls).toHaveLength(0);
+        expect(deps.applyFlagsCalls).toEqual([{ retire: true }]);
+    });
+
+    test('retire unpublishes a published scene, then flips flags', async () => {
+        const deps = makeDeps({
+            resolution: { candidates: [obj(1, eSystemObjectType.eItem), obj(2, eSystemObjectType.eScene)], blockers: [] },
+            publishedScenes: [2],
+        });
+        const res = await executeRetire(1, true, deps);
+        expect(res.applied).toBe(true);
+        expect(deps.unpublishCalls).toEqual([2]);
+        expect(deps.applyFlagsCalls).toEqual([{ retire: true }]);
+        expect(res.items.find(i => i.idSystemObject === 2)?.unpublishedFromEdan).toBe(true);
+        expect(res.message).toMatch(/unpublished 1 scene/);
+    });
+
+    test('aborts all when an EDAN unpublish fails — no flags flipped', async () => {
+        const deps = makeDeps({
+            resolution: { candidates: [obj(1, eSystemObjectType.eItem), obj(2, eSystemObjectType.eScene)], blockers: [] },
+            publishedScenes: [2],
+            unpublish: () => ({ success: false, error: 'EDAN 500' }),
+        });
+        const res = await executeRetire(1, true, deps);
+        expect(res.applied).toBe(false);
+        expect(res.edanFailures).toBe(1);
+        expect(deps.applyFlagsCalls).toHaveLength(0); // abort before flag flip
+        expect(statusOf(res.items, 2)).toBe('failed');
+        expect(res.items.find(i => i.idSystemObject === 2)?.error).toBe('EDAN 500');
+        expect(statusOf(res.items, 1)).toBe('notApplied');
+    });
+
+    test('on abort, a scene already unpublished is flagged as drift, not silently dropped', async () => {
+        const deps = makeDeps({
+            resolution: { candidates: [obj(2, eSystemObjectType.eScene), obj(3, eSystemObjectType.eScene)], blockers: [] },
+            publishedScenes: [2, 3],
+            unpublish: (id: number) => (id === 3 ? { success: false, error: 'EDAN 500' } : { success: true }),
+        });
+        const res = await executeRetire(2, true, deps);
+        expect(res.applied).toBe(false);
+        expect(statusOf(res.items, 2)).toBe('notApplied');
+        expect(res.items.find(i => i.idSystemObject === 2)?.unpublishedFromEdan).toBe(true);
+        expect(statusOf(res.items, 3)).toBe('failed');
+        expect(deps.applyFlagsCalls).toHaveLength(0);
+    });
+
+    test('reports failure when the candidate set cannot be resolved', async () => {
+        const deps = makeDeps({ resolution: null });
+        const res = await executeRetire(99, true, deps);
+        expect(res.applied).toBe(false);
+        expect(res.items).toHaveLength(0);
+        expect(res.message).toMatch(/99/);
+    });
+});

--- a/server/tests/utils/containmentRank.test.ts
+++ b/server/tests/utils/containmentRank.test.ts
@@ -1,0 +1,53 @@
+import { eSystemObjectType, containmentRank, isContainerType, isInvertedContainmentEdge } from '@dpo-packrat/common';
+
+describe('common containment rank', () => {
+    test('containmentRank ranks the hierarchy top-down, leaves ancillary types unranked', () => {
+        expect(containmentRank(eSystemObjectType.eUnit)).toBe(0);
+        expect(containmentRank(eSystemObjectType.eProject)).toBe(1);
+        expect(containmentRank(eSystemObjectType.eSubject)).toBe(2);
+        expect(containmentRank(eSystemObjectType.eItem)).toBe(3);
+        expect(containmentRank(eSystemObjectType.eModel)).toBe(4);
+        expect(containmentRank(eSystemObjectType.eScene)).toBe(4);
+        expect(containmentRank(eSystemObjectType.eAsset)).toBe(5);
+        expect(containmentRank(eSystemObjectType.eAssetVersion)).toBe(6);
+        expect(containmentRank(eSystemObjectType.eActor)).toBeUndefined();
+        expect(containmentRank(eSystemObjectType.eStakeholder)).toBeUndefined();
+        expect(containmentRank(eSystemObjectType.eProjectDocumentation)).toBeUndefined();
+    });
+
+    test('isContainerType is true only for Unit/Project/Subject/Item', () => {
+        expect(isContainerType(eSystemObjectType.eUnit)).toBe(true);
+        expect(isContainerType(eSystemObjectType.eProject)).toBe(true);
+        expect(isContainerType(eSystemObjectType.eSubject)).toBe(true);
+        expect(isContainerType(eSystemObjectType.eItem)).toBe(true);
+        expect(isContainerType(eSystemObjectType.eModel)).toBe(false);
+        expect(isContainerType(eSystemObjectType.eScene)).toBe(false);
+        expect(isContainerType(eSystemObjectType.eAsset)).toBe(false);
+        expect(isContainerType(eSystemObjectType.eActor)).toBe(false);
+    });
+
+    test('isInvertedContainmentEdge permits valid downward container edges', () => {
+        expect(isInvertedContainmentEdge(eSystemObjectType.eUnit, eSystemObjectType.eProject)).toBe(false);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eUnit, eSystemObjectType.eSubject)).toBe(false);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eProject, eSystemObjectType.eItem)).toBe(false);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eSubject, eSystemObjectType.eItem)).toBe(false);
+    });
+
+    test('isInvertedContainmentEdge flags a container placed beneath a lower tier', () => {
+        expect(isInvertedContainmentEdge(eSystemObjectType.eModel, eSystemObjectType.eSubject)).toBe(true);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eModel, eSystemObjectType.eItem)).toBe(true);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eCaptureData, eSystemObjectType.eItem)).toBe(true);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eScene, eSystemObjectType.eUnit)).toBe(true);
+    });
+
+    test('isInvertedContainmentEdge never flags a non-container derived', () => {
+        expect(isInvertedContainmentEdge(eSystemObjectType.eItem, eSystemObjectType.eScene)).toBe(false);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eScene, eSystemObjectType.eModel)).toBe(false);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eModel, eSystemObjectType.eModel)).toBe(false);
+    });
+
+    test('isInvertedContainmentEdge forms no opinion when a type is unranked', () => {
+        expect(isInvertedContainmentEdge(eSystemObjectType.eActor, eSystemObjectType.eUnit)).toBe(false);
+        expect(isInvertedContainmentEdge(eSystemObjectType.eProjectDocumentation, eSystemObjectType.eSubject)).toBe(false);
+    });
+});


### PR DESCRIPTION
* Retire flow uses shared executor and phased orchestration
* New Action API for describe, retire, and reinstate
* Preview modal shows impact tree, assets, blockers
* Retire/Reinstate UI replaces legacy checkbox flow
* Shared containment helpers and graph resolver
* Cycle-safe traversal with container scope guards
* EDAN unpublish is atomic with abort-on-failure
* Audit IDs propagate through retire cascades
* Duplicate audit rows and legacy cascade code removed
* Server feature flags drive volumetric upload option
* Added published EDAN scenes report and admin tool
* Expanded unit test coverage for retire workflows