### PR TITLE
DPO3DPKRT-1014/UX Persistent App Shell and Navigation

### DIFF
--- a/client/src/components/controls/RepositoryIcon.tsx
+++ b/client/src/components/controls/RepositoryIcon.tsx
@@ -23,8 +23,7 @@ export function RepositoryIcon(props: RepositoryIconProps): React.ReactElement {
         <a
             href={getDetailsUrlForObject(idSystemObject)}
             onClick={event => event.stopPropagation()}
-            target='_blank'
-            rel='noopener noreferrer'
+            target='_self'
             aria-label={`link to view system object of id ${idSystemObject}`}
             style={{ textDecoration: 'none' }}
         >

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -15,6 +15,7 @@ import SelectField from './controls/SelectField';
 import InputField from './controls/InputField';
 import DateInputField from './controls/DateInputField';
 import BreadcrumbsView from './shared/BreadcrumbsView';
+import NavTrailBreadcrumbs from './shared/NavTrailBreadcrumbs';
 import NewTabLink from './shared/NewTabLink';
 import EmptyTable from './shared/EmptyTable';
 import EnvBanner from './shared/EnvBanner';
@@ -41,6 +42,7 @@ export {
     InputField,
     DateInputField,
     BreadcrumbsView,
+    NavTrailBreadcrumbs,
     NewTabLink,
     EmptyTable,
     EnvBanner,

--- a/client/src/components/shared/Header.tsx
+++ b/client/src/components/shared/Header.tsx
@@ -14,7 +14,7 @@ import Logo from '../../assets/images/logo-packrat.square.png';
 import { generateRepositoryUrl } from '../../utils/repository';
 import { Selectors } from '../../config';
 import { HOME_ROUTES, resolveRoute, ROUTES } from '../../constants';
-import { useRepositoryStore, useUserStore } from '../../store';
+import { useRepositoryStore, useUserStore, confirmLeaveEdit } from '../../store';
 import { Colors } from '../../theme';
 import { confirmLeaveIngestion } from '../../pages/Ingestion';
 
@@ -136,8 +136,7 @@ function Header(): React.ReactElement {
     };
 
     const onClick = (e) => {
-        const leaveIngestion = confirmLeaveIngestion();
-        if (!leaveIngestion) e.preventDefault();
+        if (!confirmLeaveIngestion() || !confirmLeaveEdit()) e.preventDefault();
     };
 
     const isRepository = pathname.includes(HOME_ROUTES.REPOSITORY);
@@ -155,8 +154,7 @@ function Header(): React.ReactElement {
 
     // General search function when in different views
     const onSearch = (): void => {
-        const leaveIngestion = confirmLeaveIngestion();
-        if (!leaveIngestion) return;
+        if (!confirmLeaveIngestion() || !confirmLeaveEdit()) return;
 
         const route: string = resolveRoute(HOME_ROUTES.REPOSITORY);
         resetRepositoryFilter();

--- a/client/src/components/shared/Header.tsx
+++ b/client/src/components/shared/Header.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles(({ palette, spacing, typography, breakpoints }) => 
     container: {
         display: 'flex',
         height: 60,
+        flexShrink: 0,
         alignItems: 'center',
         justifyContent: 'space-between',
         padding: '0px 1.5rem',

--- a/client/src/components/shared/NavTrailBreadcrumbs.tsx
+++ b/client/src/components/shared/NavTrailBreadcrumbs.tsx
@@ -1,0 +1,72 @@
+/**
+ * NavTrailBreadcrumbs
+ *
+ * Renders the navigation trail (the path of repository objects the user actually
+ * visited) as clickable breadcrumbs. Clicking an earlier crumb truncates the trail
+ * back to that point and navigates there in the same tab.
+ */
+import { Breadcrumbs, Typography } from '@material-ui/core';
+import { fade, makeStyles } from '@material-ui/core/styles';
+import React from 'react';
+import { MdNavigateNext } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
+import { useNavHistoryStore } from '../../store';
+import { getTermForSystemObjectType } from '../../utils/repository';
+
+const useStyles = makeStyles(({ palette }) => ({
+    container: {
+        display: 'flex',
+        backgroundColor: fade(palette.primary.main, 0.8),
+        color: palette.background.paper,
+        padding: '2.5px 10px',
+        borderRadius: 5
+    },
+    crumb: {
+        fontSize: '0.7rem',
+        color: 'white',
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+        textDecoration: 'none',
+        '&:hover': {
+            textDecoration: 'underline'
+        }
+    },
+    current: {
+        fontSize: '0.7rem',
+        color: 'white',
+        fontWeight: 600,
+        cursor: 'default'
+    }
+}));
+
+function NavTrailBreadcrumbs(): React.ReactElement | null {
+    const classes = useStyles();
+    const navigate = useNavigate();
+    const [trail, truncateTo] = useNavHistoryStore(state => [state.trail, state.truncateTo]);
+
+    if (!trail.length) return null;
+
+    return (
+        <Breadcrumbs className={classes.container} separator={<MdNavigateNext color='inherit' size={20} />}>
+            {trail.map((crumb, index) => {
+                const label = crumb.label ?? `${getTermForSystemObjectType(crumb.objectType)} ${crumb.name}`;
+                if (index === trail.length - 1)
+                    return <Typography key={crumb.idSystemObject} className={classes.current}>{label}</Typography>;
+                return (
+                    <Typography
+                        key={crumb.idSystemObject}
+                        component='button'
+                        className={classes.crumb}
+                        onClick={() => { truncateTo(index); navigate(crumb.url); }}
+                    >
+                        {label}
+                    </Typography>
+                );
+            })}
+        </Breadcrumbs>
+    );
+}
+
+export default NavTrailBreadcrumbs;

--- a/client/src/components/shared/NewTabLink.tsx
+++ b/client/src/components/shared/NewTabLink.tsx
@@ -1,11 +1,14 @@
 /**
  * NewTabLink
  *
- * This is a reusable link component.
+ * Reusable internal link. Navigates in the same tab by default; pass `newTab`
+ * to open in a new tab. Modifier-click (Ctrl/Cmd) and middle-click still open a
+ * new tab natively because this renders a real anchor.
  */
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
+import { confirmLeaveEdit } from '../../store';
 
 const useStyles = makeStyles(({ palette }) => ({
     link: {
@@ -16,24 +19,38 @@ const useStyles = makeStyles(({ palette }) => ({
 
 interface NewTabLinkProps {
     color?: string;
+    newTab?: boolean;
 }
 
 function NewTabLink(props: NewTabLinkProps & LinkProps): React.ReactElement {
     const classes = useStyles(props);
+    const { newTab, target: targetProp, rel: relProp, children, ...linkProps } = props;
+
+    const target = newTab ? '_blank' : (targetProp ?? '_self');
+    const rel = newTab ? 'noopener noreferrer' : relProp;
 
     const customProps = {
-        onClick: event => event.stopPropagation()
+        onClick: (event: React.MouseEvent) => {
+            event.stopPropagation();
+            // a plain click navigates in place; guard unsaved edits first. Modifier/
+            // middle-clicks (and newTab) open a new tab and preserve the current view.
+            const opensNewTab = newTab || event.ctrlKey || event.metaKey || event.shiftKey || event.button !== 0;
+            if (!opensNewTab && !confirmLeaveEdit())
+                event.preventDefault();
+        }
     };
 
-    if (props.children) {
-        return (
-            <Link target='_blank' className={classes.link} {...customProps} {...props}>
-                {props.children}
-            </Link>
-        );
-    }
-
-    return <Link target='_blank' className={classes.link} {...customProps} {...props} />;
+    return (
+        <Link
+            className={classes.link}
+            target={target}
+            rel={rel}
+            {...customProps}
+            {...linkProps}
+        >
+            {children}
+        </Link>
+    );
 }
 
 export default NewTabLink;

--- a/client/src/components/shared/ServiceStatusBanner.tsx
+++ b/client/src/components/shared/ServiceStatusBanner.tsx
@@ -2,12 +2,12 @@
  * ServiceStatusBanner
  *
  * Renders thin banners at the top of the screen when backend services
- * (Database, Solr, EDAN) are unavailable. Updates the --status-banner-height
- * CSS variable so that calc()-based layouts adjust automatically.
+ * (Database, Solr, EDAN) are unavailable. Pinned above the header as a
+ * non-scrolling flex child of the app shell.
  */
 import { Box, Typography } from '@material-ui/core';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { useServiceStatusStore } from '../../store';
 
 const useStyles = makeStyles(() => createStyles({
@@ -38,7 +38,6 @@ const useStyles = makeStyles(() => createStyles({
 function ServiceStatusBanner(): React.ReactElement | null {
     const classes = useStyles();
     const { status, initialized } = useServiceStatusStore();
-    const wrapperRef = useRef<HTMLDivElement>(null);
 
     const banners: { message: string; severity: 'error' | 'warning' }[] = [];
 
@@ -63,18 +62,10 @@ function ServiceStatusBanner(): React.ReactElement | null {
         });
     }
 
-    useEffect(() => {
-        const height = wrapperRef.current ? wrapperRef.current.offsetHeight : 0;
-        document.documentElement.style.setProperty('--status-banner-height', `${height}px`);
-        return () => {
-            document.documentElement.style.setProperty('--status-banner-height', '0px');
-        };
-    }, [banners.length]);
-
     if (banners.length === 0) return null;
 
     return (
-        <div ref={wrapperRef} className={classes.wrapper}>
+        <div className={classes.wrapper}>
             {banners.map((banner, index) => (
                 <Box
                     key={index}

--- a/client/src/global/root.css
+++ b/client/src/global/root.css
@@ -1,10 +1,13 @@
 html {
     scroll-behavior: smooth;
-    --status-banner-height: 0px;
+    height: 100%;
+    overflow: hidden;
 }
 
 body {
     margin: 0;
+    height: 100%;
+    overflow: hidden;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -17,7 +20,8 @@ code {
 #root {
     display: flex;
     flex: 1;
-    min-height: 100vh;
+    height: 100vh;
+    overflow: hidden;
     width: 100%;
     flex-direction: column;
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -34,13 +34,29 @@ const useStyles = makeStyles(() => ({
     container: {
         display: 'flex',
         flexDirection: 'column',
-        flex: 1,
-        width: 'fit-content',
+        height: '100%',
+        minHeight: 0,
         minWidth: '100%'
     },
     content: {
         display: 'flex',
-        flex: 1
+        flex: 1,
+        minHeight: 0,
+        overflow: 'hidden'
+    },
+    scrollRegion: {
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        overflow: 'auto'
+    },
+    noticeSlot: {
+        // Mount point for page-level content notices; pinned to the top of the
+        // scroll region while the content beneath it scrolls.
+        position: 'sticky',
+        top: 0,
+        zIndex: 1
     }
 }));
 
@@ -89,7 +105,10 @@ function AppRouter(): React.ReactElement {
                     <Header />
                     <Box className={classes.content}>
                         <SidePanel isExpanded={sideBarExpanded} onToggle={onToggle} />
-                        <Home />
+                        <Box className={classes.scrollRegion}>
+                            <Box className={classes.noticeSlot} />
+                            <Home />
+                        </Box>
                     </Box>
                 </Box>
             </AliveScope>

--- a/client/src/pages/Admin/components/Subject/SubjectForm.tsx
+++ b/client/src/pages/Admin/components/Subject/SubjectForm.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles(({ palette }) => ({
         flex: 1,
         flexDirection: 'column',
         overflow: 'auto',
-        maxHeight: 'calc(100vh - 60px - var(--status-banner-height, 0px))'
+        minHeight: 0
     },
     content: {
         display: 'flex',

--- a/client/src/pages/Home/components/SidePanel.tsx
+++ b/client/src/pages/Home/components/SidePanel.tsx
@@ -17,6 +17,8 @@ const useStyles = makeStyles(({ palette, breakpoints }) => ({
     container: {
         display: 'flex',
         flexDirection: 'column',
+        flexShrink: 0,
+        overflowY: 'auto',
         backgroundColor: palette.primary.dark,
     },
     menuOptions: {

--- a/client/src/pages/Home/components/SidePanelOption.tsx
+++ b/client/src/pages/Home/components/SidePanelOption.tsx
@@ -12,6 +12,7 @@ import { HOME_ROUTES, resolveRoute } from '../../../constants';
 import { Colors } from '../../../theme';
 import { Link } from 'react-router-dom';
 import { confirmLeaveIngestion } from '../../Ingestion';
+import { confirmLeaveEdit } from '../../../store';
 
 const useStyles = makeStyles(({ palette, spacing, breakpoints }) => createStyles({
     container: {
@@ -79,8 +80,7 @@ function SidePanelOption(props: SidePanelOptionProps): React.ReactElement {
 
     const classes = useStyles(props);
     const onClick = (e) => {
-        const leaveIngestion = confirmLeaveIngestion();
-        if (!leaveIngestion) e.preventDefault();
+        if (!confirmLeaveIngestion() || !confirmLeaveEdit()) e.preventDefault();
     };
 
     return (

--- a/client/src/pages/Ingestion/components/SubjectItem/index.tsx
+++ b/client/src/pages/Ingestion/components/SubjectItem/index.tsx
@@ -26,7 +26,8 @@ const useStyles = makeStyles(({ palette }) => ({
         flex: 1,
         flexDirection: 'column',
         overflow: 'auto',
-        maxHeight: 'calc(100vh - 60px - var(--status-banner-height, 0px))'
+        height: '100%',
+        minHeight: 0
     },
     content: {
         display: 'flex',

--- a/client/src/pages/Ingestion/components/Uploads/index.tsx
+++ b/client/src/pages/Ingestion/components/Uploads/index.tsx
@@ -27,8 +27,7 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => createStyles(
         display: 'flex',
         flex: 1,
         flexDirection: 'column',
-        // overflow: 'auto',
-        maxHeight: 'calc(100vh - 60px - var(--status-banner-height, 0px))',
+        minHeight: 0,
         overflow: 'auto'
     },
     content: {

--- a/client/src/pages/Repository/components/DetailsView/DetailsHeader.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsHeader.tsx
@@ -10,8 +10,8 @@ import { fade, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { DebounceInput } from 'react-debounce-input';
 import { Helmet } from 'react-helmet';
-import { BreadcrumbsView } from '../../../../components';
-import { GetSystemObjectDetailsResult, RepositoryPath } from '../../../../types/graphql';
+import { NavTrailBreadcrumbs } from '../../../../components';
+import { GetSystemObjectDetailsResult } from '../../../../types/graphql';
 import { eSystemObjectType } from '@dpo-packrat/common';
 import { getTermForSystemObjectType, isFieldUpdated } from '../../../../utils/repository';
 
@@ -36,14 +36,13 @@ const useStyles = makeStyles(({ palette }) => ({
 interface DetailsHeaderProps {
     originalFields: GetSystemObjectDetailsResult;
     objectType: eSystemObjectType;
-    path: RepositoryPath[][];
     name?: string | null;
     disabled: boolean;
     onNameUpdate: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 function DetailsHeader(props: DetailsHeaderProps): React.ReactElement {
-    const { objectType, path, name, onNameUpdate, disabled, originalFields } = props;
+    const { objectType, name, onNameUpdate, disabled, originalFields } = props;
     const updated: boolean = isFieldUpdated({ name }, originalFields, 'name');
 
     const classes = useStyles(updated);
@@ -63,7 +62,7 @@ function DetailsHeader(props: DetailsHeaderProps): React.ReactElement {
                 <DebounceInput title='object name' element='input' disabled={disabled} value={name || ''} className={classes.name} name='name' onChange={onNameUpdate} debounceTimeout={400} />
             </Box>
             <Box display='flex' flex={3} justifyContent='flex-end'>
-                {!!path.length && <BreadcrumbsView highlighted items={path} />}
+                <NavTrailBreadcrumbs />
             </Box>
         </Box>
     );

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
@@ -177,7 +177,7 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
             if(key==='published') {
                 publishedNotes = row.notes;
                 if(objectData.publishedUrl && objectData.publishedUrl.length>0)
-                    publishedNotes += ` (<a href='${objectData.publishedUrl}'><b>Link</b></a>)`;
+                    publishedNotes += ` (<a href='${objectData.publishedUrl}' target='_blank' rel='noopener noreferrer'><b>Link</b></a>)`;
             }
 
             return {

--- a/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
@@ -326,7 +326,7 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
                                     <Typography className={classes.value}>{licenseList.find(lic => lic.idLicense === license)?.Name}</Typography>
                                 </Box>
                                 <Typography className={classes.value}>{' inherited from '}</Typography>
-                                <NewTabLink className={classes.link} to={`/repository/details/${licenseSource.idSystemObject}`} target='_blank'>
+                                <NewTabLink className={classes.link} to={`/repository/details/${licenseSource.idSystemObject}`}>
                                     <Typography>{`${getTermForSystemObjectType(licenseSource.objectType)} ${licenseSource.name}`}</Typography>
                                 </NewTabLink>
                                 &nbsp;<Tooltip arrow title={ <ToolTip text={licenseNotes} />}><HelpOutline fontSize='small' style={{ alignSelf: 'center', cursor: 'pointer' }} /></Tooltip>

--- a/client/src/pages/Repository/components/DetailsView/VoyagerStoryView.tsx
+++ b/client/src/pages/Repository/components/DetailsView/VoyagerStoryView.tsx
@@ -81,8 +81,7 @@ function VoyagerStoryView(): React.ReactElement {
     }
 
     const {
-        objectType,
-        objectAncestors
+        objectType
     } = data.getSystemObjectDetails;
 
     // console.log(`VoyagerStoryView component (root: ${root} | document: ${document} | params: ${JSON.stringify(params)} | location: ${JSON.stringify(location)}})`);
@@ -95,7 +94,6 @@ function VoyagerStoryView(): React.ReactElement {
                     name={objectName}
                     disabled
                     objectType={objectType}
-                    path={objectAncestors}
                     onNameUpdate={() => {}}
                 />
 

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -33,7 +33,8 @@ import { useParams } from 'react-router';
 import { toast } from 'react-toastify';
 import { LoadingButton } from '../../../../components';
 import IdentifierList from '../../../../components/shared/IdentifierList';
-import { useUploadStore, useVocabularyStore, useRepositoryStore, useIdentifierStore, useDetailTabStore, ModelDetailsType, SceneDetailsType, useObjectMetadataStore, eObjectMetadataType, useUserStore, useDetailsEditStore } from '../../../../store';
+import { useUploadStore, useVocabularyStore, useRepositoryStore, useIdentifierStore, useDetailTabStore, ModelDetailsType, SceneDetailsType, useObjectMetadataStore, eObjectMetadataType, useUserStore, useDetailsEditStore, useNavHistoryStore } from '../../../../store';
+import { getDetailsUrlForObject } from '../../../../utils/repository';
 import {
     ActorDetailFieldsInput,
     AssetDetailFieldsInput,
@@ -198,6 +199,19 @@ function DetailsEditGuard({ dirty }: { dirty: boolean }): null {
             setDetailsDirty(false);
         };
     }, [setDetailsDirty]);
+
+    return null;
+}
+
+// Records the current object into the navigation-history trail (the "how you got
+// here" path shown as breadcrumbs). Keyed on the object id so each hop reconciles
+// the trail (append, or truncate-to-visited on Back/forward).
+function NavTrailRecorder({ idSystemObject, objectType, name }: { idSystemObject: number; objectType: number; name: string }): null {
+    const visit = useNavHistoryStore(state => state.visit);
+
+    useEffect(() => {
+        visit({ idSystemObject, objectType, name, url: getDetailsUrlForObject(idSystemObject) });
+    }, [idSystemObject, objectType, name, visit]);
 
     return null;
 }
@@ -1022,6 +1036,7 @@ function DetailsView(): React.ReactElement {
                     />
                 )}
                 <DetailsEditGuard dirty={hasAnyUnsaved} />
+                <NavTrailRecorder idSystemObject={idSystemObject} objectType={objectType} name={detailsResponse.name ?? ''} />
                 {hasAnyUnsaved && (
                     <Box className={classes.unsavedNotice}>
                         Unsaved changes — press <strong>Update</strong> to apply.
@@ -1033,7 +1048,6 @@ function DetailsView(): React.ReactElement {
                     name={details.name}
                     disabled={disabled || immutableNameTypes.has(objectType)}
                     objectType={objectType}
-                    path={objectAncestors}
                     onNameUpdate={onNameUpdate}
                 />
 

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -73,8 +73,12 @@ const useStyles = makeStyles(({ palette, breakpoints }) => ({
     container: {
         display: 'flex',
         flex: 1,
-        width: 'fit-content',
+        minHeight: 0,
+        width: '100%',
+        maxWidth: '100%',
+        boxSizing: 'border-box',
         flexDirection: 'column',
+        overflow: 'auto',
         padding: 20,
         paddingBottom: 0,
         paddingRight: 0,
@@ -84,12 +88,12 @@ const useStyles = makeStyles(({ palette, breakpoints }) => ({
     },
     content: {
         display: 'flex',
-        flex: 1,
+        flexShrink: 0,
+        boxSizing: 'border-box',
         flexDirection: 'column',
         padding: 20,
         marginBottom: 20,
         borderRadius: 10,
-        overflowY: 'auto',
         backgroundColor: palette.primary.light,
         [breakpoints.down('lg')]: {
             padding: 10
@@ -1216,7 +1220,7 @@ function DetailsView(): React.ReactElement {
                 )}
                 {(uploadReferences && uploadReferences.idSOAttachment) && <SpecialUploadList uploadType={eIngestionMode.eAttach} onUploaderClose={onUploaderReset} idSOAttachment={uploadReferences?.idSOAttachment} idSO={idSystemObject} />}
 
-                <Box display='flex' flex={1} padding={2}>
+                <Box display='flex' padding={2}>
                     <DetailsThumbnail
                         thumbnail={thumbnail}
                         idSystemObject={idSystemObject}

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -33,7 +33,7 @@ import { useParams } from 'react-router';
 import { toast } from 'react-toastify';
 import { LoadingButton } from '../../../../components';
 import IdentifierList from '../../../../components/shared/IdentifierList';
-import { useUploadStore, useVocabularyStore, useRepositoryStore, useIdentifierStore, useDetailTabStore, ModelDetailsType, SceneDetailsType, useObjectMetadataStore, eObjectMetadataType, useUserStore } from '../../../../store';
+import { useUploadStore, useVocabularyStore, useRepositoryStore, useIdentifierStore, useDetailTabStore, ModelDetailsType, SceneDetailsType, useObjectMetadataStore, eObjectMetadataType, useUserStore, useDetailsEditStore } from '../../../../store';
 import {
     ActorDetailFieldsInput,
     AssetDetailFieldsInput,
@@ -175,6 +175,33 @@ type SceneGeneParameters = {
     decimationPasses: number
 };
 
+// Publishes the details view's unsaved state to the shared store so navigation
+// guards (Header, side nav, internal links) can prompt before edits are lost,
+// and warns on hard reload/close via beforeunload while edits are pending.
+function DetailsEditGuard({ dirty }: { dirty: boolean }): null {
+    const setDetailsDirty = useDetailsEditStore(state => state.setDetailsDirty);
+
+    useEffect(() => {
+        setDetailsDirty(dirty);
+    }, [dirty, setDetailsDirty]);
+
+    useEffect(() => {
+        const handler = (event: BeforeUnloadEvent): void => {
+            if (useDetailsEditStore.getState().isDetailsDirty) {
+                event.preventDefault();
+                event.returnValue = '';
+            }
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => {
+            window.removeEventListener('beforeunload', handler);
+            setDetailsDirty(false);
+        };
+    }, [setDetailsDirty]);
+
+    return null;
+}
+
 function DetailsView(): React.ReactElement {
     const classes = useStyles();
     const params = useParams<DetailsParams>();
@@ -238,9 +265,19 @@ function DetailsView(): React.ReactElement {
         state.getDetail,
         state.getDetailsViewFieldErrors
     ]);
-    const hasUnsavedDetails = useDetailTabStore(s => s.hasUnsavedDetails);
+    const [hasUnsavedDetails, setHasUnsavedDetails] = useDetailTabStore(s => [s.hasUnsavedDetails, s.setHasUnsavedDetails]);
     const [getAllMetadataEntries, areMetadataUpdated, metadataControl, metadataDisplay, validateMetadataFields, initializeMetadata, resetMetadata] = useObjectMetadataStore(state => [state.getAllMetadataEntries, state.areMetadataUpdated, state.metadataControl, state.metadataDisplay, state.validateMetadataFields, state.initializeMetadata, state.resetMetadata]);
     const [resetSpecialPending] = useUploadStore(state => [state.resetSpecialPending]);
+
+    // The shared unsaved-details flag lives in a single global store slot set by the
+    // active detail tab, so it can leak from one object to the next when a tab unmounts
+    // without clearing it (e.g. after browser Back, which the leave guard cannot
+    // intercept). Reset it whenever the viewed object changes so a freshly-loaded object
+    // starts clean; the mounted tab re-asserts it only on a real edit.
+    useEffect(() => {
+        setHasUnsavedDetails(false);
+        return () => setHasUnsavedDetails(false);
+    }, [idSystemObject, setHasUnsavedDetails]);
 
     const objectDetailsData = data;
     const fetchDetailTabDataAndSetState = async () => {
@@ -984,6 +1021,7 @@ function DetailsView(): React.ReactElement {
                         messageText={notice.messageText}
                     />
                 )}
+                <DetailsEditGuard dirty={hasAnyUnsaved} />
                 {hasAnyUnsaved && (
                     <Box className={classes.unsavedNotice}>
                         Unsaved changes — press <strong>Update</strong> to apply.

--- a/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
@@ -13,6 +13,7 @@ import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import { FiLink2 } from 'react-icons/fi';
 import { IoIosRemoveCircle } from 'react-icons/io';
 import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
 import { Loader } from '../../../../components';
 import { useRepositoryStore, useVocabularyStore } from '../../../../store';
 import { Colors, palette } from '../../../../theme';
@@ -119,6 +120,7 @@ function RepositoryFilterView(): React.ReactElement {
     const [units, projects, has, missing, captureMethod, variantType, modelPurpose, modelFileType, dateCreatedFrom, dateCreatedTo, isExpanded, repositoryBrowserRootObjectType, repositoryBrowserRootName, repositoryRootType] = useRepositoryStore(state => [state.units, state.projects, state.has, state.missing, state.captureMethod, state.variantType, state.modelPurpose, state.modelFileType, state.dateCreatedFrom, state.dateCreatedTo, state.isExpanded, state.repositoryBrowserRootObjectType, state.repositoryBrowserRootName, state.repositoryRootType]);
     const [toggleFilter, removeChipOption, initializeFilterPosition] = useRepositoryStore(state => [state.toggleFilter, state.removeChipOption, state.initializeFilterPosition]);
     const [getEntries, getVocabularyTerm] = useVocabularyStore(state => [state.getEntries, state.getVocabularyTerm]);
+    const navigate = useNavigate();
     const classes = useStyles(isExpanded);
     const { href: url } = window.location;
     let isModal: boolean = false;
@@ -213,8 +215,18 @@ function RepositoryFilterView(): React.ReactElement {
                     const { id, type, name } = chip;
                     const label: string = `${getTermForRepositoryFilterType(type)}: ${name}`;
 
-                    const onClick = () => {
-                        window.open(getDetailsUrlForObject(id), '_blank');
+                    const url = getDetailsUrlForObject(id);
+                    const onClick = (e: React.MouseEvent) => {
+                        // modifier-click opens the object in a new tab; a plain click navigates in the same tab
+                        if (e.ctrlKey || e.metaKey)
+                            window.open(url, '_blank');
+                        else
+                            navigate(url);
+                    };
+                    const onAuxClick = (e: React.MouseEvent) => {
+                        // middle-click opens the object in a new tab
+                        if (e.button === 1)
+                            window.open(url, '_blank');
                     };
 
                     // if it's not a project or unit (i.e. no idSystemObject), we don't want the link to work
@@ -226,6 +238,7 @@ function RepositoryFilterView(): React.ReactElement {
                             deleteIcon={<IoIosRemoveCircle color={palette.primary.contrastText} />}
                             className={classes.chip}
                             onClick={onClick}
+                            onAuxClick={onAuxClick}
                             onDelete={() => removeChipOption(id, type, isModal)}
                             variant='outlined'
                         />

--- a/client/src/pages/Repository/components/RepositoryTreeView/TreeLabel.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/TreeLabel.tsx
@@ -12,6 +12,7 @@ import lodash from 'lodash';
 import React, { useMemo, useState, useEffect } from 'react';
 import { FaCheckCircle, FaRegCircle } from 'react-icons/fa';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
+import { useNavigate } from 'react-router-dom';
 import { palette } from '../../../../theme';
 import { getDetailsUrlForObject, getTermForSystemObjectType } from '../../../../utils/repository';
 import MetadataView, { TreeViewColumn } from './MetadataView';
@@ -35,19 +36,33 @@ function TreeLabel(props: TreeLabelProps): React.ReactElement {
     const { idSystemObject, label, treeColumns, renderSelected = false, selected = false, onSelect, onUnSelect, objectType, makeStyles, color, nodeId } = props;
     const [waitTime, setWaitTime] = useState<NodeJS.Timeout[]>([]);
     const objectTitle = useMemo(() => `${getTermForSystemObjectType(objectType)} ${label}`, [objectType, label]);
+    const navigate = useNavigate();
     const WAIT_INTERVAL_MS = 200;
     const onClick = async (e) => {
         e.stopPropagation();
-        // if there's already a click, that means we want to stop the timeout for that and just open a new tab
-        // otherwise just set a timer that'll expand the node in 200 ms
+        const url = getDetailsUrlForObject(idSystemObject);
+        // modifier-click opens the object in a new tab, like an anchor would
+        if (e.ctrlKey || e.metaKey) {
+            window.open(url, '_blank')?.focus();
+            return;
+        }
+        // second click within the interval opens the object in the same tab;
+        // a lone click starts a timer that expands the node in 200 ms
         if (waitTime.length) {
             clearTimeout(waitTime[0]);
             setWaitTime([]);
-            window.open(getDetailsUrlForObject(idSystemObject), '_blank')?.focus();
+            navigate(url);
             return;
         } else {
             const timer = setTimeout(() => { const target = document.getElementById(nodeId)?.firstChild as HTMLElement; target?.click(); }, WAIT_INTERVAL_MS);
             setWaitTime([timer]);
+        }
+    };
+    const onAuxClick = (e) => {
+        // middle-click opens the object in a new tab
+        if (e.button === 1) {
+            e.stopPropagation();
+            window.open(getDetailsUrlForObject(idSystemObject), '_blank')?.focus();
         }
     };
 
@@ -71,7 +86,7 @@ function TreeLabel(props: TreeLabelProps): React.ReactElement {
                         </Box>
                     )}
                     <div className={makeStyles?.labelText} style={{ backgroundColor: color }}>
-                        <span title={objectTitle} onClick={onClick}>{label}</span>
+                        <span title={objectTitle} onClick={onClick} onAuxClick={onAuxClick}>{label}</span>
                     </div>
                 </div>
                 <MetadataView header={false} treeColumns={treeColumns} makeStyles={{ text: makeStyles?.text || '', column: makeStyles?.column || '' }} />

--- a/client/src/pages/Repository/index.tsx
+++ b/client/src/pages/Repository/index.tsx
@@ -25,8 +25,9 @@ const useStyles = makeStyles(({ breakpoints }) => ({
     container: {
         display: 'flex',
         flex: 1,
-        width: 'fit-content',
+        width: '100%',
         maxWidth: '100%',
+        boxSizing: 'border-box',
         flexDirection: 'column',
         padding: 20,
         paddingBottom: 0,
@@ -34,8 +35,9 @@ const useStyles = makeStyles(({ breakpoints }) => ({
         [breakpoints.down('lg')]: {
             paddingRight: 20
         },
-        height: 'calc(100vh - 80px - var(--status-banner-height, 0px))',
-        overflowY: 'auto'
+        height: '100%',
+        minHeight: 0,
+        overflow: 'auto'
     }
 }));
 

--- a/client/src/pages/Repository/index.tsx
+++ b/client/src/pages/Repository/index.tsx
@@ -11,8 +11,8 @@ import { Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect } from 'react';
 import { useLocation, useParams, Route, Routes } from 'react-router';
-import { REPOSITORY_ROUTE, resolveRoute } from '../../constants';
-import { useControlStore, useRepositoryStore } from '../../store';
+import { REPOSITORY_ROUTE, resolveRoute, HOME_ROUTES } from '../../constants';
+import { useControlStore, useRepositoryStore, useNavHistoryStore, NAV_ROOT_ID } from '../../store';
 import { eMetadata, eSystemObjectType } from '@dpo-packrat/common';
 import { generateRepositoryUrl, parseRepositoryUrl } from '../../utils/repository';
 import DetailsView from './components/DetailsView';
@@ -80,6 +80,13 @@ function Repository(): React.ReactElement {
 function TreeViewPage(): React.ReactElement {
     const sideBarExpanded = useControlStore(state => state.sideBarExpanded);
     const classes = useStyles(sideBarExpanded);
+    const seedRoot = useNavHistoryStore(state => state.seedRoot);
+
+    // Entering the tree root starts a fresh navigation trail seeded with a
+    // "Repository" crumb, so drilling into objects reads as "Repository › … › here".
+    useEffect(() => {
+        seedRoot({ idSystemObject: NAV_ROOT_ID, objectType: 0, name: 'Repository', label: 'Repository', url: resolveRoute(HOME_ROUTES.REPOSITORY) });
+    }, [seedRoot]);
 
     const location = useLocation();
     const {

--- a/client/src/store/detailsEdit.ts
+++ b/client/src/store/detailsEdit.ts
@@ -1,0 +1,25 @@
+/**
+ * Details Edit Store
+ *
+ * Tracks whether the repository details view has unsaved edits, so navigation
+ * away from it can prompt before the changes are lost.
+ */
+import create, { SetState } from 'zustand';
+
+type DetailsEditStore = {
+    isDetailsDirty: boolean;
+    setDetailsDirty: (isDetailsDirty: boolean) => void;
+};
+
+export const useDetailsEditStore = create<DetailsEditStore>((set: SetState<DetailsEditStore>) => ({
+    isDetailsDirty: false,
+    setDetailsDirty: (isDetailsDirty: boolean): void => set({ isDetailsDirty })
+}));
+
+// Returns true when it is safe to navigate away from a details view (no unsaved
+// edits, or the user confirmed leaving); false to stay. Mirrors confirmLeaveIngestion.
+export function confirmLeaveEdit(): boolean {
+    if (!useDetailsEditStore.getState().isDetailsDirty)
+        return true;
+    return window.confirm('You have unsaved changes. Are you sure you want to navigate away? Changes will be lost.');
+}

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -15,6 +15,7 @@ export * from './control';
 export * from './identifier';
 export * from './license';
 export * from './detailTab';
+export * from './detailsEdit';
 export * from './workflow';
 export * from './users';
 export * from './objectMetadata';

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -16,6 +16,7 @@ export * from './identifier';
 export * from './license';
 export * from './detailTab';
 export * from './detailsEdit';
+export * from './navHistory';
 export * from './workflow';
 export * from './users';
 export * from './objectMetadata';

--- a/client/src/store/navHistory.ts
+++ b/client/src/store/navHistory.ts
@@ -1,0 +1,89 @@
+/**
+ * Navigation History Store
+ *
+ * Records the trail of repository objects the user actually visited (a "how you
+ * got here" path), so the details header can show clickable breadcrumbs that step
+ * back the way the user came — distinct from an object's ancestry hierarchy.
+ *
+ * The trail is persisted to sessionStorage so a refresh keeps it, while a fresh
+ * tab starts empty (a new journey).
+ */
+import create, { SetState, GetState } from 'zustand';
+
+export type NavCrumb = {
+    idSystemObject: number;
+    objectType: number;
+    name: string;
+    url: string;
+    // When set, render this label verbatim instead of "<type> <name>" — used for the
+    // synthetic "Repository" root crumb, which has no real system object.
+    label?: string;
+};
+
+// Sentinel id for the synthetic repository-root crumb (real objects are positive).
+export const NAV_ROOT_ID = 0;
+
+const STORAGE_KEY = 'navTrail';
+const TRAIL_CAP = 8;
+
+function loadTrail(): NavCrumb[] {
+    try {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+function saveTrail(trail: NavCrumb[]): void {
+    try {
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(trail));
+    } catch {
+        // ignore storage failures (private mode / quota)
+    }
+}
+
+type NavHistoryStore = {
+    trail: NavCrumb[];
+    visit: (crumb: NavCrumb) => void;
+    seedRoot: (rootCrumb: NavCrumb) => void;
+    truncateTo: (index: number) => void;
+    reset: () => void;
+};
+
+export const useNavHistoryStore = create<NavHistoryStore>((set: SetState<NavHistoryStore>, get: GetState<NavHistoryStore>) => ({
+    trail: loadTrail(),
+    seedRoot: (rootCrumb: NavCrumb): void => {
+        // Entering the repository tree starts a fresh journey seeded with the root
+        // crumb, so subsequent object hops read as "Repository › … › here".
+        set({ trail: [rootCrumb] });
+        saveTrail([rootCrumb]);
+    },
+    visit: (crumb: NavCrumb): void => {
+        const trail = get().trail;
+        const existingIndex = trail.findIndex(c => c.idSystemObject === crumb.idSystemObject);
+        let next: NavCrumb[];
+        if (existingIndex >= 0) {
+            // already visited earlier: truncate back to it (keeps browser Back/forward in sync)
+            next = trail.slice(0, existingIndex + 1);
+            next[existingIndex] = crumb; // refresh name/type in case it changed since
+        } else {
+            next = [...trail, crumb];
+        }
+        if (next.length > TRAIL_CAP)
+            next = next.slice(next.length - TRAIL_CAP);
+        set({ trail: next });
+        saveTrail(next);
+    },
+    truncateTo: (index: number): void => {
+        const next = get().trail.slice(0, index + 1);
+        set({ trail: next });
+        saveTrail(next);
+    },
+    reset: (): void => {
+        set({ trail: [] });
+        saveTrail([]);
+    }
+}));

--- a/client/src/utils/repository.tsx
+++ b/client/src/utils/repository.tsx
@@ -227,8 +227,7 @@ export function getObjectInterfaceDetails(objectType: eSystemObjectType, variant
         <a
             href={getDetailsUrlForObject(idSystemObject)}
             onClick={event => event.stopPropagation()}
-            target='_blank'
-            rel='noopener noreferrer'
+            target='_self'
             aria-label={`link to view system object of id ${idSystemObject}`}
             style={{ textDecoration: 'none', color: 'black' }}
         >


### PR DESCRIPTION
* Unified page scrolling with persistent app shell.
* Pinned header and nav for steadier layouts.
* Removed brittle height-offset layout calculations.
* Details, tree, and notices now scroll cleanly.
* Added unsaved-edit guard across same-tab navigation.
* Same-tab navigation now prompts before losing changes.
* Ctrl/Cmd and middle-click still open new tabs.
* Added navigation-trail breadcrumbs based on visit history.
* Breadcrumbs now reflect actual navigation path.
* Clicking breadcrumbs returns and trims trail history.