### PR TITLE
DPO3DPKRT-1001/CI Install Hardening & Repository Pagination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.9.0
+          cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --network-timeout 600000
 
       - name: Install E2E dependencies
-        run: cd e2e && yarn install --frozen-lockfile && cd ..
+        run: cd e2e && yarn install --frozen-lockfile --network-timeout 600000 && cd ..
 
       - name: Check for lint errors
         run: yarn lint
@@ -71,6 +72,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.9.0
+          cache: 'yarn'
 
       # Disabled: ubuntu-latest already ships a modern git, and apt-add-repository
       # reaches api.launchpad.net which has been timing out from GitHub-hosted runners
@@ -80,11 +82,11 @@ jobs:
 
       # Install dependencies in CI mode
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --network-timeout 600000
 
       # Install E2E dependencies in CI mode
       - name: Install E2E dependencies
-        run: cd e2e && yarn install --frozen-lockfile && cd ..
+        run: cd e2e && yarn install --frozen-lockfile --network-timeout 600000 && cd ..
 
       # Run tests using test DB
       - name: Run Tests

--- a/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
@@ -11,7 +11,7 @@ import { makeStyles, createStyles } from '@material-ui/core/styles';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { TreeView } from '@material-ui/lab';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Loader } from '../../../../components';
 import { StateRelatedObject, treeRootKey, useControlStore, useRepositoryStore, useTreeColumnsStore, NavigationResultEntryState } from '../../../../store';
 import {
@@ -25,10 +25,11 @@ import {
 import RepositoryTreeHeader from './RepositoryTreeHeader';
 import StyledTreeItem from './StyledTreeItem';
 import TreeLabel, { TreeLabelEmpty, TreeLabelLoading } from './TreeLabel';
-import InViewTreeItem from './InViewTreeItem';
-import { repositoryRowCount } from '@dpo-packrat/common';
 
-const repositoryRowPrefetchThreshold = 75;
+// Root-level pagination: selectable page sizes, and the minimum number of root
+// objects at which the pager (with its size selector) is shown.
+const ROOT_PAGE_SIZE_OPTIONS = [10, 25, 100];
+const ROOT_PAGER_MIN_ITEMS = 10;
 
 const useStyles = makeStyles(({ breakpoints, palette }) => createStyles({
     container: {
@@ -56,7 +57,8 @@ const useStyles = makeStyles(({ breakpoints, palette }) => createStyles({
         width: '100%'
     },
     treeViewContainer: {
-        height: '100%',
+        flex: 1,
+        minHeight: 0,
         overflowY: 'auto',
         width: '100%',
         // Note: this is to help relocate the scrollbar to the left
@@ -137,6 +139,44 @@ const useStyles = makeStyles(({ breakpoints, palette }) => createStyles({
     link: {
         color: palette.primary.dark,
         textDecoration: 'none'
+    },
+    pager: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        padding: '6px 8px',
+        flexShrink: 0
+    },
+    pagerButton: {
+        cursor: 'pointer',
+        fontSize: '0.8em',
+        padding: '2px 10px',
+        borderRadius: 4,
+        border: `1px solid ${palette.primary.main}`,
+        backgroundColor: palette.background.paper,
+        color: palette.primary.dark,
+        '&:disabled': { opacity: 0.4, cursor: 'default' }
+    },
+    pagerLabel: {
+        fontSize: '0.8em',
+        color: palette.primary.dark
+    },
+    pagerInput: {
+        width: 48,
+        fontSize: '0.8em',
+        padding: '2px 4px',
+        borderRadius: 4,
+        border: `1px solid ${palette.primary.main}`
+    },
+    pagerSelect: {
+        fontSize: '0.8em',
+        padding: '2px 4px',
+        borderRadius: 4,
+        border: `1px solid ${palette.primary.main}`,
+        backgroundColor: palette.background.paper,
+        color: palette.primary.dark,
+        cursor: 'pointer'
     }
 }));
 
@@ -149,20 +189,34 @@ interface RepositoryTreeViewProps {
 
 function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement {
     const { isModal = false, selectedItems = [], onSelect, onUnSelect } = props;
-    const [tree, getChildren, deleteChildren, getMoreRoot, getMoreChildren, setExpandedCount, cursors] = useRepositoryStore(state => [
+    const [tree, getChildren, deleteChildren, setExpandedCount] = useRepositoryStore(state => [
         state.tree,
         state.getChildren,
         state.deleteChildren,
-        state.getMoreRoot,
-        state.getMoreChildren,
-        state.setExpandedCount,
-        state.cursors
+        state.setExpandedCount
+    ]);
+    const [rootPage, rootPageSize, rootTotal, setRootPage, setRootPageSize] = useRepositoryStore(state => [
+        state.rootPage,
+        state.rootPageSize,
+        state.rootTotal,
+        state.setRootPage,
+        state.setRootPageSize
     ]);
     const metadataColumns = useRepositoryStore(state => state.metadataToDisplay);
     const [initializeWidths, initializeOrder, columnOrder] = useTreeColumnsStore((state) => [state.initializeWidth, state.initializeOrder, state.order]);
     const [loading, isExpanded] = useRepositoryStore(useCallback(state => [state.loading, state.isExpanded], []));
     const sideBarExpanded = useControlStore(state => state.sideBarExpanded);
     const classes = useStyles({ isExpanded, sideBarExpanded, isModal });
+
+    const [jumpValue, setJumpValue] = useState('');
+    const totalRootPages = Math.max(1, Math.ceil(rootTotal / rootPageSize));
+    const showPager = !isModal && rootTotal > ROOT_PAGER_MIN_ITEMS;
+    const goToPage = (): void => {
+        const page = parseInt(jumpValue, 10);
+        if (!isNaN(page) && page >= 1 && page <= totalRootPages && page !== rootPage)
+            setRootPage(page);
+        setJumpValue('');
+    };
 
     useEffect(() => {
         initializeWidths();
@@ -185,10 +239,10 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
     );
 
     // recursive
-    const renderTree = (children: NavigationResultEntryState[] | undefined, isChild?: boolean, parentNodeId?: string) => {
+    const renderTree = (children: NavigationResultEntryState[] | undefined, _isChild?: boolean, parentNodeId?: string) => {
 
         if (!children) return null;
-        return children.map((child: NavigationResultEntryState, index: number) => {
+        const items = children.map((child: NavigationResultEntryState, index: number) => {
             const { idSystemObject, objectType, idObject, name, metadata, hierarchy } = child;
             let idSystemObjectParent: number = 0;
             if (parentNodeId) {
@@ -259,53 +313,6 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
             if (idSystemObject === -1)
                 return <TreeLabelLoading key={idSystemObject} />;
 
-            // non-root case for end of list
-            if ((index + 1 + repositoryRowPrefetchThreshold) % repositoryRowCount === 0 && index + 1 + repositoryRowPrefetchThreshold === children.length && isChild) {
-                return (
-                    <InViewTreeItem
-                        id={nodeId}
-                        key={idSystemObject}
-                        nodeId={nodeId}
-                        icon={icon}
-                        color={color}
-                        label={label}
-                        childNodesContent={childNodesContent}
-                        triggerOnce
-                        onView={async () => {
-                            if (parentNodeId) {
-                                const parentCursor = cursors.get(parentNodeId);
-                                if (parentCursor && parentCursor.length) {
-                                    await getMoreChildren(parentNodeId, parentCursor);
-                                }
-                            }
-                        }}
-                    />
-                );
-            }
-
-            // root case for end of list
-            if ((index + 1 + repositoryRowPrefetchThreshold) % repositoryRowCount === 0 && index + 1 + repositoryRowPrefetchThreshold === children.length) {
-                return (
-                    <InViewTreeItem
-                        id={nodeId}
-                        key={idSystemObject}
-                        nodeId={nodeId}
-                        icon={icon}
-                        color={color}
-                        label={label}
-                        childNodesContent={childNodesContent}
-                        triggerOnce
-                        onView={async () => {
-                            const rootCursor = cursors.get('root');
-                            if (rootCursor && rootCursor.length) {
-                                await getMoreRoot();
-                            }
-                        }}
-                    />
-                );
-            }
-
-            // base case
             return (
                 <StyledTreeItem
                     id={nodeId}
@@ -319,6 +326,8 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
                 </StyledTreeItem>
             );
         });
+
+        return items;
     };
 
     let content: React.ReactNode = <Loader maxWidth='85vw' minHeight='40vh' width='40vw' size={40} />;
@@ -339,6 +348,27 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
                         {renderTree(children)}
                     </TreeView>
                 </div>
+                {showPager && (
+                    <div className={classes.pager}>
+                        <button className={classes.pagerButton} disabled={rootPage <= 1} onClick={() => setRootPage(rootPage - 1)}>Prev</button>
+                        <span className={classes.pagerLabel}>{`Page ${rootPage} of ${totalRootPages}`}</span>
+                        <button className={classes.pagerButton} disabled={rootPage >= totalRootPages} onClick={() => setRootPage(rootPage + 1)}>Next</button>
+                        <input
+                            className={classes.pagerInput}
+                            type='number'
+                            min={1}
+                            max={totalRootPages}
+                            placeholder='Go to'
+                            value={jumpValue}
+                            onChange={(e) => setJumpValue(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === 'Enter') goToPage(); }}
+                            onBlur={goToPage}
+                        />
+                        <select className={classes.pagerSelect} value={rootPageSize} onChange={(e) => setRootPageSize(Number(e.target.value))}>
+                            {ROOT_PAGE_SIZE_OPTIONS.map(size => <option key={size} value={size}>{`${size} / page`}</option>)}
+                        </select>
+                    </div>
+                )}
             </>
         );
     }

--- a/client/src/pages/Repository/hooks/useRepository.ts
+++ b/client/src/pages/Repository/hooks/useRepository.ts
@@ -9,7 +9,7 @@ import { apolloClient } from '../../../graphql';
 import { GetObjectChildrenDocument, GetObjectChildrenQuery } from '../../../types/graphql';
 import { repositoryRowCount } from '@dpo-packrat/common';
 
-function getObjectChildrenForRoot(filter: RepositoryFilter, idSystemObjects: number[] = []): Promise<ApolloQueryResult<GetObjectChildrenQuery>> {
+function getObjectChildrenForRoot(filter: RepositoryFilter, idSystemObjects: number[] = [], start = 0, rows: number = repositoryRowCount): Promise<ApolloQueryResult<GetObjectChildrenQuery>> {
     return apolloClient.query({
         query: GetObjectChildrenDocument,
         fetchPolicy: 'network-only',
@@ -30,8 +30,9 @@ function getObjectChildrenForRoot(filter: RepositoryFilter, idSystemObjects: num
                 modelFileType: filter.modelFileType,
                 dateCreatedFrom: filter.dateCreatedFrom,
                 dateCreatedTo: filter.dateCreatedTo,
-                rows: repositoryRowCount,
-                cursorMark: filter.cursorMark ?? ''
+                rows,
+                cursorMark: filter.cursorMark ?? '',
+                start
             }
         }
     });
@@ -58,7 +59,7 @@ function getObjectChildren(idRoots: number[], filter: RepositoryFilter): Promise
                 modelFileType: filter.modelFileType,
                 dateCreatedFrom: filter.dateCreatedFrom,
                 dateCreatedTo: filter.dateCreatedTo,
-                rows: repositoryRowCount,
+                rows: 0, // load all children at once when a node is expanded (0 = all)
                 cursorMark: filter.cursorMark ?? ''
             }
         }

--- a/client/src/pages/Repository/index.tsx
+++ b/client/src/pages/Repository/index.tsx
@@ -59,6 +59,8 @@ export type RepositoryFilter = {
     dateCreatedTo?: Date | string | null;
     cursorMark?: string | null;
     idRoots?: number[] | null;
+    rootPage?: number;
+    rootPageSize?: number;
 };
 
 function DetailsViewKeyed(): React.ReactElement {
@@ -105,6 +107,8 @@ function TreeViewPage(): React.ReactElement {
         dateCreatedFrom,
         dateCreatedTo,
         idRoots,
+        rootPage,
+        rootPageSize,
         updateRepositoryFilter
     } = useRepositoryStore();
     const queries: RepositoryFilter = parseRepositoryUrl(location.search);
@@ -126,7 +130,9 @@ function TreeViewPage(): React.ReactElement {
             modelFileType: [],
             dateCreatedFrom: null,
             dateCreatedTo: null,
-            idRoots: null
+            idRoots: null,
+            rootPage: 1,
+            rootPageSize: 25
         })};path=/`;
     };
 
@@ -169,7 +175,9 @@ function TreeViewPage(): React.ReactElement {
         modelFileType,
         dateCreatedFrom,
         dateCreatedTo,
-        idRoots
+        idRoots,
+        rootPage,
+        rootPageSize
     };
     const route = generateRepositoryUrl(newRepositoryFilterState) || generateRepositoryUrl(cookieFilterSelections);
     if (route !== location.search) {

--- a/client/src/store/repository.ts
+++ b/client/src/store/repository.ts
@@ -21,20 +21,15 @@ export interface NavigationResultEntryState extends NavigationResultEntry {
     hierarchy?: string;
 }
 
-const loadingEntry: NavigationResultEntryState = {
-    idSystemObject: -1,
-    idObject: 0,
-    name: 'Loading...',
-    objectType: 1,
-    metadata: []
-};
-
 type RepositoryStore = {
     isExpanded: boolean;
     search: string;
     keyword: string;
     tree: Map<string, NavigationResultEntryState[]>;
     cursors: Map<string, string>;
+    rootPage: number;                         // 1-based page index of the top-level (root) objects
+    rootPageSize: number;                     // number of root objects per page (user-selectable)
+    rootTotal: number;                        // total count of root objects (Solr numFound) for pager math
     loading: boolean;
     expandedCount: number;
     updateSearch: (value: string) => void;
@@ -61,10 +56,10 @@ type RepositoryStore = {
     resetRepositoryFilter: (modifyCookie?: boolean, keepMetadata?: boolean) => void;
     resetKeywordSearch: () => void;
     initializeTree: () => Promise<void>;
-    getMoreRoot: () => Promise<void>;
+    setRootPage: (page: number) => Promise<void>;
+    setRootPageSize: (size: number) => Promise<void>;
     getChildren: (nodeId: string) => Promise<void>;
     deleteChildren: (nodeId: string) => Promise<void>;
-    getMoreChildren: (nodeId: string, cursorMark: string) => Promise<void>;
     updateRepositoryFilter: (filter: RepositoryFilter, isModal: boolean) => void;
     setCookieToState: () => void;
     setDefaultIngestionFilters: (systemObjectType: eSystemObjectType, idRoots: number[], displayOverride?: { repositoryRootType: eSystemObjectType[]; objectsToDisplay: eSystemObjectType[] }) => Promise<void>;
@@ -85,6 +80,9 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
     keyword: '',
     tree: new Map<string, NavigationResultEntryState[]>([[treeRootKey, []]]),
     cursors: new Map<string, string>(),
+    rootPage: 1,
+    rootPageSize: 25,
+    rootTotal: 0,
     loading: true,
     expandedCount: 0,
     repositoryRootType: [],
@@ -105,7 +103,8 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
     repositoryBrowserRootName: null,
     updateFilterValue: (name: string, value: number | number[] | Date | null, isModal: boolean): void => {
         const { initializeTree, setCookieToState, keyword } = get();
-        set({ [name]: value, loading: true, search: keyword });
+        // A filter change re-queries from the first page of roots.
+        set({ [name]: value, loading: true, search: keyword, rootPage: 1 });
         if (!isModal) setCookieToState();
 
         initializeTree();
@@ -119,12 +118,14 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
         set({ isExpanded: !isExpanded });
     },
     initializeTree: async (): Promise<void> => {
-        const { getFilterState, getChildrenForIngestion, idRoots } = get();
+        const { getFilterState, getChildrenForIngestion, idRoots, rootPage, rootPageSize } = get();
         const filter = getFilterState();
         if (idRoots && idRoots.length > 0) {
             getChildrenForIngestion(idRoots);
         } else {
-            const { data, error } = await getObjectChildrenForRoot(filter);
+            // Root level uses numbered offset pagination: load exactly one page of roots.
+            const start = (rootPage - 1) * rootPageSize;
+            const { data, error } = await getObjectChildrenForRoot(filter, [], start, rootPageSize);
             if (data && !error) {
                 const { getObjectChildren } = data;
                 if (getObjectChildren.success === false) {
@@ -132,47 +133,26 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
                     set({ loading: false });
                     return;
                 }
-                const { entries, cursorMark } = getObjectChildren;
-                const newCursors = new Map<string, string>();
-                if (cursorMark)
-                    newCursors.set(treeRootKey, cursorMark);
-                set({ cursors: newCursors });
+                const { entries, total } = getObjectChildren;
 
                 const updatedTree: Map<string, NavigationResultEntryState[]> = new Map();
                 updatedTree.set(treeRootKey, entries);
-                set({ tree: updatedTree, loading: false, expandedCount: 0 });
+                // Changing the root page resets the tree: drop prior pages' children and cursors.
+                set({ tree: updatedTree, cursors: new Map<string, string>(), rootTotal: total ?? 0, loading: false, expandedCount: 0 });
             }
         }
     },
-    getMoreRoot: async (): Promise<void> => {
-        const { tree, cursors, getFilterState } = get();
-        const filter = getFilterState();
-        const rootCursor = cursors.get(treeRootKey);
-
-        const treeCopy = new Map(tree);
-        const rootWithoutLoader = treeCopy.get(treeRootKey) ?? [];
-        const rootWithLoader = [...rootWithoutLoader, loadingEntry] as NavigationResultEntryState[];
-        treeCopy.set(treeRootKey, rootWithLoader);
-        set({ tree: treeCopy });
-
-        if (rootCursor) {
-            filter.cursorMark = rootCursor;
-        }
-        const { data, error } = await getObjectChildrenForRoot(filter);
-        if (data && !error) {
-            const { getObjectChildren } = data;
-            const { entries, cursorMark } = getObjectChildren;
-            const newCursors = new Map(cursors);
-            if (cursorMark && cursorMark !== rootCursor)
-                newCursors.set(treeRootKey, cursorMark);
-            else
-                newCursors.delete(treeRootKey);
-            set({ cursors: newCursors });
-
-            const updatedNode = rootWithoutLoader.concat(entries) as NavigationResultEntryState[];
-            treeCopy.set(treeRootKey, updatedNode);
-            set({ tree: treeCopy, loading: false });
-        }
+    setRootPage: async (page: number): Promise<void> => {
+        // Switching root pages tears down the current page (bounding mounted DOM) and loads the new one.
+        set({ rootPage: page, loading: true, tree: new Map<string, NavigationResultEntryState[]>([[treeRootKey, []]]), cursors: new Map<string, string>() });
+        get().setCookieToState();
+        await get().initializeTree();
+    },
+    setRootPageSize: async (size: number): Promise<void> => {
+        // Changing the page size restarts at page 1 with the new size and rebuilds the tree.
+        set({ rootPageSize: size, rootPage: 1, loading: true, tree: new Map<string, NavigationResultEntryState[]>([[treeRootKey, []]]), cursors: new Map<string, string>() });
+        get().setCookieToState();
+        await get().initializeTree();
     },
     getChildren: async (nodeId: string): Promise<void> => {
         const { tree, getFilterState, cursors } = get();
@@ -209,44 +189,6 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             updatedTree.delete(nodeId);
             // console.log('deleteChildren', updatedTree);
             set({ tree: updatedTree });
-        }
-    },
-    getMoreChildren: async (nodeId: string, cursorMark: string): Promise<void> => {
-        const { tree, cursors, getFilterState } = get();
-        const filter = getFilterState();
-        const { idSystemObject, hierarchy } = parseRepositoryTreeNodeId(nodeId);
-
-        const treeCopy = new Map(tree);
-        const nodeWithoutLoader = treeCopy.get(nodeId) ?? [];
-        const nodeWithLoader = [...nodeWithoutLoader, loadingEntry] as NavigationResultEntryState[];
-        treeCopy.set(nodeId, nodeWithLoader);
-        set({ tree: treeCopy });
-
-        if (cursorMark) filter.cursorMark = cursorMark;
-        const { data, error } = await getObjectChildren([idSystemObject], filter);
-        if (data && !error) {
-            const { getObjectChildren } = data;
-            const { entries, cursorMark } = getObjectChildren;
-
-            const uniqueEntries = entries.map((entry) => {
-                const entryCopy: NavigationResultEntryState = { ...entry };
-                entryCopy.hierarchy = (hierarchy ? hierarchy + '|' : '') + entryCopy.idSystemObject.toString();
-                return entryCopy;
-            });
-
-            const updatedNode = nodeWithoutLoader.concat(uniqueEntries) as NavigationResultEntryState[];
-            treeCopy.set(nodeId, updatedNode);
-
-            set({ tree: treeCopy });
-            if (cursorMark) {
-                const newCursors = cursors;
-                if (cursorMark !== cursors.get(nodeId)) {
-                    newCursors.set(nodeId, cursorMark);
-                } else {
-                    newCursors.delete(nodeId);
-                }
-                set({ cursors: newCursors });
-            }
         }
     },
     removeChipOption: (id: number, type: eRepositoryChipFilterType, isModal: boolean): void => {
@@ -318,7 +260,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
                 break;
             }
         }
-        set({ search: keyword, loading: true });
+        set({ search: keyword, loading: true, rootPage: 1 });
         if (!isModal) setCookieToState();
 
         initializeTree();
@@ -360,6 +302,8 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
                 // dateCreatedTo: filter.dateCreatedTo,
             };
             set(stateValues);
+            // Restore the page/size from a persisted URL/cookie state; a fresh filter (no page) starts at page 1.
+            set({ rootPage: filter.rootPage ?? 1, rootPageSize: filter.rootPageSize ?? get().rootPageSize });
 
             if (filter.idRoots && filter.idRoots.length > 0) {
                 const { data: { getSystemObjectDetails: { name, objectType } } } = await apolloClient.query({
@@ -397,7 +341,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             repositoryBrowserRootObjectType: null,
             repositoryBrowserRootName: null
         };
-        set({ ...stateValues, cursors: new Map<string, string>(), loading: true });
+        set({ ...stateValues, cursors: new Map<string, string>(), rootPage: 1, rootTotal: 0, loading: true });
         if (modifyCookie) {
             setCookieToState();
         }
@@ -445,7 +389,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
         };
     },
     setCookieToState: (): void => {
-        const { getFilterState } = get();
+        const { getFilterState, rootPage, rootPageSize } = get();
         const {
             repositoryRootType,
             objectsToDisplay,
@@ -476,7 +420,9 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             modelFileType,
             dateCreatedFrom,
             dateCreatedTo,
-            idRoots
+            idRoots,
+            rootPage,
+            rootPageSize
         };
         // 20 years
         document.cookie = `filterSelections=${JSON.stringify(currentFilterState)};path=/;max-age=630700000`;

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -853,6 +853,7 @@ export type GetObjectChildrenInput = {
   projects: Array<Scalars['Int']>;
   rows: Scalars['Int'];
   search: Scalars['String'];
+  start?: InputMaybe<Scalars['Int']>;
   units: Array<Scalars['Int']>;
   variantType: Array<Scalars['Int']>;
 };
@@ -864,6 +865,7 @@ export type GetObjectChildrenResult = {
   error?: Maybe<Scalars['String']>;
   metadataColumns: Array<Scalars['Int']>;
   success: Scalars['Boolean'];
+  total?: Maybe<Scalars['Int']>;
 };
 
 export type GetObjectsForItemInput = {
@@ -3152,7 +3154,7 @@ export type GetObjectChildrenQueryVariables = Exact<{
 }>;
 
 
-export type GetObjectChildrenQuery = { __typename?: 'Query', getObjectChildren: { __typename?: 'GetObjectChildrenResult', success: boolean, error?: string | null, metadataColumns: Array<number>, cursorMark?: string | null, entries: Array<{ __typename?: 'NavigationResultEntry', idSystemObject: number, name: string, objectType: number, idObject: number, metadata: Array<string> }> } };
+export type GetObjectChildrenQuery = { __typename?: 'Query', getObjectChildren: { __typename?: 'GetObjectChildrenResult', success: boolean, error?: string | null, metadataColumns: Array<number>, cursorMark?: string | null, total?: number | null, entries: Array<{ __typename?: 'NavigationResultEntry', idSystemObject: number, name: string, objectType: number, idObject: number, metadata: Array<string> }> } };
 
 export type GetIntermediaryFileQueryVariables = Exact<{
   input: GetIntermediaryFileInput;
@@ -5239,6 +5241,7 @@ export const GetObjectChildrenDocument = gql`
     }
     metadataColumns
     cursorMark
+    total
   }
 }
     `;

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -534,7 +534,7 @@ export enum eWorkflowListSortColumns {
 
 export const authenticationFailureMessage: string = 'GraphQL user is not authenticated';
 
-export const repositoryRowCount = 300;
+export const repositoryRowCount = 50;
 
 // Single source of truth mapping a file's extension to a coarse category, used to reason about which
 // asset type(s) an uploaded package is compatible with. This is intentionally separate from the

--- a/server/graphql/api/queries/repository/getObjectChildren.ts
+++ b/server/graphql/api/queries/repository/getObjectChildren.ts
@@ -14,6 +14,7 @@ const getObjectChildren = gql`
             }
             metadataColumns
             cursorMark
+            total
         }
     }
 `;

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -772,6 +772,7 @@ input GetObjectChildrenInput {
   projects: [Int!]!
   rows: Int!
   search: String!
+  start: Int
   units: [Int!]!
   variantType: [Int!]!
 }
@@ -782,6 +783,7 @@ type GetObjectChildrenResult {
   error: String
   metadataColumns: [Int!]!
   success: Boolean!
+  total: Int
 }
 
 input GetObjectsForItemInput {

--- a/server/graphql/schema/repository/queries.graphql
+++ b/server/graphql/schema/repository/queries.graphql
@@ -23,6 +23,7 @@ input GetObjectChildrenInput {
     dateCreatedTo: DateTime
     rows: Int!
     cursorMark: String!
+    start: Int
 }
 
 type NavigationResultEntry {
@@ -39,6 +40,7 @@ type GetObjectChildrenResult {
     entries: [NavigationResultEntry!]!
     metadataColumns: [Int!]!
     cursorMark: String
+    total: Int
 }
 
 type GetFilterViewDataResult {

--- a/server/graphql/schema/repository/resolvers/queries/getObjectChildren.ts
+++ b/server/graphql/schema/repository/resolvers/queries/getObjectChildren.ts
@@ -24,7 +24,8 @@ export default async function getObjectChildren(_: Parent, args: QueryGetObjectC
         dateCreatedFrom,
         dateCreatedTo,
         rows,
-        cursorMark
+        cursorMark,
+        start
     } = args.input;
     const navigation: INavigation | null = await NavigationFactory.getInstance();
 
@@ -57,7 +58,8 @@ export default async function getObjectChildren(_: Parent, args: QueryGetObjectC
         dateCreatedFrom: H.Helpers.safeDate(dateCreatedFrom),   // convert ISO representation to Date
         dateCreatedTo: H.Helpers.safeDate(dateCreatedTo),       // convert ISO representation to Date
         rows,
-        cursorMark
+        cursorMark,
+        start: start ?? undefined
     };
 
     // Enforce authorization on the filter

--- a/server/navigation/impl/NavigationSolr/NavigationSolr.ts
+++ b/server/navigation/impl/NavigationSolr/NavigationSolr.ts
@@ -77,7 +77,13 @@ export class NavigationSolr implements NAV.INavigation {
             SQ = SQ.q('*:*');
             SQ = SQ.sort({ CommonOTNumber: 'asc', CommonName: 'asc', id: 'asc' }); // sort by the object type enumeration, then by name, then by id (idSystemObject)
         }
-        SQ = SQ.cursorMark(filter.cursorMark ? filter.cursorMark : '*'); // c.f. https://lucene.apache.org/solr/guide/6_6/pagination-of-results.html#using-cursors
+        // Root-level queries (no idRoots) use numbered offset pagination; drill-down queries
+        // keep cursor pagination for the child "Load more". Solr forbids start and cursorMark
+        // in the same request, so apply exactly one.
+        if (filter.idRoots.length === 0)
+            SQ = SQ.start(filter.start && filter.start > 0 ? filter.start : 0);
+        else
+            SQ = SQ.cursorMark(filter.cursorMark ? filter.cursorMark : '*'); // c.f. https://lucene.apache.org/solr/guide/6_6/pagination-of-results.html#using-cursors
 
         // idRoots: number[];                      // idSystemObject[] of items for which we should get children; empty means get everything
         if (filter.idRoots.length > 0) {          // objectsToDisplay: COMMON.eSystemObjectType[];  // objects to display
@@ -148,6 +154,8 @@ export class NavigationSolr implements NAV.INavigation {
 
         if (filter.rows > 0)
             SQ = SQ.rows(filter.rows);
+        else
+            SQ = SQ.rows(1000000); // rows <= 0 means "all" (per the NavigationFilter contract); Solr needs an explicit upper bound
 
         RK.logDebug(RK.LogSection.eNAV,'compute search query success',undefined,H.Helpers.removeEmptyFields(filter),'Navigation.Solr');
         return SQ;
@@ -279,7 +287,7 @@ export class NavigationSolr implements NAV.INavigation {
 
         // LOG.info(`NavigationSolr.executeSolrQuery: ${JSON.stringify(queryResult.result)}`, LOG.LS.eNAV);
         RK.logInfo(RK.LogSection.eNAV,'execute search query success',undefined,{ numFound: queryResult.result.numFound, start: queryResult.result.start, docsCount: queryResult.result.docs.length, nextCursorMark: queryResult.nextCursorMark },'Navigation.Solr');
-        return { success: true, entries, metadataColumns: filter.metadataColumns, cursorMark };
+        return { success: true, entries, metadataColumns: filter.metadataColumns, cursorMark, total: queryResult.result.numFound };
     }
 
     private computeNavMetadata(doc: any, metadataColumns: COMMON.eMetadata[]): string[] {

--- a/server/navigation/interface/INavigation.ts
+++ b/server/navigation/interface/INavigation.ts
@@ -19,6 +19,7 @@ export type NavigationFilter = {
     dateCreatedTo: Date | null;             // Date Created filter
     rows: number;                           // max result row count; a value of 0 means "all"
     cursorMark: string;                     // a non-empty value indicates a cursor position through a set of result values, used to request the next set of values
+    start?: number;                         // offset (Solr start) for numbered root-level pagination; used instead of cursorMark for root-level queries (idRoots empty)
 };
 
 export type NavigationResultEntry = {
@@ -35,6 +36,7 @@ export type NavigationResult = {
     entries: NavigationResultEntry[];
     metadataColumns: COMMON.eMetadata[];
     cursorMark?: string | null;             // when provided, additional results are available by requesting another navigation, using this returned value for the NavigationFilter.cursorMark
+    total?: number | null;                  // total matching row count (Solr numFound), used to compute the number of numbered root pages
 };
 
 export type MetadataFilter = {

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -850,6 +850,7 @@ export type GetObjectChildrenInput = {
   projects: Array<Scalars['Int']>;
   rows: Scalars['Int'];
   search: Scalars['String'];
+  start?: InputMaybe<Scalars['Int']>;
   units: Array<Scalars['Int']>;
   variantType: Array<Scalars['Int']>;
 };
@@ -861,6 +862,7 @@ export type GetObjectChildrenResult = {
   error?: Maybe<Scalars['String']>;
   metadataColumns: Array<Scalars['Int']>;
   success: Scalars['Boolean'];
+  total?: Maybe<Scalars['Int']>;
 };
 
 export type GetObjectsForItemInput = {


### PR DESCRIPTION
* Enabled Yarn caching in both CI setup steps.
* Added longer network timeout to all installs.
* Added root pagination with page-size selector.
* Server pagination now returns offset and total.
* Root page and size persist in URL/cookie.
* Expanding nodes now loads all children once.
* Removed buggy auto-load and Load More logic.
* Fixed pager visibility and removed dead paging code.