### PR TITLE
DPO3DPKRT-907/Subject EDAN Publish Controls

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
@@ -105,6 +105,9 @@ interface ObjectDetailsProps {
     publishedEnum: number;
     publishable: boolean;
     isDraft?: boolean;
+    isAdmin?: boolean;
+    edanRecordUrl?: string | null;
+    edanUnitCode?: string | null;
     retired: boolean;
     hideRetired?: boolean;
     objectType?: number;
@@ -133,6 +136,9 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
         publishedEnum,
         publishable,
         isDraft,
+        isAdmin,
+        edanRecordUrl,
+        edanUnitCode,
         retired,
         hideRetired,
         objectType,
@@ -227,7 +233,6 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
     const onAPIOnly = async () => { onPublishWorker(ePublishedState.eAPIOnly, 'Publish as Public (Unlisted)'); };
     const onUnpublish = async () => { onPublishWorker(ePublishedState.eNotPublished, 'Unpublish'); };
     const onInternal = async () => { onPublishWorker(ePublishedState.eInternal, 'Publish as Internal'); };
-    const onSyncToEdan = async () => { onPublishWorker(ePublishedState.ePublished, 'Sync to Edan'); };
 
     const onPublishWorker = async (eState: number, action: string) => {
         setLoading(true);
@@ -306,15 +311,35 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
                 </>
             )}
             {(objectType === eSystemObjectType.eSubject) && (
-                <Detail
-                    label='Edan Sync State'
-                    valueComponent={
-                        <Box className={classes.inheritedLicense}>
-                            <Typography className={classes.value}>{publishedState}</Typography>
-                            &nbsp;<LoadingButton onClick={onSyncToEdan} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Sync to Edan</LoadingButton>
-                        </Box>
-                    }
-                />
+                <>
+                    <Divider className={classes.sectionDivider} />
+                    <Detail
+                        label='EDAN Publish State'
+                        valueComponent={
+                            <Box display='flex' flexDirection='column' width='100%'>
+                                <Box className={classes.inheritedLicense}>
+                                    <Typography className={classes.value}>{publishedState}</Typography>
+                                    &nbsp;<Tooltip arrow title={<ToolTip text={subjectPublishButtonNotes} />}><HelpOutline fontSize='small' style={{ alignSelf: 'center', cursor: 'pointer' }} /></Tooltip>
+                                </Box>
+                                <Box className={classes.inheritedLicense}>
+                                    <Typography className={classes.value}>
+                                        {edanRecordUrl
+                                            ? `Target EDAN record: ${edanRecordUrl}${edanUnitCode ? ` (${edanUnitCode})` : ''}`
+                                            : 'No EDAN Record ID — add one before publishing.'}
+                                    </Typography>
+                                </Box>
+                                {isAdmin && (
+                                    <Box className={classes.buttonRow}>
+                                        <LoadingButton onClick={onPublish} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Public</LoadingButton>
+                                        <LoadingButton onClick={onAPIOnly} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Public (Unlisted)</LoadingButton>
+                                        <LoadingButton onClick={onInternal} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Internal</LoadingButton>
+                                        {(publishedEnum !== ePublishedState.eNotPublished) && (<LoadingButton onClick={onUnpublish} className={classes.loadingBtn} loading={loading}>Unpublish</LoadingButton>)}
+                                    </Box>
+                                )}
+                            </Box>
+                        }
+                    />
+                </>
             )}
             {(objectType === eSystemObjectType.eScene) && <Divider className={classes.sectionDivider} />}
             {licenseSource ? (
@@ -459,6 +484,15 @@ Public (Unlisted): transmits the scene package to EDAN, but the record is not se
 Internal: transmits the scene package to EDAN, but access is restricted to users behind the Smithsonian firewall.
 .
 Unpublish: marks the EDAN package as inactive and not searchable.`;
+
+const subjectPublishButtonNotes =
+`Public: creates or updates this subject's EDANMDM record on EDAN and marks it searchable on si.edu.
+.
+Public (Unlisted): creates or updates the EDANMDM record but leaves it not searchable; it is reachable only via direct URL.
+.
+Internal: keeps the EDANMDM record inactive to the public (Smithsonian-internal only).
+.
+Unpublish: marks the EDANMDM record as inactive and not searchable. It is not deleted.`;
 
 export const scenePublishRequirementsNotes =
 `In order to publish a scene to EDAN, the following criteria must be met:

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -475,11 +475,16 @@ function DetailsView(): React.ReactElement {
         objectVersions,
         metadata,
         licenseInheritance = null,
+        edanRecordUrl,
+        edanUnitCode,
+        subjectUnitMismatch,
     } = data.getSystemObjectDetails;
-    const disabled: boolean = !allowed;
+
+    const isAdmin = user?.isAdmin ?? false;
+    // Editing a Subject is admin-only for the moment; non-admins get a read-only view.
+    const disabled: boolean = !allowed || (objectType === eSystemObjectType.eSubject && !isAdmin);
 
     // Hide retire checkbox for Subject, Unit, Project if user is not admin
-    const isAdmin = user?.isAdmin ?? false;
     const adminOnlyRetireTypes = [eSystemObjectType.eSubject, eSystemObjectType.eUnit, eSystemObjectType.eProject];
     const hideRetired = !isAdmin && adminOnlyRetireTypes.includes(objectType);
 
@@ -1032,6 +1037,13 @@ function DetailsView(): React.ReactElement {
                         messageText={notice.messageText}
                     />
                 )}
+                {isAdmin && subjectUnitMismatch && (
+                    <NoticeBanner
+                        state='warning'
+                        title='Editing outside your Unit'
+                        messageText='This Subject belongs to a Unit you are not assigned to. You can still edit it, but confirm this is intentional.'
+                    />
+                )}
                 <DetailsEditGuard dirty={hasAnyUnsaved} />
                 <NavTrailRecorder idSystemObject={idSystemObject} objectType={objectType} name={detailsResponse.name ?? ''} />
                 {hasAnyUnsaved && (
@@ -1060,6 +1072,9 @@ function DetailsView(): React.ReactElement {
                         publishedEnum={publishedEnum}
                         publishable={publishable}
                         isDraft={isDraft}
+                        isAdmin={isAdmin}
+                        edanRecordUrl={edanRecordUrl}
+                        edanUnitCode={edanUnitCode}
                         retired={withDefaultValueBoolean(details.retired, false)}
                         hideRetired={hideRetired}
                         objectType={objectType}

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -986,6 +986,9 @@ export type GetSystemObjectDetailsResult = {
   asset?: Maybe<RepositoryPath>;
   assetOwner?: Maybe<RepositoryPath>;
   derivedObjects: Array<RelatedObject>;
+  edanRecordId?: Maybe<Scalars['String']>;
+  edanRecordUrl?: Maybe<Scalars['String']>;
+  edanUnitCode?: Maybe<Scalars['String']>;
   idObject: Scalars['Int'];
   idSystemObject: Scalars['Int'];
   identifiers: Array<IngestIdentifier>;
@@ -1008,6 +1011,7 @@ export type GetSystemObjectDetailsResult = {
   sourceObjects: Array<RelatedObject>;
   subTitle?: Maybe<Scalars['String']>;
   subject?: Maybe<Array<RepositoryPath>>;
+  subjectUnitMismatch?: Maybe<Scalars['Boolean']>;
   thumbnail?: Maybe<Scalars['String']>;
   unit?: Maybe<Array<RepositoryPath>>;
 };
@@ -3220,7 +3224,7 @@ export type GetSystemObjectDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetSystemObjectDetailsQuery = { __typename?: 'Query', getSystemObjectDetails: { __typename?: 'GetSystemObjectDetailsResult', idSystemObject: number, idObject: number, name: string, subTitle?: string | null, retired: boolean, objectType: number, allowed: boolean, allowedReason?: string | null, publishedState: string, publishedEnum: number, publishable: boolean, isDraft: boolean, thumbnail?: string | null, licenseInheritance?: number | null, identifiers: Array<{ __typename?: 'IngestIdentifier', identifier: string, identifierType: number, idIdentifier: number }>, unit?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, project?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, subject?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, item?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, asset?: { __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number } | null, assetOwner?: { __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number } | null, objectAncestors: Array<Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }>>, sourceObjects: Array<{ __typename?: 'RelatedObject', idSystemObject: number, name: string, identifier?: string | null, objectType: number, retired: boolean, type?: string | null, variant?: string | null }>, derivedObjects: Array<{ __typename?: 'RelatedObject', idSystemObject: number, name: string, identifier?: string | null, objectType: number, retired: boolean, type?: string | null, variant?: string | null }>, objectVersions: Array<{ __typename?: 'SystemObjectVersion', idSystemObjectVersion: number, idSystemObject: number, PublishedState: number, DateCreated: any, Comment?: string | null, CommentLink?: string | null }>, metadata: Array<{ __typename?: 'Metadata', idMetadata: number, Name: string, ValueShort?: string | null, ValueExtended?: string | null, idAssetVersionValue?: number | null, idVMetadataSource?: number | null, Value?: string | null, Label?: string | null }>, license?: { __typename?: 'License', idLicense: number, Name: string, Description: string, RestrictLevel: number } | null, objectProperties: Array<{ __typename?: 'ObjectPropertyResult', propertyType: string, level: number, rationale: string, idContact?: number | null }> } };
+export type GetSystemObjectDetailsQuery = { __typename?: 'Query', getSystemObjectDetails: { __typename?: 'GetSystemObjectDetailsResult', idSystemObject: number, idObject: number, name: string, subTitle?: string | null, retired: boolean, objectType: number, allowed: boolean, allowedReason?: string | null, publishedState: string, publishedEnum: number, publishable: boolean, publishBlocker?: string | null, isDraft: boolean, edanRecordId?: string | null, edanRecordUrl?: string | null, edanUnitCode?: string | null, subjectUnitMismatch?: boolean | null, thumbnail?: string | null, licenseInheritance?: number | null, identifiers: Array<{ __typename?: 'IngestIdentifier', identifier: string, identifierType: number, idIdentifier: number }>, unit?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, project?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, subject?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, item?: Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }> | null, asset?: { __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number } | null, assetOwner?: { __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number } | null, objectAncestors: Array<Array<{ __typename?: 'RepositoryPath', idSystemObject: number, name: string, objectType: number }>>, sourceObjects: Array<{ __typename?: 'RelatedObject', idSystemObject: number, name: string, identifier?: string | null, objectType: number, retired: boolean, type?: string | null, variant?: string | null }>, derivedObjects: Array<{ __typename?: 'RelatedObject', idSystemObject: number, name: string, identifier?: string | null, objectType: number, retired: boolean, type?: string | null, variant?: string | null }>, objectVersions: Array<{ __typename?: 'SystemObjectVersion', idSystemObjectVersion: number, idSystemObject: number, PublishedState: number, DateCreated: any, Comment?: string | null, CommentLink?: string | null }>, metadata: Array<{ __typename?: 'Metadata', idMetadata: number, Name: string, ValueShort?: string | null, ValueExtended?: string | null, idAssetVersionValue?: number | null, idVMetadataSource?: number | null, Value?: string | null, Label?: string | null }>, license?: { __typename?: 'License', idLicense: number, Name: string, Description: string, RestrictLevel: number } | null, objectProperties: Array<{ __typename?: 'ObjectPropertyResult', propertyType: string, level: number, rationale: string, idContact?: number | null }> } };
 
 export type GetVersionsForAssetQueryVariables = Exact<{
   input: GetVersionsForAssetInput;
@@ -5853,7 +5857,12 @@ export const GetSystemObjectDetailsDocument = gql`
     publishedState
     publishedEnum
     publishable
+    publishBlocker
     isDraft
+    edanRecordId
+    edanRecordUrl
+    edanUnitCode
+    subjectUnitMismatch
     thumbnail
     identifiers {
       identifier

--- a/server/collections/impl/EdanCollection.ts
+++ b/server/collections/impl/EdanCollection.ts
@@ -199,7 +199,7 @@ export class EdanCollection implements COL.ICollection {
             }
             case COMMON.eSystemObjectType.eSubject: {
                 const PS: PublishSubject = new PublishSubject(idSystemObject);
-                return PS.publish(this);
+                return PS.publish(this, ePublishState);
             }
         }
         return { success: false, error: 'Unsupported object type for publishing' };

--- a/server/collections/impl/PublishSubject.ts
+++ b/server/collections/impl/PublishSubject.ts
@@ -5,6 +5,7 @@ import * as COL from '../../collections/interface/';
 import * as H from '../../utils/helpers';
 import * as COMMON from '@dpo-packrat/common';
 import { RecordKeeper as RK } from '../../records/recordKeeper';
+import { SubjectHelpers } from '../../utils/subjectHelpers';
 
 /** This class is used to create and update EDANMDM records, translating Packrat Subject data and metadata into the EdanMDMContent format required for EDANMDM records
  * TODO: pass data contextual data into response routine
@@ -31,7 +32,7 @@ export class PublishSubject {
         this.idSystemObject = idSystemObject;
     }
 
-    async publish(ICol: COL.ICollection): Promise<H.IOResults> {
+    async publish(ICol: COL.ICollection, ePublishedStateIntended: COMMON.ePublishedState = COMMON.ePublishedState.ePublished): Promise<H.IOResults> {
         let res: H.IOResults = await this.analyze();
         if (!res.success)
             return res;
@@ -40,17 +41,31 @@ export class PublishSubject {
         if (!res.success)
             return res;
 
-        this.edanRecord = await ICol.createEdanMDM(this.edanMDM, 0, true);
+        const { status, publicSearch } = PublishSubject.computeEdanSearchFlags(ePublishedStateIntended);
+        this.edanRecord = await ICol.createEdanMDM(this.edanMDM, status, publicSearch);
         if (!this.edanRecord) {
             RK.logError(RK.LogSection.eCOLL,'publish failed','cannot create EDAN MDM record',{ edanMDM: this.edanMDM },'Publish.Subject');
             return this.returnResults(false, 'Edan publishing failed');
         }
 
-        // update SystemObjectVersion.PublishedState
-        res = await this.updatePublishedState(COMMON.ePublishedState.ePublished);
+        // update SystemObjectVersion.PublishedState to the intended state
+        res = await this.updatePublishedState(ePublishedStateIntended);
         if (!res.success)
             return res;
         return this.returnResults(true);
+    }
+
+    /** Map a published state to EDANMDM search flags, mirroring PublishScene.computeEdanSearchFlags
+     * without the scene-only `downloads` flag (EDANMDM records have no download derivatives).
+     * "Unpublish" deactivates the record (status 1, not searchable); it does not delete it. */
+    private static computeEdanSearchFlags(eState: COMMON.ePublishedState): { status: number, publicSearch: boolean } {
+        switch (eState) {
+            case COMMON.ePublishedState.ePublished:     return { status: 0, publicSearch: true };
+            case COMMON.ePublishedState.eAPIOnly:       return { status: 0, publicSearch: false };
+            case COMMON.ePublishedState.eInternal:      return { status: 1, publicSearch: false };
+            case COMMON.ePublishedState.eNotPublished:  return { status: 1, publicSearch: false };
+            default:                                    return { status: 0, publicSearch: true };
+        }
     }
 
     private async analyze(): Promise<H.IOResults> {
@@ -119,6 +134,14 @@ export class PublishSubject {
             if (nonRepeating && values.length > 1)
                 RK.logError(RK.LogSection.eCOLL,'publish failed','encountered non-repeating element wih multiple value',{ metadataName, metadataList },'Publish.Subject');
         }
+
+        // Identity fields come from first-class sources, not metadata: record_ID from the EDAN
+        // Record ID Identifier, unit_code/data_source from the Subject's Unit. These override
+        // any 'record id'/'unit' metadata read above so a stale copy cannot mistarget the upsert.
+        const target = await SubjectHelpers.computeTargetRecord(this.idSystemObject);
+        this.edanMDM.descriptiveNonRepeating.record_ID = target.recordId;
+        this.edanMDM.descriptiveNonRepeating.unit_code = target.unitCode;
+        this.edanMDM.descriptiveNonRepeating.data_source = target.dataSource;
 
         if (!this.edanMDM.descriptiveNonRepeating.title.label)
             return this.returnResults(false, 'descriptiveNonRepeating.title.label missing');

--- a/server/graphql/api/queries/systemobject/getSystemObjectDetails.ts
+++ b/server/graphql/api/queries/systemobject/getSystemObjectDetails.ts
@@ -14,7 +14,12 @@ const getSystemObjectDetails = gql`
             publishedState
             publishedEnum
             publishable
+            publishBlocker
             isDraft
+            edanRecordId
+            edanRecordUrl
+            edanUnitCode
+            subjectUnitMismatch
             thumbnail
             identifiers {
                 identifier

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -893,6 +893,9 @@ type GetSystemObjectDetailsResult {
   asset: RepositoryPath
   assetOwner: RepositoryPath
   derivedObjects: [RelatedObject!]!
+  edanRecordId: String
+  edanRecordUrl: String
+  edanUnitCode: String
   idObject: Int!
   idSystemObject: Int!
   identifiers: [IngestIdentifier!]!
@@ -915,6 +918,7 @@ type GetSystemObjectDetailsResult {
   sourceObjects: [RelatedObject!]!
   subTitle: String
   subject: [RepositoryPath!]
+  subjectUnitMismatch: Boolean
   thumbnail: String
   unit: [RepositoryPath!]
 }

--- a/server/graphql/schema/systemobject/queries.graphql
+++ b/server/graphql/schema/systemobject/queries.graphql
@@ -184,6 +184,10 @@ type GetSystemObjectDetailsResult {
     publishable: Boolean!
     publishBlocker: String
     isDraft: Boolean!
+    edanRecordId: String
+    edanRecordUrl: String
+    edanUnitCode: String
+    subjectUnitMismatch: Boolean
     thumbnail: String
     identifiers: [IngestIdentifier!]!
     objectAncestors: [[RepositoryPath!]!]!

--- a/server/graphql/schema/systemobject/resolvers/mutations/deleteIdentifier.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/deleteIdentifier.ts
@@ -1,6 +1,8 @@
 import { DeleteIdentifierResult, MutationDeleteIdentifierArgs } from '../../../../../types/graphql';
 import { Parent } from '../../../../../types/resolvers';
 import * as DBAPI from '../../../../../db';
+import * as CACHE from '../../../../../cache';
+import * as COMMON from '@dpo-packrat/common';
 import { RecordKeeper as RK } from '../../../../../records/recordKeeper';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
@@ -18,6 +20,11 @@ export default async function deleteIdentifier(_: Parent, args: MutationDeleteId
     if (identifier.idSystemObject) {
         if (!ctx || !await Authorization.canAccessSystemObject(ctx, identifier.idSystemObject))
             return { success: false, message: AUTH_ERROR.ACCESS_DENIED };
+
+        // Editing a Subject's identifiers requires admin (for the moment), matching updateObjectDetails.
+        const oID = await CACHE.SystemObjectCache.getObjectFromSystem(identifier.idSystemObject);
+        if (oID?.eObjectType === COMMON.eSystemObjectType.eSubject && !ctx.isAdmin)
+            return { success: false, message: AUTH_ERROR.ADMIN_REQUIRED };
     }
 
     return withAuditTransaction(async () => {

--- a/server/graphql/schema/systemobject/resolvers/mutations/publish.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/publish.ts
@@ -2,6 +2,7 @@ import { PublishResult, MutationPublishArgs } from '../../../../../types/graphql
 import { Parent } from '../../../../../types/resolvers';
 import * as COL from '../../../../../collections/interface';
 import * as DBAPI from '../../../../../db';
+import * as CACHE from '../../../../../cache';
 import * as COMMON from '@dpo-packrat/common';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
@@ -18,6 +19,11 @@ export default async function publish(_: Parent, args: MutationPublishArgs): Pro
     const ctx = Authorization.getContext();
     if (!ctx || !await Authorization.canAccessSystemObject(ctx, idSystemObject))
         return { success: false, message: AUTH_ERROR.ACCESS_DENIED };
+
+    // Publishing a Subject requires admin (for the moment); Scene publishing is unchanged.
+    const oID = await CACHE.SystemObjectCache.getObjectFromSystem(idSystemObject);
+    if (oID?.eObjectType === COMMON.eSystemObjectType.eSubject && !ctx.isAdmin)
+        return { success: false, message: AUTH_ERROR.ADMIN_REQUIRED };
 
     // Capture the prior published state for the audit diff before the publish
     // call mutates SystemObjectVersion. Reads are cheap and the row may not

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
@@ -34,6 +34,10 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
     if (!ctx || !await Authorization.canAccessSystemObject(ctx, idSystemObject))
         return sendResult(false, 'update object details failed', AUTH_ERROR.ACCESS_DENIED);
 
+    // Editing a Subject requires admin (for the moment); Scene/other editing is unchanged.
+    if (objectType === COMMON.eSystemObjectType.eSubject && !ctx.isAdmin)
+        return sendResult(false, 'update object details failed', AUTH_ERROR.ADMIN_REQUIRED);
+
     // Capture-by-reference for handleSceneUpdates to fire post-commit for the
     // Scene case. Cook download generation/removal must NOT run inside the tx.
     let pendingSceneUpdate: PendingSceneUpdate | null = null;

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -13,6 +13,7 @@ import {
 import { Parent } from '../../../../../types/resolvers';
 import { RecordKeeper as RK } from '../../../../../records/recordKeeper';
 import { SceneHelpers } from '../../../../../utils/sceneHelpers';
+import { SubjectHelpers } from '../../../../../utils/subjectHelpers';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 
 type PublishedStateInfo = {
@@ -21,6 +22,10 @@ type PublishedStateInfo = {
     publishable: boolean;
     publishBlocker: string | null;
     isDraft: boolean;
+    edanRecordId: string | null;
+    edanRecordUrl: string | null;
+    edanUnitCode: string | null;
+    subjectUnitMismatch: boolean;
 };
 
 const UNKNOWN_NAME: string = '<UNKNOWN>';
@@ -126,6 +131,10 @@ export default async function getSystemObjectDetails(_: Parent, args: QueryGetSy
         publishable: publishedStateInfo.publishable,
         publishBlocker: publishedStateInfo.publishBlocker,
         isDraft: publishedStateInfo.isDraft,
+        edanRecordId: publishedStateInfo.edanRecordId,
+        edanRecordUrl: publishedStateInfo.edanRecordUrl,
+        edanUnitCode: publishedStateInfo.edanUnitCode,
+        subjectUnitMismatch: publishedStateInfo.subjectUnitMismatch,
         thumbnail: null,
         unit,
         project,
@@ -170,6 +179,10 @@ async function getPublishedState(idSystemObject: number, oID: DBAPI.ObjectIDAndT
 
     let publishable: boolean = false;
     let publishBlocker: string | null = null;
+    let edanRecordId: string | null = null;
+    let edanRecordUrl: string | null = null;
+    let edanUnitCode: string | null = null;
+    let subjectUnitMismatch: boolean = false;
     if (oID) {
         switch (oID.eObjectType) {
             case COMMON.eSystemObjectType.eScene: {
@@ -198,12 +211,35 @@ async function getPublishedState(idSystemObject: number, oID: DBAPI.ObjectIDAndT
                     RK.logError(RK.LogSection.eGQL,'get published state failed','unable to compute scene',{ idSystemObject, ...oID },'GraphQL.SystemObject.Details');
             } break;
 
-            case COMMON.eSystemObjectType.eSubject:
-                publishable = true;
-                break;
+            case COMMON.eSystemObjectType.eSubject: {
+                // The EDAN Record ID Identifier is the target record and a real publish blocker:
+                // no record id -> nothing to upsert.
+                const target = await SubjectHelpers.computeTargetRecord(idSystemObject);
+                edanRecordId = target.recordId || null;
+                edanRecordUrl = target.url || null;
+                edanUnitCode = target.unitCode || null;
+                if (target.recordId) {
+                    publishable = true;
+                } else {
+                    publishable = false;
+                    publishBlocker = 'No EDAN Record ID';
+                }
+
+                // Warn an admin editing a Subject in a Unit they are not directly assigned to.
+                // Admin context units are zeroed, so read the raw assignments.
+                const ctx = Authorization.getContext();
+                if (ctx?.isAdmin && oID.idObject) {
+                    const subjectDB: DBAPI.Subject | null = await DBAPI.Subject.fetch(oID.idObject);
+                    if (subjectDB) {
+                        const ownUnits: number[] = await DBAPI.UserAuthorization.fetchUnitsForUser(ctx.idUser);
+                        subjectUnitMismatch = !ownUnits.includes(subjectDB.idUnit);
+                    }
+                }
+            } break;
         }
     }
-    return { publishedState, publishedEnum, publishable, publishBlocker, isDraft };
+    return { publishedState, publishedEnum, publishable, publishBlocker, isDraft,
+        edanRecordId, edanRecordUrl, edanUnitCode, subjectUnitMismatch };
 }
 
 // Classifies a Model's display Type + Variant from the Model row alone. Purpose distinguishes

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -983,6 +983,9 @@ export type GetSystemObjectDetailsResult = {
   asset?: Maybe<RepositoryPath>;
   assetOwner?: Maybe<RepositoryPath>;
   derivedObjects: Array<RelatedObject>;
+  edanRecordId?: Maybe<Scalars['String']>;
+  edanRecordUrl?: Maybe<Scalars['String']>;
+  edanUnitCode?: Maybe<Scalars['String']>;
   idObject: Scalars['Int'];
   idSystemObject: Scalars['Int'];
   identifiers: Array<IngestIdentifier>;
@@ -1005,6 +1008,7 @@ export type GetSystemObjectDetailsResult = {
   sourceObjects: Array<RelatedObject>;
   subTitle?: Maybe<Scalars['String']>;
   subject?: Maybe<Array<RepositoryPath>>;
+  subjectUnitMismatch?: Maybe<Scalars['Boolean']>;
   thumbnail?: Maybe<Scalars['String']>;
   unit?: Maybe<Array<RepositoryPath>>;
 };

--- a/server/utils/subjectHelpers.ts
+++ b/server/utils/subjectHelpers.ts
@@ -1,0 +1,66 @@
+import * as DBAPI from '../db';
+import * as CACHE from '../cache';
+import * as COMMON from '@dpo-packrat/common';
+
+/** The EDAN record a Subject publish will create or overwrite: the record id from the
+ * Subject's EDAN Record ID Identifier, and the unit fields from the Subject's Unit. */
+export type SubjectTargetRecord = {
+    recordId: string;   // IdentifierValue of the EDAN Record ID Identifier, '' when absent
+    unitCode: string;   // Unit.Abbreviation
+    dataSource: string; // Unit.Name
+    url: string;        // edanmdm:<recordId>, '' when no recordId
+};
+
+export class SubjectHelpers {
+    private static idVocabEdanRecordID: number | null = null;
+
+    private static async resolveEdanRecordIDVocab(): Promise<number | null> {
+        if (SubjectHelpers.idVocabEdanRecordID === null) {
+            const vocab: DBAPI.Vocabulary | undefined =
+                await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eIdentifierIdentifierTypeEdanRecordID);
+            if (!vocab)
+                return null;
+            SubjectHelpers.idVocabEdanRecordID = vocab.idVocabulary;
+        }
+        return SubjectHelpers.idVocabEdanRecordID;
+    }
+
+    /** Single source of truth for the Subject's EDAN target record, shared by the publish
+     * path (PublishSubject) and the details query (getSystemObjectDetails). record_ID comes
+     * from the EDAN Record ID Identifier; unit_code/data_source from the Subject's Unit. */
+    static async computeTargetRecord(idSystemObject: number): Promise<SubjectTargetRecord> {
+        const empty: SubjectTargetRecord = { recordId: '', unitCode: '', dataSource: '', url: '' };
+
+        const oID: DBAPI.ObjectIDAndType | undefined = await CACHE.SystemObjectCache.getObjectFromSystem(idSystemObject);
+        if (!oID || oID.eObjectType !== COMMON.eSystemObjectType.eSubject || !oID.idObject)
+            return empty;
+
+        const subject: DBAPI.Subject | null = await DBAPI.Subject.fetch(oID.idObject);
+        if (!subject)
+            return empty;
+
+        let recordId: string = '';
+        const idVocab: number | null = await SubjectHelpers.resolveEdanRecordIDVocab();
+        if (idVocab !== null) {
+            const identifiers: DBAPI.Identifier[] | null = await DBAPI.Identifier.fetchFromSystemObject(idSystemObject);
+            if (identifiers) {
+                for (const ident of identifiers) {
+                    if (ident.idVIdentifierType === idVocab && ident.IdentifierValue) {
+                        recordId = ident.IdentifierValue;
+                        break;
+                    }
+                }
+            }
+        }
+
+        let unitCode: string = '';
+        let dataSource: string = '';
+        const unit: DBAPI.Unit | null = await DBAPI.Unit.fetch(subject.idUnit);
+        if (unit) {
+            unitCode = unit.Abbreviation ?? '';
+            dataSource = unit.Name ?? '';
+        }
+
+        return { recordId, unitCode, dataSource, url: recordId ? `edanmdm:${recordId}` : '' };
+    }
+}


### PR DESCRIPTION
* Added shared Subject EDAN target helper.
* Subject publish now supports all publish states.
* Subject EDAN uses Identifier and Unit source data.
* Details expose target record and unit mismatch.
* Subjects now block publish without EDAN Record ID.
* Added admin-only publish row on Subject page.
* Admins see out-of-unit advisory banner.
* Added Subject-specific publish help tooltip.
* Enforced server-side admin checks for Subject publishing.
* Retired legacy single Sync-to-EDAN button.