### PR TITLE
DPO3DPKRT-1017/QA Approval for Date-Flagged Derivatives

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
@@ -20,7 +20,7 @@ import {
     // Theme,
     createStyles
 } from '@material-ui/core';
-import { Edit, Sync } from '@material-ui/icons';
+import { Edit, Sync, CheckCircleOutline } from '@material-ui/icons';
 import { Alert } from '@material-ui/lab';
 import { makeStyles } from '@material-ui/core/styles';
 import API, { RequestResponse } from '../../../../../api';
@@ -95,6 +95,25 @@ const qcRowTooltips: Record<string, string> = {
     captureData: 'Source capture datasets (photogrammetry, CT, etc.) linked to this scene',
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mapSceneQCData = (d: any): SceneQCData => ({
+    idSystemObject: d.idSystemObject,
+    idScene: d.idScene,
+    publishedUrl: d.publishedUrl,
+    published: d.published,
+    license: d.license,
+    reviewed: d.reviewed,
+    scale: d.scale,
+    thumbnails: d.thumbnails,
+    baseModels: d.baseModels,
+    downloads: d.downloads,
+    arModels: d.arModels,
+    captureData: d.captureData,
+    edanRecordId: d.edanRecordId,
+    edanUUID: d.edanUUID,
+    edanRecordIdRaw: d.edanRecordIdRaw,
+});
+
 // Define styles
 const useStyles = makeStyles(() =>
     createStyles({
@@ -168,6 +187,13 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
     const [saving, setSaving] = useState<boolean>(false);
     const [saveError, setSaveError] = useState<string | null>(null);
 
+    // verify/approve dialog state (date-flagged AR + Downloads)
+    const [approveOpen, setApproveOpen] = useState<boolean>(false);
+    const [approveKind, setApproveKind] = useState<'ar' | 'downloads'>('ar');
+    const [approveReason, setApproveReason] = useState<string>('');
+    const [approveSaving, setApproveSaving] = useState<boolean>(false);
+    const [approveError, setApproveError] = useState<string | null>(null);
+
     const buildRows = useCallback((objectData: SceneQCData): QCRow[] => {
         return qcRowKeys.map((key) => {
             const row = objectData[key] as QCStatus;
@@ -196,23 +222,7 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
             try {
                 const response: RequestResponse = await API.getObjectDetailsStatus(props.idSceneSO);
 
-                const objectData: SceneQCData = {
-                    idSystemObject: response.data.idSystemObject,
-                    idScene: response.data.idScene,
-                    publishedUrl: response.data.publishedUrl,
-                    published: response.data.published,
-                    license: response.data.license,
-                    reviewed: response.data.reviewed,
-                    scale: response.data.scale,
-                    thumbnails: response.data.thumbnails,
-                    baseModels: response.data.baseModels,
-                    downloads: response.data.downloads,
-                    arModels: response.data.arModels,
-                    captureData: response.data.captureData,
-                    edanRecordId: response.data.edanRecordId,
-                    edanUUID: response.data.edanUUID,
-                    edanRecordIdRaw: response.data.edanRecordIdRaw,
-                };
+                const objectData: SceneQCData = mapSceneQCData(response.data);
                 setData(objectData);
                 setRows(buildRows(objectData));
             } catch (err) {
@@ -265,23 +275,7 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
 
             // re-fetch full status to rebuild all rows
             const statusResponse: RequestResponse = await API.getObjectDetailsStatus(props.idSceneSO);
-            const updatedData: SceneQCData = {
-                idSystemObject: statusResponse.data.idSystemObject,
-                idScene: statusResponse.data.idScene,
-                publishedUrl: statusResponse.data.publishedUrl,
-                published: statusResponse.data.published,
-                license: statusResponse.data.license,
-                reviewed: statusResponse.data.reviewed,
-                scale: statusResponse.data.scale,
-                thumbnails: statusResponse.data.thumbnails,
-                baseModels: statusResponse.data.baseModels,
-                downloads: statusResponse.data.downloads,
-                arModels: statusResponse.data.arModels,
-                captureData: statusResponse.data.captureData,
-                edanRecordId: statusResponse.data.edanRecordId,
-                edanUUID: statusResponse.data.edanUUID,
-                edanRecordIdRaw: statusResponse.data.edanRecordIdRaw,
-            };
+            const updatedData: SceneQCData = mapSceneQCData(statusResponse.data);
             setData(updatedData);
             setRows(buildRows(updatedData));
             setDialogOpen(false);
@@ -292,6 +286,47 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
             console.error(err);
         } finally {
             setSaving(false);
+        }
+    };
+
+    const handleOpenApprove = (kind: 'ar' | 'downloads') => {
+        setApproveKind(kind);
+        setApproveReason('');
+        setApproveError(null);
+        setApproveOpen(true);
+    };
+
+    const handleCancelApprove = () => {
+        setApproveOpen(false);
+        setApproveError(null);
+        setApproveReason('');
+    };
+
+    const handleApplyApprove = async () => {
+        if (!data) return;
+        setApproveSaving(true);
+        setApproveError(null);
+        try {
+            const field: string = approveKind === 'ar' ? 'approveARModels' : 'approveDownloadModels';
+            const patchResponse: RequestResponse = await API.patchObject(data.idSystemObject, { [field]: { reason: approveReason.trim() } });
+            if (!patchResponse.success) {
+                setApproveError(patchResponse.message ?? 'Failed to record approval');
+                return;
+            }
+
+            // re-fetch full status to rebuild all rows (server returns the row as "Verified")
+            const statusResponse: RequestResponse = await API.getObjectDetailsStatus(props.idSceneSO);
+            const updatedData: SceneQCData = mapSceneQCData(statusResponse.data);
+            setData(updatedData);
+            setRows(buildRows(updatedData));
+            setApproveOpen(false);
+            setApproveReason('');
+            props.onUpdate?.();
+        } catch (err) {
+            setApproveError('An unexpected error occurred');
+            console.error(err);
+        } finally {
+            setApproveSaving(false);
         }
     };
 
@@ -343,6 +378,13 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
                                         <Tooltip title='Edit EDAN Record ID'>
                                             <IconButton size='small' onClick={handleOpenDialog}>
                                                 <Edit fontSize='small' />
+                                            </IconButton>
+                                        </Tooltip>
+                                    )}
+                                    {(row.key === 'arModels' || row.key === 'downloads') && row.status === 'Outdated' && (
+                                        <Tooltip title='Verify / Approve'>
+                                            <IconButton size='small' onClick={() => handleOpenApprove(row.key === 'arModels' ? 'ar' : 'downloads')}>
+                                                <CheckCircleOutline fontSize='small' />
                                             </IconButton>
                                         </Tooltip>
                                     )}
@@ -402,6 +444,47 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
                         style={{ color: 'white' }}
                     >
                         {saving ? <CircularProgress size={20} /> : 'Apply'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog open={approveOpen} onClose={handleCancelApprove} maxWidth='sm' fullWidth>
+                <DialogTitle>Verify {approveKind === 'ar' ? 'AR Models' : 'Download Models'}</DialogTitle>
+                <DialogContent>
+                    <Typography variant='body2' style={{ marginBottom: 8 }}>
+                        These derivatives were generated before the 2024-06-14 Cook material fix, so
+                        Packrat flags them as possibly outdated. This is a <strong>date check</strong>,
+                        not a detected defect &mdash; the assets may be fine. Approving records a QA
+                        sign-off and clears the warning; it does not modify the assets.
+                    </Typography>
+                    <TextField
+                        variant='outlined'
+                        size='small'
+                        fullWidth
+                        multiline
+                        rows={2}
+                        label='Reason (optional)'
+                        placeholder='Optional note recorded with this approval'
+                        value={approveReason}
+                        onChange={(e) => setApproveReason(e.target.value)}
+                        disabled={approveSaving}
+                    />
+                    {approveError && (
+                        <Alert severity='error' style={{ marginTop: 8 }}>{approveError}</Alert>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCancelApprove} disabled={approveSaving}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleApplyApprove}
+                        color='primary'
+                        variant='contained'
+                        disabled={approveSaving}
+                        style={{ color: 'white' }}
+                    >
+                        {approveSaving ? <CircularProgress size={20} /> : 'Approve / Verify'}
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -223,6 +223,11 @@ export const Config: ConfigType = {
             [eAuditType.eActionAccessRevoke]:       AuditTier.PROTECT,
             [eAuditType.eActionUpload]:             AuditTier.PROTECT,
             [eAuditType.eActionIngestFailed]:       AuditTier.PROTECT,
+            // INVARIANT: any eAuditType read back via Audit.fetchLast* to reconstruct current UI
+            // state (e.g. QA sign-offs surfaced in the scene status table) MUST be PROTECT so the
+            // row is never pruned or skeletonized out from under the status calc.
+            [eAuditType.eActionApproveARModels]:       AuditTier.PROTECT,
+            [eAuditType.eActionApproveDownloadModels]: AuditTier.PROTECT,
             // TIER_STANDARD - CRUD on meaningful business entities (routed at the entity level via logOnlyObjectTypes)
             [eAuditType.eDBCreate]:                 AuditTier.STANDARD,
             [eAuditType.eDBUpdate]:                 AuditTier.STANDARD,

--- a/server/db/api/Audit.ts
+++ b/server/db/api/Audit.ts
@@ -334,4 +334,31 @@ export class Audit extends DBC.DBObject<AuditBase> implements AuditBase {
             return null;
         }
     }
+
+    /**
+     * Return the most recent approval row of the given action for a SystemObject,
+     * joined to the approver's name and stamped with the audit date. Sibling to
+     * fetchLastUser (which returns the User only) — used for DISPLAY (Verified by
+     * <name> on <date>). The honor decision for a QA approval is presence-only and
+     * does not consult AuditDate.
+     */
+    static async fetchLastApproval(idSystemObject: number, eAudit: eAuditType): Promise<{ idUser: number; Name: string; AuditDate: Date } | null> {
+        if (!idSystemObject || !eAudit)
+            return null;
+        try {
+            const rows: { idUser: number; Name: string; AuditDate: Date }[] =
+                await DBC.DBConnection.prisma.$queryRaw<{ idUser: number; Name: string; AuditDate: Date }[]>`
+                SELECT U.idUser, U.Name, AU.AuditDate
+                FROM Audit AS AU
+                JOIN User AS U ON (AU.idUser = U.idUser)
+                WHERE AU.AuditType = ${eAudit}
+                  AND AU.idSystemObject = ${idSystemObject}
+                ORDER BY AU.AuditDate DESC
+                LIMIT 1`;
+            return (rows && rows.length > 0) ? rows[0] : null;
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB,'fetch last approval failed',H.Helpers.getErrorString(error),{ idSystemObject, eAudit },'DB.Audit');
+            return null;
+        }
+    }
 }

--- a/server/db/api/ObjectType.ts
+++ b/server/db/api/ObjectType.ts
@@ -327,6 +327,8 @@ export enum eAuditType {
     eActionSystemMaintenance = 115,
     eActionUpload = 116,
     eActionIngestFailed = 117,
+    eActionApproveARModels = 118,
+    eActionApproveDownloadModels = 119,
 }
 
 export function LicenseRestrictLevelToPublishedStateEnum(restrictLevel: number): COMMON.ePublishedState {

--- a/server/http/routes/api/object.ts
+++ b/server/http/routes/api/object.ts
@@ -8,9 +8,10 @@ import { Request, Response } from 'express';
 import { Config, ENVIRONMENT_TYPE } from '../../../config';
 import { RecordKeeper as RK } from '../../../records/recordKeeper';
 import * as CACHE from '../../../cache';
-import { buildProjectSceneDef, SceneSummary } from './project';
+import { buildProjectSceneDef, SceneSummary, COOK_MATERIAL_FIX_DATE } from './project';
 import { SceneHelpers, EdanRecordIdResult } from '../../../utils/sceneHelpers';
 import { Authorization, AUTH_ERROR } from '../../../auth/Authorization';
+import { AuditFactory } from '../../../audit/interface/AuditFactory';
 
 //#region Types and Definitions
 
@@ -321,7 +322,11 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         else
             return { name, status: 'Error', level: 'fail', notes: `${count}/${expected} datasets found. unexpected relationships` };
     };
-    const getModelARStatus = (status: string, licenseAllows: boolean): FieldStatus => {
+    const formatApprovalDate = (d: Date): string => {
+        const date: Date = d instanceof Date ? d : new Date(String(d));
+        return isNaN(date.getTime()) ? String(d) : date.toISOString().slice(0, 10);
+    };
+    const getModelARStatus = async (status: string, licenseAllows: boolean): Promise<FieldStatus> => {
         const name = 'Models: AR';
 
         switch(status) {
@@ -334,8 +339,15 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
             case 'Missing: All':
                 return { name, status, level: (licenseAllows)?'fail':'warn', notes: 'no AR models found. Regenerate the scene and generate downloads' };
             default: {
-                if (status.startsWith('Error:'))
+                if (status.startsWith('Error:')) {
+                    // Date-driven Outdated flag. Presence of an approval audit row clears it to a
+                    // neutral "Verified" state — no date comparison, no asset mutation. Non-date
+                    // failures fall through and are never cleared.
+                    const approval = await DBAPI.Audit.fetchLastApproval(idSystemObject, DBAPI.eAuditType.eActionApproveARModels);
+                    if (approval)
+                        return { name, status: 'Verified', level: 'info', notes: `Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}` };
                     return { name, status: 'Outdated', level: 'warn', notes: `AR model may have material issues. Consider regenerating. (${status})` };
+                }
                 return { name, status: 'Error', level: 'critical', notes: `unexpected AR model status: ${status}` };
             }
         }
@@ -348,7 +360,7 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         else
             return formatResultField(name,'Missing','fail',`${count}/${expected} base models found`);
     };
-    const getModelDownloadsStatus = ( status: string, count: number, expected: number, licenseAllows: boolean): FieldStatus => {
+    const getModelDownloadsStatus = async ( status: string, count: number, expected: number, licenseAllows: boolean): Promise<FieldStatus> => {
         const name = 'Download Models';
         const expectedCount = expected > 0 ? expected : 6;
 
@@ -364,7 +376,11 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
             else
                 return formatResultField(name,'Missing','warn',`downloads not found (${count}/${expectedCount}). consider generating them.`);
         } else if(status === 'Error') {
-            // downloads exist but may have material issues (created before June 14, 2024 Cook fix)
+            // downloads exist but may have material issues (created before June 14, 2024 Cook fix).
+            // Presence of an approval audit row clears the date flag to a neutral "Verified" state.
+            const approval = await DBAPI.Audit.fetchLastApproval(idSystemObject, DBAPI.eAuditType.eActionApproveDownloadModels);
+            if(approval)
+                return formatResultField(name,'Verified','info',`Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}`);
             if(licenseAllows===true)
                 return formatResultField(name,'Outdated','warn',`downloads found (${count}/${expectedCount}) but may have material issues. consider regenerating.`);
             else
@@ -440,9 +456,9 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         baseModels:
             getModelBaseStatus(sceneSummary.derivatives.models.status,sceneSummary.derivatives.models.items.length,sceneSummary.derivatives.models.expected ?? -1),
         downloads:
-            getModelDownloadsStatus(sceneSummary.derivatives.downloads.status,sceneSummary.derivatives.downloads.items.length,sceneSummary.derivatives.downloads.expected ?? -1,doesLicenseAllowDownloads(licenseStatus.status)),
+            await getModelDownloadsStatus(sceneSummary.derivatives.downloads.status,sceneSummary.derivatives.downloads.items.length,sceneSummary.derivatives.downloads.expected ?? -1,doesLicenseAllowDownloads(licenseStatus.status)),
         arModels:
-            getModelARStatus(sceneSummary.derivatives.ar.status,doesLicenseAllowDownloads(licenseStatus.status)),
+            await getModelARStatus(sceneSummary.derivatives.ar.status,doesLicenseAllowDownloads(licenseStatus.status)),
         captureData:
             getCaptureDataStatus(sceneSummary.sources.captureData.items.length,sceneSummary.sources.captureData.expected ?? -1)
     };
@@ -533,6 +549,49 @@ export async function patchObject(req: Request, res: Response): Promise<void> {
                             db: edanResult.dbEdanRecordId,
                             subjectCount: edanResult.subjectCount,
                         }
+                    })));
+                    return;
+                }
+                case 'approveARModels':
+                case 'approveDownloadModels': {
+                    const isAR: boolean = key === 'approveARModels';
+                    const action: DBAPI.eAuditType = isAR
+                        ? DBAPI.eAuditType.eActionApproveARModels
+                        : DBAPI.eAuditType.eActionApproveDownloadModels;
+
+                    // optional free-text reason: client sends { [field]: { reason } }, but a bare
+                    // string is also accepted
+                    const rawValue = fields[key];
+                    const reason: string | undefined = (rawValue && typeof rawValue === 'object' && typeof rawValue.reason === 'string')
+                        ? (rawValue.reason.trim() || undefined)
+                        : (typeof rawValue === 'string' ? (rawValue.trim() || undefined) : undefined);
+
+                    // snapshot the currently date-flagged derivatives so the audit row records
+                    // exactly what was approved (forensics); honoring itself is presence-only
+                    const sceneSummary: SceneSummary | null = await buildProjectSceneDef(scene, null);
+                    const derivativeItems = sceneSummary
+                        ? (isAR ? sceneSummary.derivatives.ar.items : sceneSummary.derivatives.downloads.items)
+                        : [];
+                    const approvedModels = derivativeItems
+                        .filter(item => item.dateModified < COOK_MATERIAL_FIX_DATE)
+                        .map(item => ({ idSystemObject: item.id, name: item.name, dateModified: item.dateModified }));
+
+                    const emitted: boolean = await AuditFactory.emitSemantic({
+                        action,
+                        target: { idObject: scene.idScene, eObjectType: COMMON.eSystemObjectType.eScene },
+                        idSystemObject,
+                        payload: { reason, cutoff: COOK_MATERIAL_FIX_DATE, approvedModels },
+                    });
+                    if(!emitted) {
+                        res.status(200).send(JSON.stringify(generateResponse(false,'patchObject: failed to record approval')));
+                        return;
+                    }
+
+                    RK.logInfo(RK.LogSection.eHTTP,'patch object',`approved ${isAR ? 'AR models':'download models'} for scene ${idSystemObject}`,
+                        { idSystemObject, action, approvedCount: approvedModels.length, reason },'HTTP.Object.PatchObject',true);
+                    res.status(200).send(JSON.stringify(generateResponse(true,'Approved',{
+                        field: isAR ? 'arModels' : 'downloads',
+                        approvedCount: approvedModels.length,
                     })));
                     return;
                 }

--- a/server/http/routes/api/project.ts
+++ b/server/http/routes/api/project.ts
@@ -61,7 +61,7 @@ export type SceneSummary = DBAPI.DBReference & {
 // Cook fix for material properties during inspection landed on 2024-06-14.
 // Downloads/AR assets produced before this date may have material issues and
 // should be flagged as outdated until regenerated.
-const COOK_MATERIAL_FIX_DATE: Date = new Date('2024-06-14T00:00:00Z');
+export const COOK_MATERIAL_FIX_DATE: Date = new Date('2024-06-14T00:00:00Z');
 //#endregion
 
 //#region Get Projects & Scenes


### PR DESCRIPTION
- Add AR/Download approve audit actions (118/119)
- Map both approve actions to PROTECT retention tier
- Add fetchLastApproval query for approver name/date
- Export Cook fix cutoff date for reuse in status
- Presence-only approval honoring in scene status
- patchObject cases for AR + download approvals
- Verify/Approve modal on Outdated AR/download rows