### PR TITLE
DPO3DPKRT-1021/License Assignment Tx Scope + Fast-Path

### DIFF
--- a/server/cache/LicenseCache.ts
+++ b/server/cache/LicenseCache.ts
@@ -86,21 +86,24 @@ export class LicenseCache {
 
     private async clearAssignmentInternal(idSystemObject: number): Promise<boolean> {
         // LOG.info(`LicenseCache.clearAssignmentInternal(${idSystemObject})`, LOG.LS.eCACHE);
-        // Compute object graph of descendants; remove assignment from each
-        const OGD: DBAPI.ObjectGraphDatabase = new DBAPI.ObjectGraphDatabase();
-        const OG: DBAPI.ObjectGraph = new DBAPI.ObjectGraph(idSystemObject, DBAPI.eObjectGraphMode.eDescendents, 32, OGD); /* istanbul ignore if */
-        if (!await OG.fetch()) {
-            RK.logError(RK.LogSection.eCACHE,'clear assignment failed','unable to fetch object graph',{ idSystemObject },'Cache.License');
-            return false;
-        }
+        // Gather the descendant idSystemObject set and drop each one's cached resolver so it recomputes
+        // its inherited license on the next read. The lightweight xref traversal has parity with
+        // ObjectGraph(eDescendents) without the per-node 13-table join that made this heavy.
+        const descendants: Set<number> = await DBAPI.SystemObjectXref.fetchDescendentIDs(idSystemObject, 32);
 
-        for (const idSODescendant of OGD.objectMap.keys()) {
+        for (const idSODescendant of descendants) {
             // LOG.info(`LicenseCache.clearAssignmentInternal(${idSystemObject}) cleared ${idSODescendant}`, LOG.LS.eCACHE);
             this.licenseResolverMap.delete(idSODescendant);
         }
 
         RK.logDebug(RK.LogSection.eCACHE,'clear assignment success',undefined,{ idSystemObject },'Cache.License');
         return true;
+    }
+
+    /** Drops only this object's cached resolver (no descendant traversal). Used on a failure/rollback
+     * path to defensively discard a single potentially-stale entry without the descendant walk. */
+    private invalidateResolverInternal(idSystemObject: number): void {
+        this.licenseResolverMap.delete(idSystemObject);
     }
 
     private async setAssignmentInternal(idSystemObject: number, licenseResolver: DBAPI.LicenseResolver): Promise<boolean> {
@@ -141,6 +144,12 @@ export class LicenseCache {
 
     static async clearAssignment(idSystemObject: number): Promise<boolean> {
         return await (await this.getInstance()).clearAssignmentInternal(idSystemObject);
+    }
+
+    /** Drops a single object's cached resolver without touching descendants. Safe, cheap failure-path
+     * cleanup — the entry recomputes from the DB on the next read. */
+    static async invalidateResolver(idSystemObject: number): Promise<void> {
+        (await this.getInstance()).invalidateResolverInternal(idSystemObject);
     }
 
     static async setAssignment(idSystemObject: number, licenseResolver: DBAPI.LicenseResolver): Promise<boolean> {

--- a/server/db/api/SystemObjectXref.ts
+++ b/server/db/api/SystemObjectXref.ts
@@ -168,6 +168,144 @@ export class SystemObjectXref extends DBC.DBObject<SystemObjectXrefBase> impleme
         }
     }
 
+    /**
+     * Returns the set of descendant idSystemObjects (including idSystemObject itself), matching the
+     * node set produced by `new ObjectGraph(idSystemObject, eDescendents, depth).objectMap.keys()`,
+     * without building the typed ObjectGraphDatabase or issuing the per-node 13-table SystemObjectPairs
+     * join. Used by LicenseCache to invalidate every descendant's cached inherited license.
+     *
+     * A level-batched breadth-first walk: each level issues a fixed handful of `IN (...)` queries
+     * regardless of node count, rather than ObjectGraph's per-node sequential round-trips. It follows
+     * the same descendant edges ObjectGraph does — SystemObjectXref derived edges, owned assets and
+     * their versions, per-type thumbnail assets, Unit→Subject/Actor and Project→ProjectDocumentation —
+     * so the id set has parity. A visited set + depth cap guard cycles exactly like ObjectGraph.
+     */
+    static async fetchDescendentIDs(idSystemObject: number, depth: number = 32): Promise<Set<number>> {
+        const visited: Set<number> = new Set<number>();
+        if (!idSystemObject)
+            return visited;
+        visited.add(idSystemObject);
+
+        let frontier: number[] = [idSystemObject];
+        let level: number = 0;
+        try {
+            while (frontier.length > 0 && level < depth) {
+                const children: number[] = await SystemObjectXref.fetchDescendentChildrenBatch(frontier);
+                const nextFrontier: number[] = [];
+                for (const idChild of children) {
+                    if (!visited.has(idChild)) {
+                        visited.add(idChild);
+                        nextFrontier.push(idChild);
+                    }
+                }
+                frontier = nextFrontier;
+                level++;
+            }
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB,'fetch descendent ids failed',H.Helpers.getErrorString(error),{ idSystemObject },'DB.SystemObject.Xref');
+        }
+        return visited;
+    }
+
+    /** One breadth-first hop: given a frontier of idSystemObjects, returns every immediate descendant
+     * idSystemObject, mirroring the child edges ObjectGraph gathers in eDescendents mode. Each edge
+     * class is resolved with a single batched `IN (...)` query. */
+    private static async fetchDescendentChildrenBatch(frontier: number[]): Promise<number[]> {
+        const prisma = DBC.DBConnection.prisma;
+        const children: Set<number> = new Set<number>();
+
+        // Classify the frontier nodes by type (single-table read; no SystemObjectPairs join).
+        const sos = await prisma.systemObject.findMany({
+            where: { idSystemObject: { in: frontier } },
+            select: { idSystemObject: true, idUnit: true, idProject: true, idSubject: true,
+                idItem: true, idCaptureData: true, idModel: true, idScene: true, idAsset: true },
+        });
+        const unitIDs: number[] = [];
+        const projectIDs: number[] = [];
+        const subjectIDs: number[] = [];
+        const itemIDs: number[] = [];
+        const captureDataIDs: number[] = [];
+        const modelIDs: number[] = [];
+        const sceneIDs: number[] = [];
+        const assetIDs: number[] = [];  // nodes that are themselves Assets
+        for (const so of sos) {
+            if (so.idUnit) unitIDs.push(so.idUnit);
+            if (so.idProject) projectIDs.push(so.idProject);
+            if (so.idSubject) subjectIDs.push(so.idSubject);
+            if (so.idItem) itemIDs.push(so.idItem);
+            if (so.idCaptureData) captureDataIDs.push(so.idCaptureData);
+            if (so.idModel) modelIDs.push(so.idModel);
+            if (so.idScene) sceneIDs.push(so.idScene);
+            if (so.idAsset) assetIDs.push(so.idAsset);
+        }
+
+        // Edge: SystemObjectXref derived (the structural child edges — the common case).
+        const xrefs = await prisma.systemObjectXref.findMany({
+            where: { idSystemObjectMaster: { in: frontier } }, select: { idSystemObjectDerived: true } });
+        for (const x of xrefs)
+            children.add(x.idSystemObjectDerived);
+
+        // Edge: assets owned by any frontier node (Asset.idSystemObject → owning node).
+        const ownedAssets = await prisma.asset.findMany({
+            where: { idSystemObject: { in: frontier } }, select: { idAsset: true } });
+        await SystemObjectXref.addSystemObjectsForField(children, 'idAsset', ownedAssets.map(a => a.idAsset));
+
+        // Edge: asset children — AssetVersions of nodes that are themselves Assets.
+        if (assetIDs.length > 0) {
+            const avs = await prisma.assetVersion.findMany({
+                where: { idAsset: { in: assetIDs } }, select: { idAssetVersion: true } });
+            await SystemObjectXref.addSystemObjectsForField(children, 'idAssetVersion', avs.map(a => a.idAssetVersion));
+        }
+
+        // Edge: Unit → Subjects and Unit → Actors (FK edges, not modeled in SystemObjectXref).
+        if (unitIDs.length > 0) {
+            const subs = await prisma.subject.findMany({ where: { idUnit: { in: unitIDs } }, select: { idSubject: true } });
+            await SystemObjectXref.addSystemObjectsForField(children, 'idSubject', subs.map(s => s.idSubject));
+            const actors = await prisma.actor.findMany({ where: { idUnit: { in: unitIDs } }, select: { idActor: true } });
+            await SystemObjectXref.addSystemObjectsForField(children, 'idActor', actors.map(a => a.idActor));
+        }
+
+        // Edge: Project → ProjectDocumentation (FK edge).
+        if (projectIDs.length > 0) {
+            const pds = await prisma.projectDocumentation.findMany({
+                where: { idProject: { in: projectIDs } }, select: { idProjectDocumentation: true } });
+            await SystemObjectXref.addSystemObjectsForField(children, 'idProjectDocumentation', pds.map(p => p.idProjectDocumentation));
+        }
+
+        // Edge: per-type thumbnail assets (Subject/Item/CaptureData/Model/Scene → idAssetThumbnail).
+        const thumbnailAssetIDs: number[] = [];
+        const collectThumbnails = (rows: { idAssetThumbnail: number | null }[]): void => {
+            for (const r of rows)
+                if (r.idAssetThumbnail) thumbnailAssetIDs.push(r.idAssetThumbnail);
+        };
+        if (subjectIDs.length > 0)
+            collectThumbnails(await prisma.subject.findMany({ where: { idSubject: { in: subjectIDs } }, select: { idAssetThumbnail: true } }));
+        if (itemIDs.length > 0)
+            collectThumbnails(await prisma.item.findMany({ where: { idItem: { in: itemIDs } }, select: { idAssetThumbnail: true } }));
+        if (captureDataIDs.length > 0)
+            collectThumbnails(await prisma.captureData.findMany({ where: { idCaptureData: { in: captureDataIDs } }, select: { idAssetThumbnail: true } }));
+        if (modelIDs.length > 0)
+            collectThumbnails(await prisma.model.findMany({ where: { idModel: { in: modelIDs } }, select: { idAssetThumbnail: true } }));
+        if (sceneIDs.length > 0)
+            collectThumbnails(await prisma.scene.findMany({ where: { idScene: { in: sceneIDs } }, select: { idAssetThumbnail: true } }));
+        await SystemObjectXref.addSystemObjectsForField(children, 'idAsset', thumbnailAssetIDs);
+
+        return Array.from(children);
+    }
+
+    /** Resolves a batch of entity ids (e.g. idAsset values) to their idSystemObjects and adds them to
+     * the accumulating child set. `field` is the SystemObject FK column that references the entity. */
+    private static async addSystemObjectsForField(children: Set<number>,
+        field: 'idAsset' | 'idAssetVersion' | 'idSubject' | 'idActor' | 'idProjectDocumentation',
+        entityIDs: number[]): Promise<void> {
+        if (entityIDs.length === 0)
+            return;
+        const rows = await DBC.DBConnection.prisma.systemObject.findMany({
+            where: { [field]: { in: entityIDs } }, select: { idSystemObject: true } });
+        for (const r of rows)
+            children.add(r.idSystemObject);
+    }
+
     static async wireObjectsIfNeeded(master: SystemObjectBased, derived: SystemObjectBased): Promise<SystemObjectXref | null>;
     static async wireObjectsIfNeeded(master: SystemObjectBased, derivedID: number): Promise<SystemObjectXref | null>;
     static async wireObjectsIfNeeded(masterID: number, derived: SystemObjectBased): Promise<SystemObjectXref | null>;

--- a/server/db/api/composite/LicenseManager.ts
+++ b/server/db/api/composite/LicenseManager.ts
@@ -3,10 +3,31 @@ import * as CACHE from '../../../cache';
 import { RecordKeeper as RK } from '../../../records/recordKeeper';
 import { LicenseResolver } from './LicenseResolver';
 
-/** LicenseManager exists to manage the setting and clearing of license data from system objects. */
+/** Result of a DB-write-core assignment: `success` reflects the DB writes only; `resolver`, when
+ * present, is the LicenseResolver the caller should hand to LicenseCache.setAssignment after the
+ * enclosing transaction commits. A `success` with no `resolver` means no active assignment was
+ * created (the cache is left untouched, matching the prior behavior). */
+export type LicenseAssignmentDBResult = {
+    success: boolean;
+    resolver?: LicenseResolver;
+};
+
+/** LicenseManager exists to manage the setting and clearing of license data from system objects.
+ *
+ * The DB-write core (`*DBWrites`) performs only the LicenseAssignment table writes and never touches
+ * the in-memory LicenseCache — which, for a high-hierarchy object, runs a large descendant traversal.
+ * Callers that mutate inside an audit transaction use the core and then run the cache maintenance
+ * (`maintainCacheAfterSet` / `maintainCacheAfterClear`) AFTER commit, so the heavy descendant walk
+ * never extends the transaction lock window (which previously blew the statement timeout and left the
+ * cache holding a phantom assignment from a rolled-back transaction). The combined `setAssignment` /
+ * `clearAssignment` keep the original DB-then-cache behavior for callers not inside a tight tx. */
 export class LicenseManager {
-    /** Clears license assignment from idSystemObject by setting LicenseAssignment.DateEnd to now; returns false if clear fails */
-    static async clearAssignment(idSystemObject: number, clearAll?: boolean | undefined): Promise<boolean> {
+    // ***********************************************************************
+    // #region DB-write core (no cache maintenance, no descendant traversal)
+    // ***********************************************************************
+    /** Terminates license assignments on idSystemObject by setting DateEnd to now (active only, or all
+     * when clearAll). DB writes only — does not touch LicenseCache. */
+    static async clearAssignmentDBWrites(idSystemObject: number, clearAll?: boolean | undefined): Promise<boolean> {
         RK.logInfo(RK.LogSection.eDB,'clear assignmemt',undefined,{ idSystemObject, clearAll },'DB.Composite.License.Manager',true);
 
         const assignments: LicenseAssignment[] | null = await LicenseAssignment.fetchFromSystemObject(idSystemObject); /* istanbul ignore if */
@@ -22,16 +43,17 @@ export class LicenseManager {
             }
         }
 
-        return await CACHE.LicenseCache.clearAssignment(idSystemObject) && retValue;
+        return retValue;
     }
 
-    /** Assigns license to idSystemObject. First clears active, existing licenses */
-    static async setAssignment(idSystemObject: number, license: License, idUserCreator?: number | null | undefined,
-        DateStart?: Date | null | undefined, DateEnd?: Date | null | undefined): Promise<boolean> {
+    /** Clears active assignments then creates the new one on idSystemObject. DB writes only — does not
+     * touch LicenseCache. Returns the resolver to feed into maintainCacheAfterSet post-commit. */
+    static async setAssignmentDBWrites(idSystemObject: number, license: License, idUserCreator?: number | null | undefined,
+        DateStart?: Date | null | undefined, DateEnd?: Date | null | undefined): Promise<LicenseAssignmentDBResult> {
         /* istanbul ignore if */
-        if (!await LicenseManager.clearAssignment(idSystemObject, false)) {
+        if (!await LicenseManager.clearAssignmentDBWrites(idSystemObject, false)) {
             RK.logError(RK.LogSection.eDB,'set assignment failed','failed to clear active assignments',{ idSystemObject, license },'DB.Composite.License.Manager');
-            return false;
+            return { success: false };
         }
         RK.logInfo(RK.LogSection.eDB,'set assignment',undefined,{ idSystemObject, license, idUserCreator, start: DateStart, end: DateEnd },'DB.Composite.License.Manager',true);
 
@@ -51,10 +73,52 @@ export class LicenseManager {
             idLicenseAssignment: 0
         });
 
+        // A non-active assignment (e.g. DateEnd in the past) is not persisted and leaves the cache
+        // unchanged — no resolver is returned.
         if (!assignment.assignmentActive())
-            return true;
-        const retValue: boolean = await assignment.create();
+            return { success: true };
+        if (!await assignment.create())
+            return { success: false };
 
-        return await CACHE.LicenseCache.setAssignment(idSystemObject, new LicenseResolver(license, assignment, false)) && retValue;
+        return { success: true, resolver: new LicenseResolver(license, assignment, false) };
     }
+    // #endregion
+
+    // ***********************************************************************
+    // #region Post-commit cache maintenance (runs the descendant traversal)
+    // ***********************************************************************
+    /** Clears every descendant's cached resolver after a license was cleared. Run this AFTER the
+     * enclosing transaction commits — never inside it. */
+    static async maintainCacheAfterClear(idSystemObject: number): Promise<boolean> {
+        return await CACHE.LicenseCache.clearAssignment(idSystemObject);
+    }
+
+    /** Clears every descendant's cached resolver and records the new assignment after a license was
+     * assigned. Run this AFTER the enclosing transaction commits. A missing resolver (non-active
+     * assignment) is a no-op, matching the DB-write core. */
+    static async maintainCacheAfterSet(idSystemObject: number, resolver: LicenseResolver | undefined): Promise<boolean> {
+        if (!resolver)
+            return true;
+        return await CACHE.LicenseCache.setAssignment(idSystemObject, resolver);
+    }
+    // #endregion
+
+    // ***********************************************************************
+    // #region Combined DB + cache (for callers not inside a tight transaction)
+    // ***********************************************************************
+    /** Clears license assignment from idSystemObject and maintains the cache; returns false if clear fails */
+    static async clearAssignment(idSystemObject: number, clearAll?: boolean | undefined): Promise<boolean> {
+        const dbSuccess: boolean = await LicenseManager.clearAssignmentDBWrites(idSystemObject, clearAll);
+        return await LicenseManager.maintainCacheAfterClear(idSystemObject) && dbSuccess;
+    }
+
+    /** Assigns license to idSystemObject and maintains the cache. First clears active, existing licenses */
+    static async setAssignment(idSystemObject: number, license: License, idUserCreator?: number | null | undefined,
+        DateStart?: Date | null | undefined, DateEnd?: Date | null | undefined): Promise<boolean> {
+        const dbResult: LicenseAssignmentDBResult = await LicenseManager.setAssignmentDBWrites(idSystemObject, license, idUserCreator, DateStart, DateEnd); /* istanbul ignore if */
+        if (!dbResult.success)
+            return false;
+        return await LicenseManager.maintainCacheAfterSet(idSystemObject, dbResult.resolver);
+    }
+    // #endregion
 }

--- a/server/graphql/schema/license/resolvers/mutations/assignLicense.ts
+++ b/server/graphql/schema/license/resolvers/mutations/assignLicense.ts
@@ -26,28 +26,50 @@ export default async function assignLicense(_: Parent, args: MutationAssignLicen
     if (!LicenseNew)
         return { success: false, message: 'There was an error fetching the license for assignment. Please try again.' };
 
-    // Wrap the DB-mutating section so the LicenseAssignment writes and the
-    // semantic audit row commit atomically. PublishScene.handleSceneUpdates
-    // (Cook workflow trigger) runs AFTER commit so it never extends the lock
-    // window.
-    const dbResult = await withAuditTransaction(async () => {
-        const assignmentSuccess = await DBAPI.LicenseManager.setAssignment(idSystemObject, LicenseNew);
-        if (!assignmentSuccess)
-            return { ok: false, message: 'Error assigning license' };
+    // Wrap only the LicenseAssignment writes and the semantic audit row so they commit atomically.
+    // The LicenseCache maintenance (a descendant-graph traversal that can be very large for a Subject
+    // or higher object) is deliberately kept OUT of the transaction and run post-commit — inside the
+    // tx it blew the statement timeout and, because the cache is not transactional, left a phantom
+    // assignment behind after the rollback. PublishScene.handleSceneUpdates (Cook trigger) likewise
+    // runs post-commit.
+    let cacheResolver: DBAPI.LicenseResolver | undefined = undefined;
+    let dbResult: { ok: boolean; message?: string };
+    try {
+        dbResult = await withAuditTransaction(async () => {
+            const dbWrite = await DBAPI.LicenseManager.setAssignmentDBWrites(idSystemObject, LicenseNew);
+            if (!dbWrite.success)
+                return { ok: false, message: 'Error assigning license' };
+            cacheResolver = dbWrite.resolver;
 
-        await AuditFactory.emitSemantic({
-            action: eAuditType.eActionAssignLicense,
-            idSystemObject,
-            payload: {
-                before: LicenseOld ? { idLicense: LicenseOld.idLicense, Name: LicenseOld.Name, RestrictLevel: LicenseOld.RestrictLevel } : null,
-                after:  { idLicense: LicenseNew.idLicense, Name: LicenseNew.Name, RestrictLevel: LicenseNew.RestrictLevel },
-            },
+            await AuditFactory.emitSemantic({
+                action: eAuditType.eActionAssignLicense,
+                idSystemObject,
+                payload: {
+                    before: LicenseOld ? { idLicense: LicenseOld.idLicense, Name: LicenseOld.Name, RestrictLevel: LicenseOld.RestrictLevel } : null,
+                    after:  { idLicense: LicenseNew.idLicense, Name: LicenseNew.Name, RestrictLevel: LicenseNew.RestrictLevel },
+                },
+            });
+            return { ok: true };
         });
-        return { ok: true };
-    });
+    } catch (error) {
+        // The transaction threw and rolled back: nothing was persisted. The cache was not mutated in
+        // the tx, but drop this object's entry defensively so no stale value can be read. Raw error
+        // text is kept server-side only.
+        RK.logError(RK.LogSection.eGQL,'assign license failed','transaction failed',{ ...args.input, error: error instanceof Error ? error.message : String(error) },'GraphQL.License');
+        await CACHE.LicenseCache.invalidateResolver(idSystemObject);
+        return { success: false, message: 'There was an error assigning the license. Please try again.' };
+    }
 
-    if (!dbResult.ok)
-        return { success: false, message: dbResult.message };
+    if (!dbResult.ok) {
+        await CACHE.LicenseCache.invalidateResolver(idSystemObject);
+        return { success: false, message: dbResult.message ?? 'Error assigning license' };
+    }
+
+    // Post-commit: maintain the license cache now that the assignment is durably persisted. The
+    // descendant traversal runs outside the lock window; a failure here is non-fatal (the cache is
+    // rebuildable) and drops to a targeted invalidation.
+    if (!await DBAPI.LicenseManager.maintainCacheAfterSet(idSystemObject, cacheResolver))
+        await CACHE.LicenseCache.invalidateResolver(idSystemObject);
 
     // If this is a scene, handle license changes (post-commit):
     const oID: DBAPI.ObjectIDAndType | undefined = await CACHE.SystemObjectCache.getObjectFromSystem(idSystemObject);

--- a/server/graphql/schema/license/resolvers/mutations/clearLicenseAssignment.ts
+++ b/server/graphql/schema/license/resolvers/mutations/clearLicenseAssignment.ts
@@ -22,31 +22,49 @@ export default async function clearLicenseAssignment(_: Parent, args: MutationCl
     const LROld: DBAPI.LicenseResolver | undefined = await CACHE.LicenseCache.getLicenseResolver(idSystemObject);
     const LicenseOld: DBAPI.License | undefined = LROld?.License ?? undefined;
 
-    // DB-mutating section commits atomically with its audit row. The Cook
-    // workflow trigger via PublishScene.handleSceneUpdates runs post-commit.
-    const dbResult = await withAuditTransaction(async () => {
-        const clearAssignmentSuccess = await DBAPI.LicenseManager.clearAssignment(idSystemObject, clearAll ?? undefined);
-        if (!clearAssignmentSuccess)
-            return { ok: false as const, message: 'There was an error clearing the assigned license. Please try again.' };
+    // Wrap only the LicenseAssignment writes and the audit row. The LicenseCache maintenance (a
+    // potentially large descendant traversal) is kept OUT of the tx and run post-commit — inside it
+    // blew the statement timeout and left the cache inconsistent after a rollback. The Cook trigger
+    // via PublishScene.handleSceneUpdates likewise runs post-commit.
+    let LicenseNew: DBAPI.License | undefined = undefined;
+    let dbResult: { ok: boolean; message?: string };
+    try {
+        dbResult = await withAuditTransaction(async () => {
+            const clearAssignmentSuccess = await DBAPI.LicenseManager.clearAssignmentDBWrites(idSystemObject, clearAll ?? undefined);
+            if (!clearAssignmentSuccess)
+                return { ok: false, message: 'There was an error clearing the assigned license. Please try again.' };
 
-        const LRNewInner: DBAPI.LicenseResolver | undefined = await CACHE.LicenseCache.getLicenseResolver(idSystemObject);
-        const LicenseNewInner: DBAPI.License | undefined = LRNewInner?.License ?? undefined;
+            // Resolve the post-clear inherited license directly from the DB (reflecting this tx's
+            // termination writes) rather than the cache, which still holds the pre-clear value until
+            // the post-commit maintenance runs.
+            const LRNewInner: DBAPI.LicenseResolver | null = await DBAPI.LicenseResolver.fetch(idSystemObject);
+            LicenseNew = LRNewInner?.License ?? undefined;
 
-        await AuditFactory.emitSemantic({
-            action: eAuditType.eActionClearLicense,
-            idSystemObject,
-            payload: {
-                clearAll: Boolean(clearAll),
-                before: LicenseOld ? { idLicense: LicenseOld.idLicense, Name: LicenseOld.Name, RestrictLevel: LicenseOld.RestrictLevel } : null,
-                after:  LicenseNewInner ? { idLicense: LicenseNewInner.idLicense, Name: LicenseNewInner.Name, RestrictLevel: LicenseNewInner.RestrictLevel } : null,
-            },
+            await AuditFactory.emitSemantic({
+                action: eAuditType.eActionClearLicense,
+                idSystemObject,
+                payload: {
+                    clearAll: Boolean(clearAll),
+                    before: LicenseOld ? { idLicense: LicenseOld.idLicense, Name: LicenseOld.Name, RestrictLevel: LicenseOld.RestrictLevel } : null,
+                    after:  LicenseNew ? { idLicense: LicenseNew.idLicense, Name: LicenseNew.Name, RestrictLevel: LicenseNew.RestrictLevel } : null,
+                },
+            });
+            return { ok: true };
         });
-        return { ok: true as const, LicenseNew: LicenseNewInner };
-    });
+    } catch (error) {
+        RK.logError(RK.LogSection.eGQL,'clear license assignment failed','transaction failed',{ idSystemObject, error: error instanceof Error ? error.message : String(error) },'GraphQL.License.Assignment');
+        await CACHE.LicenseCache.invalidateResolver(idSystemObject);
+        return { success: false, message: 'There was an error clearing the assigned license. Please try again.' };
+    }
 
-    if (!dbResult.ok)
-        return { success: false, message: dbResult.message };
-    const LicenseNew = dbResult.LicenseNew;
+    if (!dbResult.ok) {
+        await CACHE.LicenseCache.invalidateResolver(idSystemObject);
+        return { success: false, message: dbResult.message ?? 'There was an error clearing the assigned license. Please try again.' };
+    }
+
+    // Post-commit: maintain the license cache now that the clear is durably persisted.
+    if (!await DBAPI.LicenseManager.maintainCacheAfterClear(idSystemObject))
+        await CACHE.LicenseCache.invalidateResolver(idSystemObject);
 
     // If this is a scene, handle license changes:
     const oID: DBAPI.ObjectIDAndType | undefined = await CACHE.SystemObjectCache.getObjectFromSystem(idSystemObject);

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateObjectDetails.ts
@@ -24,6 +24,11 @@ type PendingSceneUpdate = {
     LicenseNew: DBAPI.License | undefined;
 };
 
+type PendingLicenseCache = {
+    clear: boolean;                                 // true = license cleared; false = license assigned
+    resolver: DBAPI.LicenseResolver | undefined;    // resolver to record post-commit when assigning
+};
+
 export default async function updateObjectDetails(_: Parent, args: MutationUpdateObjectDetailsArgs, context: Context): Promise<UpdateObjectDetailsResult> {
     const { input } = args;
     const { user } = context;
@@ -45,6 +50,10 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
     // performs EDAN unpublish for published scenes). Capture the intended transition here; null =
     // no change requested.
     let pendingRetire: boolean | null = null;
+    // LicenseCache maintenance runs the descendant traversal, so it is kept out of the tx and applied
+    // post-commit (see the license phases). Capture which maintenance the DB writes require; null =
+    // no license change.
+    let pendingLicenseCache: PendingLicenseCache | null = null;
 
     const txResult = await withAuditTransaction(async (): Promise<UpdateObjectDetailsResult> => {
         if (!data.Name || isUndefined(data.Retired) || isNull(data.Retired))
@@ -97,12 +106,15 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
                 if (!reassignedLicense)
                     return sendResult(false,'update object details failed',`Unable to fetch license with id ${data.License}; update failed`);
 
-                if (!await DBAPI.LicenseManager.setAssignment(idSystemObject, reassignedLicense))
+                const dbWrite = await DBAPI.LicenseManager.setAssignmentDBWrites(idSystemObject, reassignedLicense);
+                if (!dbWrite.success)
                     return sendResult(false,'update object details failed',`Unable to reassign license for idSystemObject ${idSystemObject} with id ${reassignedLicense.idLicense}; update failed`);
+                pendingLicenseCache = { clear: false, resolver: dbWrite.resolver };
                 LicenseNew = reassignedLicense;
             } else {
-                if (!await DBAPI.LicenseManager.clearAssignment(idSystemObject))
+                if (!await DBAPI.LicenseManager.clearAssignmentDBWrites(idSystemObject))
                     return sendResult(false,'update object details failed',`Unable to clear license with for idSystemObject ${idSystemObject}; update failed`);
+                pendingLicenseCache = { clear: true, resolver: undefined };
                 LicenseNew = undefined;
             }
         }
@@ -582,6 +594,18 @@ export default async function updateObjectDetails(_: Parent, args: MutationUpdat
     // Tx errored, or business logic returned a failure result inside the tx.
     if (!txResult.success)
         return txResult;
+
+    // Post-commit: maintain the license cache now that the assignment change is durably persisted.
+    // Run this before the scene/retire side-effects so any downstream license read sees fresh data.
+    // A failure is non-fatal (the cache is rebuildable); drop to a targeted invalidation.
+    if (pendingLicenseCache) {
+        const plc: PendingLicenseCache = pendingLicenseCache;
+        const cacheOk: boolean = plc.clear
+            ? await DBAPI.LicenseManager.maintainCacheAfterClear(idSystemObject)
+            : await DBAPI.LicenseManager.maintainCacheAfterSet(idSystemObject, plc.resolver);
+        if (!cacheOk)
+            await CACHE.LicenseCache.invalidateResolver(idSystemObject);
+    }
 
     // Post-commit: apply retire/reinstate via the shared executor. Runs outside the tx because it
     // performs EDAN unpublish (external HTTP) for published scenes and manages its own audit

--- a/server/tests/db/composite/SystemObjectXrefDescendents.test.ts
+++ b/server/tests/db/composite/SystemObjectXrefDescendents.test.ts
@@ -1,0 +1,72 @@
+import * as DBAPI from '../../../db';
+import { ObjectGraphTestSetup } from './ObjectGraph.setup';
+
+// *******************************************************************
+// DB SystemObjectXref.fetchDescendentIDs — parity with ObjectGraph
+// *******************************************************************
+// The lightweight descendant-id fast-path used by LicenseCache must produce the same node set as
+// new ObjectGraph(id, eDescendents, 32, OGD).objectMap.keys(), so cache invalidation can never
+// silently under-invalidate a descendant's inherited license. This suite asserts that parity on the
+// shared ObjectGraph fixture across a representative range of root types.
+
+const OHTS: ObjectGraphTestSetup = new ObjectGraphTestSetup();
+
+async function idOf(SOBased: DBAPI.SystemObjectBased | null): Promise<number> {
+    expect(SOBased).toBeTruthy();
+    if (!SOBased)
+        return 0;
+    const SO: DBAPI.SystemObject | null = await SOBased.fetchSystemObject();
+    expect(SO).toBeTruthy();
+    return SO ? SO.idSystemObject : 0;
+}
+
+/** Ground-truth descendant node set: the keys ObjectGraph records into its ObjectGraphDatabase. */
+async function objectGraphDescendentIDs(idSystemObject: number): Promise<Set<number>> {
+    const OGD: DBAPI.ObjectGraphDatabase = new DBAPI.ObjectGraphDatabase();
+    const OG: DBAPI.ObjectGraph = new DBAPI.ObjectGraph(idSystemObject, DBAPI.eObjectGraphMode.eDescendents, 32, OGD);
+    expect(await OG.fetch()).toBeTruthy();
+    return new Set<number>(OGD.objectMap.keys());
+}
+
+async function expectDescendentParity(idSystemObject: number): Promise<void> {
+    const expected: Set<number> = await objectGraphDescendentIDs(idSystemObject);
+    const actual: Set<number> = await DBAPI.SystemObjectXref.fetchDescendentIDs(idSystemObject, 32);
+
+    // No under-invalidation: every node ObjectGraph reaches must be present in the fast-path set.
+    for (const id of expected)
+        expect(actual.has(id)).toBeTruthy();
+
+    // No wild over-invalidation: the fast-path adds at most the root itself (ObjectGraph omits the
+    // root from objectMap only when it has no descendants at all).
+    for (const id of actual)
+        expect(expected.has(id) || id === idSystemObject).toBeTruthy();
+}
+
+describe('DB Composite SystemObjectXref Setup', () => {
+    test('DB Composite DB Object Creation', async () => {
+        await OHTS.initialize();
+        await OHTS.wire();
+    });
+});
+
+describe('DB SystemObjectXref.fetchDescendentIDs parity with ObjectGraph', () => {
+    test('Unit descendents', async () => { await expectDescendentParity(await idOf(OHTS.unit1)); });
+    test('Project descendents', async () => { await expectDescendentParity(await idOf(OHTS.project2)); });
+    test('Subject descendents', async () => { await expectDescendentParity(await idOf(OHTS.subject1)); });
+    test('Item descendents', async () => { await expectDescendentParity(await idOf(OHTS.item1)); });
+    test('CaptureData descendents', async () => { await expectDescendentParity(await idOf(OHTS.captureData1)); });
+    test('Model (master) descendents', async () => { await expectDescendentParity(await idOf(OHTS.model1)); });
+    test('Model (derived) descendents', async () => { await expectDescendentParity(await idOf(OHTS.model2)); });
+    test('Scene descendents', async () => { await expectDescendentParity(await idOf(OHTS.scene1)); });
+
+    test('Leaf (AssetVersion) yields only itself', async () => {
+        const id: number = await idOf(OHTS.assetVersion1c);
+        const actual: Set<number> = await DBAPI.SystemObjectXref.fetchDescendentIDs(id, 32);
+        expect(actual.has(id)).toBeTruthy();
+    });
+
+    test('Invalid input yields empty set', async () => {
+        const actual: Set<number> = await DBAPI.SystemObjectXref.fetchDescendentIDs(0, 32);
+        expect(actual.size).toEqual(0);
+    });
+});


### PR DESCRIPTION
* Split license DB writes from cache maintenance.
* Added batched descendant lookup for large subtrees.
* Moved license cache upkeep after commit.
* Added single-license cache invalidation helper.
* Added parity test for descendant traversal.
* Large license saves no longer time out.
* Rollbacks no longer leave phantom licenses.
* Moved updateObjectDetails license path outside transaction.