### PR TITLE
DPO3DPKRT-1022/Publish State Correctness Fix

### DIFF
--- a/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
+++ b/client/src/pages/Repository/components/DetailsView/ObjectDetails.tsx
@@ -303,7 +303,7 @@ function ObjectDetails(props: ObjectDetailsProps): React.ReactElement {
                                     <LoadingButton onClick={onPublish} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Public</LoadingButton>
                                     <LoadingButton onClick={onAPIOnly} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Public (Unlisted)</LoadingButton>
                                     <LoadingButton onClick={onInternal} className={classes.loadingBtn} loading={loading} disabled={!publishable}>Internal</LoadingButton>
-                                    {(isDraft || publishedEnum !== ePublishedState.eNotPublished) && (<LoadingButton onClick={onUnpublish} className={classes.loadingBtn} loading={loading}>Unpublish</LoadingButton>)}
+                                    {(publishedEnum !== ePublishedState.eNotPublished) && (<LoadingButton onClick={onUnpublish} className={classes.loadingBtn} loading={loading}>Unpublish</LoadingButton>)}
                                 </Box>
                             </Box>
                         }

--- a/server/collections/impl/PublishScene.ts
+++ b/server/collections/impl/PublishScene.ts
@@ -962,6 +962,11 @@ export class PublishScene {
         return { filename, url, type, title, name, attributes, category: COMMON.toEdanFileQuality(category) };
     }
 
+    // Completeness invariant: the detail page derives an object's *current* publication state from the
+    // eActionPublish / eActionUnpublish audit events, not from this field. This writer is reached only
+    // via ICol.publish, whose callers (publish.ts, RetireExecutorDeps.ts) emit that audit event. Any new
+    // path that flips SystemObjectVersion.PublishedState for a publish/unpublish must emit the matching
+    // event, or the displayed state silently diverges from what was persisted.
     private async updatePublishedState(LR: DBAPI.LicenseResolver | undefined, ePublishedStateIntended: COMMON.ePublishedState): Promise<boolean> {
         if (!this.systemObjectVersion)
             return false;

--- a/server/db/api/Audit.ts
+++ b/server/db/api/Audit.ts
@@ -361,4 +361,39 @@ export class Audit extends DBC.DBObject<AuditBase> implements AuditBase {
             return null;
         }
     }
+
+    /**
+     * Return the most recent publish or unpublish audit event for a SystemObject, or null when the
+     * object has none. These PROTECT-tier events (eActionPublish / eActionUnpublish) are the
+     * authoritative record of the object's *current* publication state: unlike
+     * SystemObjectVersion.PublishedState — which is reset to eNotPublished on every content edit and so
+     * cannot tell an edit apart from a real unpublish — an eActionUnpublish is unambiguously an
+     * unpublish, and each event carries after.eState plus a timestamp.
+     *
+     * Indexing: this runs on the existing @@index([idSystemObject, AuditDate]) — MariaDB seeks the
+     * object, walks the index backward in AuditDate order, and applies the AuditType IN (…) filter as a
+     * residual, stopping at the first match. No filesort, no full scan; the residual only scans the
+     * per-object audit rows newer than the last publication event, which is bounded and small. A
+     * dedicated index is deliberately avoided: Audit is an append-heavy hot table (a row on nearly every
+     * mutation), so any added index is paid on every insert to speed a read that runs once per
+     * detail-page load — a bad trade at current volumes, and it would be a schema migration this change
+     * is scoped to avoid. If profiling ever shows this lookup hot (e.g. a scene with heavy post-publish
+     * audit churn — the edited-after-publish/draft case this query serves), the correctly shaped index
+     * is (idSystemObject, AuditType, AuditDate) — NOT (idSystemObject, AuditType) alone, which would
+     * filter but still sort on AuditDate — added as its own isolated migration.
+     */
+    static async fetchLatestPublicationEvent(idSystemObject: number): Promise<Audit | null> {
+        if (!idSystemObject)
+            return null;
+        try {
+            return DBC.CopyObject<AuditBase, Audit>(
+                await DBC.DBConnection.prisma.audit.findFirst({
+                    where: { idSystemObject, AuditType: { in: [eAuditType.eActionPublish, eAuditType.eActionUnpublish] } },
+                    orderBy: [{ AuditDate: 'desc' }, { idAudit: 'desc' }],
+                }), Audit);
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB,'fetch latest publication event failed',H.Helpers.getErrorString(error),{ idSystemObject },'DB.Audit');
+            return null;
+        }
+    }
 }

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -156,7 +156,7 @@ export default async function getSystemObjectDetails(_: Parent, args: QueryGetSy
 
 // A published value is any state other than Not Published (Public / Public Unlisted / Internal).
 // Only these carry a live EDAN presence and can be drafted or unpublished.
-function isPublishedState(s: COMMON.ePublishedState): boolean {
+export function isPublishedState(s: COMMON.ePublishedState): boolean {
     return s === COMMON.ePublishedState.ePublished ||
         s === COMMON.ePublishedState.eAPIOnly ||
         s === COMMON.ePublishedState.eInternal;
@@ -165,7 +165,7 @@ function isPublishedState(s: COMMON.ePublishedState): boolean {
 // Read after.eState from a publish/unpublish audit payload (shape emitted by publish.ts /
 // RetireExecutorDeps.ts: { before, after: { eState, eStateName } }). Parsed defensively — an
 // unreadable or unknown payload yields null so the caller drops to the legacy version-chain read.
-function parsePublishedStateFromAudit(data: string | null): COMMON.ePublishedState | null {
+export function parsePublishedStateFromAudit(data: string | null): COMMON.ePublishedState | null {
     if (!data)
         return null;
     try {
@@ -179,6 +179,45 @@ function parsePublishedStateFromAudit(data: string | null): COMMON.ePublishedSta
     }
 }
 
+// Minimal SystemObjectVersion projection the derivation needs: identity (for chain ordering),
+// published state, and creation time (for draft-drift detection).
+export type PublishedStateVersion = {
+    idSystemObjectVersion: number;
+    published: COMMON.ePublishedState;
+    dateCreated: Date;
+};
+
+// Pure derivation of an object's CURRENT published state + draft flag from the latest publish/unpublish
+// audit event (its parsed after.eState `eventState` and timestamp `eventWhen`), the latest content
+// version, and the full version chain. No DB access, so the whole publish-state matrix is unit-testable.
+export function derivePublishedState(eventState: COMMON.ePublishedState | null, eventWhen: Date | null,
+    latest: PublishedStateVersion | null, allVersions: PublishedStateVersion[]): { publishedEnum: COMMON.ePublishedState; isDraft: boolean } {
+    // Audit-derived path: the event is the authoritative current state.
+    if (eventState !== null && eventWhen !== null) {
+        // Draft = currently published AND content has drifted since that publish. Publishing mutates a
+        // version in place without bumping DateCreated, so a published scene with no later edits has its
+        // latest SOV DateCreated before the event (not a draft); a subsequent edit rolls a newer SOV.
+        const isDraft: boolean = isPublishedState(eventState) && latest !== null
+            && latest.dateCreated.getTime() > eventWhen.getTime();
+        return { publishedEnum: eventState, isDraft };
+    }
+
+    // Legacy fallback (no usable audit event): compute from the version chain. Current state is the
+    // latest version's state; draft = latest version newer than the last published version and itself
+    // not published. No regression for un-audited objects; reconciled by the EDAN sync work.
+    const publishedEnum: COMMON.ePublishedState = latest ? latest.published : COMMON.ePublishedState.eNotPublished;
+    let isDraft: boolean = false;
+    if (allVersions.length > 0) {
+        const sorted = [...allVersions].sort((a, b) => b.idSystemObjectVersion - a.idSystemObjectVersion);
+        const latestV = sorted[0];
+        const lastPublished = sorted.find(v => isPublishedState(v.published)) ?? null;
+        if (lastPublished)
+            isDraft = latestV.idSystemObjectVersion > lastPublished.idSystemObjectVersion
+                && !isPublishedState(latestV.published);
+    }
+    return { publishedEnum, isDraft };
+}
+
 async function getPublishedState(idSystemObject: number, oID: DBAPI.ObjectIDAndType | undefined,
     LR: DBAPI.LicenseResolver | undefined): Promise<PublishedStateInfo> {
     // Current publication state is derived from the authoritative publish/unpublish audit trail rather
@@ -190,38 +229,24 @@ async function getPublishedState(idSystemObject: number, oID: DBAPI.ObjectIDAndT
     // record of publication-state changes: any future path that writes PublishedState for a
     // publish/unpublish MUST emit eActionPublish / eActionUnpublish (today only publish.ts and
     // RetireExecutorDeps.ts do), or this label silently breaks.
-    let publishedEnum: COMMON.ePublishedState;
-    let isDraft: boolean = false;
-
     const publicationEvent: DBAPI.Audit | null = await DBAPI.Audit.fetchLatestPublicationEvent(idSystemObject);
     const eventState: COMMON.ePublishedState | null = publicationEvent ? parsePublishedStateFromAudit(publicationEvent.Data) : null;
+    const useAudit: boolean = eventState !== null;
 
-    if (publicationEvent && eventState !== null) {
-        publishedEnum = eventState;
-        // Draft = currently published AND content has drifted since that publish. Publishing mutates a
-        // version in place without bumping DateCreated, so a published scene with no later edits has its
-        // latest SOV DateCreated before the event (not a draft); a subsequent edit rolls a newer SOV.
-        if (isPublishedState(publishedEnum)) {
-            const latest: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
-            if (latest)
-                isDraft = latest.DateCreated.getTime() > publicationEvent.AuditDate.getTime();
-        }
-    } else {
-        // Legacy fallback (no publish/unpublish audit event): compute from the version chain exactly as
-        // before. No regression for un-audited objects; reconciled by the EDAN sync work.
-        const systemObjectVersion: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
-        publishedEnum = systemObjectVersion ? systemObjectVersion.publishedStateEnum() : COMMON.ePublishedState.eNotPublished;
+    const latestSOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+    const latest: PublishedStateVersion | null = latestSOV
+        ? { idSystemObjectVersion: latestSOV.idSystemObjectVersion, published: latestSOV.publishedStateEnum(), dateCreated: latestSOV.DateCreated }
+        : null;
 
-        const allVersions: DBAPI.SystemObjectVersion[] | null = await DBAPI.SystemObjectVersion.fetchFromSystemObject(idSystemObject);
-        if (allVersions && allVersions.length > 0) {
-            const sorted = [...allVersions].sort((a, b) => b.idSystemObjectVersion - a.idSystemObjectVersion);
-            const latest = sorted[0];
-            const lastPublished = sorted.find(v => isPublishedState(v.publishedStateEnum())) ?? null;
-            if (lastPublished)
-                isDraft = latest.idSystemObjectVersion > lastPublished.idSystemObjectVersion
-                    && !isPublishedState(latest.publishedStateEnum());
-        }
+    // The full version chain is only consulted by the legacy fallback's draft computation.
+    let allVersions: PublishedStateVersion[] = [];
+    if (!useAudit) {
+        const versions: DBAPI.SystemObjectVersion[] | null = await DBAPI.SystemObjectVersion.fetchFromSystemObject(idSystemObject);
+        allVersions = (versions ?? []).map(v => ({ idSystemObjectVersion: v.idSystemObjectVersion, published: v.publishedStateEnum(), dateCreated: v.DateCreated }));
     }
+
+    const { publishedEnum, isDraft } = derivePublishedState(eventState,
+        useAudit && publicationEvent ? publicationEvent.AuditDate : null, latest, allVersions);
     const publishedState: string = COMMON.PublishedStateEnumToString(publishedEnum);
 
     let publishable: boolean = false;

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -154,28 +154,75 @@ export default async function getSystemObjectDetails(_: Parent, args: QueryGetSy
     };
 }
 
+// A published value is any state other than Not Published (Public / Public Unlisted / Internal).
+// Only these carry a live EDAN presence and can be drafted or unpublished.
+function isPublishedState(s: COMMON.ePublishedState): boolean {
+    return s === COMMON.ePublishedState.ePublished ||
+        s === COMMON.ePublishedState.eAPIOnly ||
+        s === COMMON.ePublishedState.eInternal;
+}
+
+// Read after.eState from a publish/unpublish audit payload (shape emitted by publish.ts /
+// RetireExecutorDeps.ts: { before, after: { eState, eStateName } }). Parsed defensively — an
+// unreadable or unknown payload yields null so the caller drops to the legacy version-chain read.
+function parsePublishedStateFromAudit(data: string | null): COMMON.ePublishedState | null {
+    if (!data)
+        return null;
+    try {
+        const parsed = JSON.parse(data);
+        const eState: unknown = parsed?.after?.eState;
+        if (typeof eState !== 'number' || COMMON.ePublishedState[eState] === undefined)
+            return null;
+        return eState as COMMON.ePublishedState;
+    } catch {
+        return null;
+    }
+}
+
 async function getPublishedState(idSystemObject: number, oID: DBAPI.ObjectIDAndType | undefined,
     LR: DBAPI.LicenseResolver | undefined): Promise<PublishedStateInfo> {
-    const systemObjectVersion: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
-    const publishedEnum: COMMON.ePublishedState = systemObjectVersion ? systemObjectVersion.publishedStateEnum() : COMMON.ePublishedState.eNotPublished;
-    const publishedState: string = COMMON.PublishedStateEnumToString(publishedEnum);
-
-    // A scene is a "draft" when the latest version is newer than the last published version
-    // and the latest version itself is not published.
+    // Current publication state is derived from the authoritative publish/unpublish audit trail rather
+    // than SystemObjectVersion.PublishedState. The version field is reset to eNotPublished on every
+    // content edit, so reading the latest version mislabels a still-live scene as Not Published, and
+    // reading the last-published version answers "was it ever published?" not "is it published now?"
+    // (an unpublish no-ops on an already-eNotPublished latest version, so it never registers). The
+    // audit events are unambiguous, timestamped, and PROTECT-tier (never pruned). This is the complete
+    // record of publication-state changes: any future path that writes PublishedState for a
+    // publish/unpublish MUST emit eActionPublish / eActionUnpublish (today only publish.ts and
+    // RetireExecutorDeps.ts do), or this label silently breaks.
+    let publishedEnum: COMMON.ePublishedState;
     let isDraft: boolean = false;
-    const allVersions: DBAPI.SystemObjectVersion[] | null = await DBAPI.SystemObjectVersion.fetchFromSystemObject(idSystemObject);
-    if (allVersions && allVersions.length > 0) {
-        const sorted = [...allVersions].sort((a, b) => b.idSystemObjectVersion - a.idSystemObjectVersion);
-        const latest = sorted[0];
-        const isPublished = (s: COMMON.ePublishedState): boolean =>
-            s === COMMON.ePublishedState.ePublished ||
-            s === COMMON.ePublishedState.eAPIOnly ||
-            s === COMMON.ePublishedState.eInternal;
-        const lastPublished = sorted.find(v => isPublished(v.publishedStateEnum())) ?? null;
-        if (lastPublished)
-            isDraft = latest.idSystemObjectVersion > lastPublished.idSystemObjectVersion
-                && !isPublished(latest.publishedStateEnum());
+
+    const publicationEvent: DBAPI.Audit | null = await DBAPI.Audit.fetchLatestPublicationEvent(idSystemObject);
+    const eventState: COMMON.ePublishedState | null = publicationEvent ? parsePublishedStateFromAudit(publicationEvent.Data) : null;
+
+    if (publicationEvent && eventState !== null) {
+        publishedEnum = eventState;
+        // Draft = currently published AND content has drifted since that publish. Publishing mutates a
+        // version in place without bumping DateCreated, so a published scene with no later edits has its
+        // latest SOV DateCreated before the event (not a draft); a subsequent edit rolls a newer SOV.
+        if (isPublishedState(publishedEnum)) {
+            const latest: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+            if (latest)
+                isDraft = latest.DateCreated.getTime() > publicationEvent.AuditDate.getTime();
+        }
+    } else {
+        // Legacy fallback (no publish/unpublish audit event): compute from the version chain exactly as
+        // before. No regression for un-audited objects; reconciled by the EDAN sync work.
+        const systemObjectVersion: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+        publishedEnum = systemObjectVersion ? systemObjectVersion.publishedStateEnum() : COMMON.ePublishedState.eNotPublished;
+
+        const allVersions: DBAPI.SystemObjectVersion[] | null = await DBAPI.SystemObjectVersion.fetchFromSystemObject(idSystemObject);
+        if (allVersions && allVersions.length > 0) {
+            const sorted = [...allVersions].sort((a, b) => b.idSystemObjectVersion - a.idSystemObjectVersion);
+            const latest = sorted[0];
+            const lastPublished = sorted.find(v => isPublishedState(v.publishedStateEnum())) ?? null;
+            if (lastPublished)
+                isDraft = latest.idSystemObjectVersion > lastPublished.idSystemObjectVersion
+                    && !isPublishedState(latest.publishedStateEnum());
+        }
     }
+    const publishedState: string = COMMON.PublishedStateEnumToString(publishedEnum);
 
     let publishable: boolean = false;
     let publishBlocker: string | null = null;

--- a/server/tests/audit/AuditPublicationEvent.test.ts
+++ b/server/tests/audit/AuditPublicationEvent.test.ts
@@ -1,0 +1,55 @@
+import * as DBC from '../../db/connection';
+import * as DBAPI from '../../db';
+import { eAuditType } from '../../db/api/ObjectType';
+
+describe('Audit.fetchLatestPublicationEvent', () => {
+    let findFirstSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        findFirstSpy = jest.spyOn(DBC.DBConnection.prisma.audit, 'findFirst');
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    test('queries only publish/unpublish types, newest first, and returns the row', async () => {
+        findFirstSpy.mockResolvedValueOnce({
+            idAudit: 7,
+            idUser: 1,
+            AuditDate: new Date('2026-07-01T00:00:00Z'),
+            AuditType: eAuditType.eActionUnpublish,
+            DBObjectType: null,
+            idDBObject: null,
+            idSystemObject: 500,
+            Data: '{"after":{"eState":0}}',
+            SystemActor: null,
+            CorrelationId: null,
+        });
+
+        const event = await DBAPI.Audit.fetchLatestPublicationEvent(500);
+
+        expect(event).not.toBeNull();
+        expect(event?.AuditType).toBe(eAuditType.eActionUnpublish);
+        expect(event?.idAudit).toBe(7);
+
+        const arg = findFirstSpy.mock.calls[0][0];
+        expect(arg.where.idSystemObject).toBe(500);
+        expect(arg.where.AuditType.in).toEqual([eAuditType.eActionPublish, eAuditType.eActionUnpublish]);
+        // Newest first: AuditDate desc, tie-broken by idAudit desc.
+        expect(arg.orderBy).toEqual([{ AuditDate: 'desc' }, { idAudit: 'desc' }]);
+    });
+
+    test('returns null when the object has no publication event', async () => {
+        findFirstSpy.mockResolvedValueOnce(null);
+        expect(await DBAPI.Audit.fetchLatestPublicationEvent(501)).toBeNull();
+    });
+
+    test('returns null on a falsy idSystemObject without hitting the DB', async () => {
+        expect(await DBAPI.Audit.fetchLatestPublicationEvent(0)).toBeNull();
+        expect(findFirstSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns null (not throw) when the query errors', async () => {
+        findFirstSpy.mockRejectedValueOnce(new Error('db down'));
+        expect(await DBAPI.Audit.fetchLatestPublicationEvent(502)).toBeNull();
+    });
+});

--- a/server/tests/audit/PublishStateDerivation.test.ts
+++ b/server/tests/audit/PublishStateDerivation.test.ts
@@ -1,0 +1,137 @@
+import * as COMMON from '@dpo-packrat/common';
+import {
+    derivePublishedState,
+    isPublishedState,
+    parsePublishedStateFromAudit,
+    PublishedStateVersion,
+} from '../../graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails';
+
+// Build a publish/unpublish audit payload string in the shape publish.ts / RetireExecutorDeps.ts emit.
+function auditData(afterState: COMMON.ePublishedState | null): string {
+    return JSON.stringify({
+        before: { eState: null, eStateName: null },
+        after: { eState: afterState, eStateName: afterState !== null ? COMMON.ePublishedState[afterState] : null },
+    });
+}
+
+function version(id: number, published: COMMON.ePublishedState, dateCreated: Date): PublishedStateVersion {
+    return { idSystemObjectVersion: id, published, dateCreated };
+}
+
+const PUBLISH_EVENT = new Date('2026-06-01T00:00:00Z');
+const BEFORE_PUBLISH = new Date('2026-05-01T00:00:00Z');
+const AFTER_PUBLISH = new Date('2026-07-01T00:00:00Z');
+
+describe('parsePublishedStateFromAudit', () => {
+    test('reads after.eState for a publish event', () => {
+        expect(parsePublishedStateFromAudit(auditData(COMMON.ePublishedState.ePublished)))
+            .toBe(COMMON.ePublishedState.ePublished);
+    });
+
+    test('reads eNotPublished (0) for an unpublish event', () => {
+        expect(parsePublishedStateFromAudit(auditData(COMMON.ePublishedState.eNotPublished)))
+            .toBe(COMMON.ePublishedState.eNotPublished);
+    });
+
+    test('null / empty / malformed / unknown payloads yield null (legacy fallback)', () => {
+        expect(parsePublishedStateFromAudit(null)).toBeNull();
+        expect(parsePublishedStateFromAudit('')).toBeNull();
+        expect(parsePublishedStateFromAudit('{not json')).toBeNull();
+        expect(parsePublishedStateFromAudit(JSON.stringify({ after: {} }))).toBeNull();
+        expect(parsePublishedStateFromAudit(JSON.stringify({ after: { eState: 999 } }))).toBeNull();
+        expect(parsePublishedStateFromAudit(JSON.stringify({ after: { eState: 'Published' } }))).toBeNull();
+    });
+});
+
+describe('isPublishedState', () => {
+    test('Public / Public-Unlisted / Internal are published; Not Published is not', () => {
+        expect(isPublishedState(COMMON.ePublishedState.ePublished)).toBe(true);
+        expect(isPublishedState(COMMON.ePublishedState.eAPIOnly)).toBe(true);
+        expect(isPublishedState(COMMON.ePublishedState.eInternal)).toBe(true);
+        expect(isPublishedState(COMMON.ePublishedState.eNotPublished)).toBe(false);
+    });
+});
+
+describe('derivePublishedState — audit-derived current state', () => {
+    // Case 1: published then unpublished -> latest event is the unpublish.
+    test('Case 1: publish then unpublish -> Not Published, no draft', () => {
+        const latest = version(2, COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH);
+        const result = derivePublishedState(COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH, latest, []);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.eNotPublished);
+        expect(result.isDraft).toBe(false);
+    });
+
+    // Case 3: published, then content edited -> still Public, and now a draft.
+    test('Case 3: published then edited (newer content) -> Public + draft', () => {
+        const latest = version(3, COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH); // edit rolled a fresh SOV
+        const result = derivePublishedState(COMMON.ePublishedState.ePublished, PUBLISH_EVENT, latest, []);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.ePublished);
+        expect(result.isDraft).toBe(true);
+    });
+
+    // Published with no later edit: latest SOV predates the publish event -> not a draft.
+    test('published, no later edit -> Public, no draft', () => {
+        const latest = version(1, COMMON.ePublishedState.ePublished, BEFORE_PUBLISH);
+        const result = derivePublishedState(COMMON.ePublishedState.ePublished, PUBLISH_EVENT, latest, []);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.ePublished);
+        expect(result.isDraft).toBe(false);
+    });
+
+    // Re-publish clears the draft: a fresh publish event newer than the latest content.
+    test('re-publish after edit -> draft cleared', () => {
+        const latest = version(3, COMMON.ePublishedState.eNotPublished, PUBLISH_EVENT);
+        const result = derivePublishedState(COMMON.ePublishedState.ePublished, AFTER_PUBLISH, latest, []);
+        expect(result.isDraft).toBe(false);
+    });
+
+    // Pathological: publish -> edit -> unpublish. The unpublish event wins; the version chain (whose
+    // last "published" row lingers) would wrongly report Public.
+    test('Pathological: publish, edit, unpublish -> Not Published, no draft', () => {
+        const latest = version(4, COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH);
+        const result = derivePublishedState(COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH, latest, []);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.eNotPublished);
+        expect(result.isDraft).toBe(false);
+    });
+
+    // Unpublished state never carries a draft suffix even if content is newer than the event.
+    test('unpublished with newer content -> not a draft', () => {
+        const latest = version(5, COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH);
+        const result = derivePublishedState(COMMON.ePublishedState.eNotPublished, PUBLISH_EVENT, latest, []);
+        expect(result.isDraft).toBe(false);
+    });
+});
+
+describe('derivePublishedState — legacy fallback (no audit event)', () => {
+    // Case 2: never published, no event, no published version.
+    test('Case 2: never published -> Not Published, no draft', () => {
+        const v1 = version(1, COMMON.ePublishedState.eNotPublished, BEFORE_PUBLISH);
+        const result = derivePublishedState(null, null, v1, [v1]);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.eNotPublished);
+        expect(result.isDraft).toBe(false);
+    });
+
+    // Legacy published-then-edited: latest version newer than the last published version and itself
+    // not published -> draft (mirrors the pre-existing version-chain heuristic).
+    test('legacy: latest newer than last-published and unpublished -> draft', () => {
+        const v1 = version(1, COMMON.ePublishedState.ePublished, BEFORE_PUBLISH);
+        const v2 = version(2, COMMON.ePublishedState.eNotPublished, AFTER_PUBLISH);
+        const result = derivePublishedState(null, null, v2, [v1, v2]);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.eNotPublished);
+        expect(result.isDraft).toBe(true);
+    });
+
+    // Legacy still-published latest -> current state Public, not a draft.
+    test('legacy: latest version is published -> Public, no draft', () => {
+        const v1 = version(1, COMMON.ePublishedState.ePublished, BEFORE_PUBLISH);
+        const result = derivePublishedState(null, null, v1, [v1]);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.ePublished);
+        expect(result.isDraft).toBe(false);
+    });
+
+    // No versions at all -> Not Published.
+    test('legacy: no versions -> Not Published', () => {
+        const result = derivePublishedState(null, null, null, []);
+        expect(result.publishedEnum).toBe(COMMON.ePublishedState.eNotPublished);
+        expect(result.isDraft).toBe(false);
+    });
+});


### PR DESCRIPTION
* Publish state now derives from audit history.
* Draft status reflects content changed after publishing.
* Legacy scenes fall back to version-chain logic.
* Live scenes no longer show Not Published incorrectly.
* Unpublish hidden when scene is not published.
* Draft label only appears beside published states.
* Extracted derivePublishedState for reusable testing.
* Added full publish-state matrix unit tests.
* Tested audit event fetching and payload parsing.