### PR TITLE
DPO3DPKRT-1023/Scene Version Derivatives + UX Quality of Life

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ JTConfig
 *.md
 tmp*-cwd
 .claude
+*.xlsx

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
@@ -21,7 +21,7 @@ import {
     // Theme,
     createStyles
 } from '@material-ui/core';
-import { Edit, Sync, CheckCircleOutline, Straighten } from '@material-ui/icons';
+import { Edit, Sync } from '@material-ui/icons';
 import { Alert } from '@material-ui/lab';
 import { makeStyles } from '@material-ui/core/styles';
 import API, { RequestResponse } from '../../../../../api';
@@ -31,6 +31,7 @@ interface QCStatus {
     status: string;
     level: 'pass' | 'warn' | 'fail' | 'critical' | 'info';
     notes: string;
+    approvable?: boolean;
 }
 interface EdanRecordIdRaw {
     svx: string | null;
@@ -75,6 +76,7 @@ interface QCRow {
     level: 'pass' | 'warn' | 'fail' | 'critical' | 'info';
     notes: string;
     tooltip: string;
+    approvable?: boolean;
 }
 interface SceneDetailsStatusProps {
     idSceneSO: number;
@@ -240,6 +242,7 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
                 level: row.level,
                 notes: (publishedNotes) ?? row.notes,
                 tooltip: qcRowTooltips[key as string] ?? '',
+                approvable: row.approvable,
             };
         });
     }, []);
@@ -453,17 +456,17 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
                                             </IconButton>
                                         </Tooltip>
                                     )}
-                                    {(row.key === 'arModels' || row.key === 'downloads') && row.status === 'Outdated' && (
+                                    {(row.key === 'arModels' || row.key === 'downloads') && row.approvable === true && (
                                         <Tooltip title='Verify / Approve'>
                                             <IconButton size='small' onClick={() => handleOpenApprove(row.key === 'arModels' ? 'ar' : 'downloads')}>
-                                                <CheckCircleOutline fontSize='small' />
+                                                <Edit fontSize='small' />
                                             </IconButton>
                                         </Tooltip>
                                     )}
                                     {row.key === 'scale' && (
                                         <Tooltip title='Set Display Units'>
                                             <IconButton size='small' onClick={handleOpenScale}>
-                                                <Straighten fontSize='small' />
+                                                <Edit fontSize='small' />
                                             </IconButton>
                                         </Tooltip>
                                     )}
@@ -531,10 +534,8 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
                 <DialogTitle>Verify {approveKind === 'ar' ? 'AR Models' : 'Download Models'}</DialogTitle>
                 <DialogContent>
                     <Typography variant='body2' style={{ marginBottom: 8 }}>
-                        These derivatives were generated before the 2024-06-14 Cook material fix, so
-                        Packrat flags them as possibly outdated. This is a <strong>date check</strong>,
-                        not a detected defect &mdash; the assets may be fine. Approving records a QA
-                        sign-off and clears the warning; it does not modify the assets.
+                        Approving signals that you have QC&apos;d these derivatives. This is a non-blocking
+                        sign-off &mdash; it does not prevent publishing and does not modify the assets.
                     </Typography>
                     <TextField
                         variant='outlined'

--- a/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsTab/SceneDetailsStatus.tsx
@@ -67,6 +67,7 @@ interface SceneQCData {
     edanUUID: QCStatus;
     edanRecordIdRaw?: EdanRecordIdRaw;
     scaleRaw?: ScaleRaw;
+    retired?: boolean;
     // network: QCStatus;
 }
 interface QCRow {
@@ -131,6 +132,7 @@ const mapSceneQCData = (d: any): SceneQCData => ({
     edanUUID: d.edanUUID,
     edanRecordIdRaw: d.edanRecordIdRaw,
     scaleRaw: d.scaleRaw,
+    retired: d.retired,
 });
 
 const UNIT_OPTIONS: string[] = ['mm', 'cm', 'm', 'km', 'in', 'ft', 'yd', 'mi'];
@@ -423,6 +425,12 @@ const SceneDetailsStatus = (props: SceneDetailsStatusProps): React.ReactElement 
 
     return (
         <div>
+            {data.retired && (
+                <Alert severity='info' style={{ marginBottom: 8 }}>
+                    This scene is <strong>retired</strong>. Publishing checks are not applicable &mdash; its
+                    derivatives are excluded from publishing and shown here for reference only.
+                </Alert>
+            )}
             <TableContainer component={Paper} className={classes.tableContainer}>
                 <Table>
                     <TableHead className={classes.tableHeader}>

--- a/client/src/pages/Repository/components/RepositoryFilterView/FilterBoolean.tsx
+++ b/client/src/pages/Repository/components/RepositoryFilterView/FilterBoolean.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable react/jsx-max-props-per-line */
+/**
+ * FilterBoolean
+ *
+ * A boolean filter control styled to match FilterSelect. Renders a labeled two-option
+ * dropdown (false/true) and writes the value to the repository store through the same
+ * updateFilterValue seam used by the other repository filters.
+ */
+import { Box, MenuItem, Select, InputLabel } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
+import { useRepositoryStore } from '../../../../store';
+import { HOME_ROUTES } from '../../../../constants';
+
+const useStyles = makeStyles(({ palette, breakpoints }) => ({
+    label: {
+        fontSize: '0.8em',
+        color: palette.primary.dark
+    },
+    select: {
+        width: 160,
+        height: 30,
+        marginLeft: 10,
+        fontSize: '0.8em',
+        color: palette.primary.dark,
+        borderRadius: 5,
+        border: `0.5px solid ${palette.primary.contrastText}`,
+        [breakpoints.down('lg')]: {
+            height: 26
+        }
+    },
+    icon: {
+        color: palette.primary.contrastText
+    }
+}));
+
+interface FilterBooleanProps {
+    label: string;
+    name: string;
+    falseLabel: string;
+    trueLabel: string;
+}
+
+function FilterBoolean(props: FilterBooleanProps): React.ReactElement {
+    const { label, name, falseLabel, trueLabel } = props;
+    const { href: url } = window.location;
+    let isModal: boolean = false;
+    if (url.includes('details') || url.includes(HOME_ROUTES.INGESTION))
+        isModal = true;
+
+    const classes = useStyles();
+
+    const [value, updateFilterValue] = useRepositoryStore(state => [state[name], state.updateFilterValue]);
+
+    const onChange = ({ target }) => {
+        updateFilterValue(name, target.value === 'true', isModal);
+    };
+
+    const inputProps = {
+        classes: {
+            icon: classes.icon
+        }
+    };
+
+    return (
+        <Box display='flex' alignItems='center' justifyContent='space-between' mb={1}>
+            <InputLabel id={name} className={classes.label} htmlFor={name}>
+                {label}
+            </InputLabel>
+            <Select
+                id={name}
+                value={value ? 'true' : 'false'}
+                className={classes.select}
+                name={name}
+                onChange={onChange}
+                disableUnderline
+                inputProps={inputProps}
+                SelectDisplayProps={{ style: { borderRadius: '5px' } }}
+            >
+                <MenuItem value='false'>{falseLabel}</MenuItem>
+                <MenuItem value='true'>{trueLabel}</MenuItem>
+            </Select>
+        </Box>
+    );
+}
+
+export default FilterBoolean;

--- a/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
@@ -270,6 +270,7 @@ function RepositoryFilterView(): React.ReactElement {
                         <FilterSelect multiple label='Top-Level Objects' name='repositoryRootType' options={repositoryRootTypesOptions} />
                         <FilterSelect multiple label='Children Objects' name='objectsToDisplay' options={objectToDisplayOptions} />
                         <FilterSelect multiple label='Metadata To Display' name='metadataToDisplay' options={metadataToDisplayOptions} />
+                        <FilterBoolean label='Retired' name='showRetired' falseLabel='Hide' trueLabel='Show' />
                     </Box>
 
                     <Box className={classes.selectContainer} width={225}>
@@ -287,7 +288,6 @@ function RepositoryFilterView(): React.ReactElement {
                             <FilterSelect multiple label='Model File Type' name='modelFileType' options={fileTypeOptions} />
                         </Box>
                         <FilterDate label='Date Created' name='dateCreated' />
-                        <FilterBoolean label='Retired' name='showRetired' falseLabel='Hide' trueLabel='Show' />
                     </Box>
                 </Box>
             </React.Fragment>

--- a/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryFilterView/index.tsx
@@ -22,6 +22,7 @@ import { eSystemObjectType, eVocabularySetID } from '@dpo-packrat/common';
 import { getDetailsUrlForObject, getTermForSystemObjectType } from '../../../../utils/repository';
 import FilterDate from './FilterDate';
 import FilterSelect from './FilterSelect';
+import FilterBoolean from './FilterBoolean';
 import { ChipOption, getRepositoryFilterOptions, eRepositoryChipFilterType, getTermForRepositoryFilterType } from './RepositoryFilterOptions';
 import { extractISOMonthDateYear } from '../../../../constants';
 import { HOME_ROUTES } from '../../../../constants';
@@ -286,6 +287,7 @@ function RepositoryFilterView(): React.ReactElement {
                             <FilterSelect multiple label='Model File Type' name='modelFileType' options={fileTypeOptions} />
                         </Box>
                         <FilterDate label='Date Created' name='dateCreated' />
+                        <FilterBoolean label='Retired' name='showRetired' falseLabel='Hide' trueLabel='Show' />
                     </Box>
                 </Box>
             </React.Fragment>

--- a/client/src/pages/Repository/components/RepositoryTreeView/TreeLabel.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/TreeLabel.tsx
@@ -15,6 +15,7 @@ import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
 import { palette } from '../../../../theme';
 import { getDetailsUrlForObject, getTermForSystemObjectType } from '../../../../utils/repository';
+import { retiredItemStyles } from '../../../../components/controls/RetiredFilterToggle';
 import MetadataView, { TreeViewColumn } from './MetadataView';
 
 interface TreeLabelProps {
@@ -22,6 +23,7 @@ interface TreeLabelProps {
     label?: React.ReactNode;
     objectType: number;
     color: string;
+    retired?: boolean;
     treeColumns: TreeViewColumn[];
     renderSelected?: boolean;
     selected?: boolean;
@@ -33,7 +35,7 @@ interface TreeLabelProps {
 
 // pass the event handler for clicking to this component
 function TreeLabel(props: TreeLabelProps): React.ReactElement {
-    const { idSystemObject, label, treeColumns, renderSelected = false, selected = false, onSelect, onUnSelect, objectType, makeStyles, color, nodeId } = props;
+    const { idSystemObject, label, treeColumns, renderSelected = false, selected = false, onSelect, onUnSelect, objectType, makeStyles, color, nodeId, retired = false } = props;
     const [waitTime, setWaitTime] = useState<NodeJS.Timeout[]>([]);
     const objectTitle = useMemo(() => `${getTermForSystemObjectType(objectType)} ${label}`, [objectType, label]);
     const navigate = useNavigate();
@@ -86,7 +88,7 @@ function TreeLabel(props: TreeLabelProps): React.ReactElement {
                         </Box>
                     )}
                     <div className={makeStyles?.labelText} style={{ backgroundColor: color }}>
-                        <span title={objectTitle} onClick={onClick} onAuxClick={onAuxClick}>{label}</span>
+                        <span title={objectTitle} onClick={onClick} onAuxClick={onAuxClick} style={retired ? retiredItemStyles.retiredText : undefined}>{label}{retired ? retiredItemStyles.retiredSuffix : ''}</span>
                     </div>
                 </div>
                 <MetadataView header={false} treeColumns={treeColumns} makeStyles={{ text: makeStyles?.text || '', column: makeStyles?.column || '' }} />

--- a/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
+++ b/client/src/pages/Repository/components/RepositoryTreeView/index.tsx
@@ -243,7 +243,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
 
         if (!children) return null;
         const items = children.map((child: NavigationResultEntryState, index: number) => {
-            const { idSystemObject, objectType, idObject, name, metadata, hierarchy } = child;
+            const { idSystemObject, objectType, idObject, name, metadata, hierarchy, retired } = child;
             let idSystemObjectParent: number = 0;
             if (parentNodeId) {
                 const { idSystemObject: idSystemObjectParentUpdated } = parseRepositoryTreeNodeId(parentNodeId);
@@ -303,6 +303,7 @@ function RepositoryTreeView(props: RepositoryTreeViewProps): React.ReactElement 
                     onUnSelect={unSelect}
                     objectType={objectType}
                     color={color}
+                    retired={retired === true}
                     treeColumns={treeColumns}
                     nodeId={nodeId}
                     makeStyles={{ container: classes.treeLabelContainer, label: classes.label, labelText: classes.labelText, column: classes.column, text: classes.text, options: classes.options, option: classes.option, link: classes.link }}

--- a/client/src/pages/Repository/hooks/useRepository.ts
+++ b/client/src/pages/Repository/hooks/useRepository.ts
@@ -30,6 +30,7 @@ function getObjectChildrenForRoot(filter: RepositoryFilter, idSystemObjects: num
                 modelFileType: filter.modelFileType,
                 dateCreatedFrom: filter.dateCreatedFrom,
                 dateCreatedTo: filter.dateCreatedTo,
+                showRetired: filter.showRetired ?? false,
                 rows,
                 cursorMark: filter.cursorMark ?? '',
                 start
@@ -59,6 +60,7 @@ function getObjectChildren(idRoots: number[], filter: RepositoryFilter): Promise
                 modelFileType: filter.modelFileType,
                 dateCreatedFrom: filter.dateCreatedFrom,
                 dateCreatedTo: filter.dateCreatedTo,
+                showRetired: filter.showRetired ?? false,
                 rows: 0, // load all children at once when a node is expanded (0 = all)
                 cursorMark: filter.cursorMark ?? ''
             }

--- a/client/src/pages/Repository/index.tsx
+++ b/client/src/pages/Repository/index.tsx
@@ -57,6 +57,7 @@ export type RepositoryFilter = {
     modelFileType: number[];
     dateCreatedFrom?: Date | string | null;
     dateCreatedTo?: Date | string | null;
+    showRetired?: boolean;
     cursorMark?: string | null;
     idRoots?: number[] | null;
     rootPage?: number;
@@ -106,6 +107,7 @@ function TreeViewPage(): React.ReactElement {
         modelFileType,
         dateCreatedFrom,
         dateCreatedTo,
+        showRetired,
         idRoots,
         rootPage,
         rootPageSize,
@@ -130,6 +132,7 @@ function TreeViewPage(): React.ReactElement {
             modelFileType: [],
             dateCreatedFrom: null,
             dateCreatedTo: null,
+            showRetired: false,
             idRoots: null,
             rootPage: 1,
             rootPageSize: 25
@@ -175,6 +178,7 @@ function TreeViewPage(): React.ReactElement {
         modelFileType,
         dateCreatedFrom,
         dateCreatedTo,
+        showRetired,
         idRoots,
         rootPage,
         rootPageSize

--- a/client/src/store/repository.ts
+++ b/client/src/store/repository.ts
@@ -47,12 +47,13 @@ type RepositoryStore = {
     modelFileType: number[];
     dateCreatedFrom: Date | string | null;
     dateCreatedTo: Date | string | null;
+    showRetired: boolean;
     idRoots: number[] | null;
     repositoryBrowserRootObjectType: string | null;
     repositoryBrowserRootName: string | null;
     getFilterState: () => RepositoryFilter;
     removeChipOption: (id: number, type: eRepositoryChipFilterType, isModal: boolean) => void;
-    updateFilterValue: (name: string, value: number | number[] | Date | null, isModal: boolean) => void;
+    updateFilterValue: (name: string, value: number | number[] | Date | boolean | null, isModal: boolean) => void;
     resetRepositoryFilter: (modifyCookie?: boolean, keepMetadata?: boolean) => void;
     resetKeywordSearch: () => void;
     initializeTree: () => Promise<void>;
@@ -98,10 +99,11 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
     modelFileType: [],
     dateCreatedFrom: null,
     dateCreatedTo: null,
+    showRetired: false,
     idRoots: null,
     repositoryBrowserRootObjectType: null,
     repositoryBrowserRootName: null,
-    updateFilterValue: (name: string, value: number | number[] | Date | null, isModal: boolean): void => {
+    updateFilterValue: (name: string, value: number | number[] | Date | boolean | null, isModal: boolean): void => {
         const { initializeTree, setCookieToState, keyword } = get();
         // A filter change re-queries from the first page of roots.
         set({ [name]: value, loading: true, search: keyword, rootPage: 1 });
@@ -337,6 +339,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             modelFileType: [],
             dateCreatedFrom: null,
             dateCreatedTo: null,
+            showRetired: false,
             idRoots: null,
             repositoryBrowserRootObjectType: null,
             repositoryBrowserRootName: null
@@ -366,7 +369,8 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             modelFileType,
             idRoots,
             dateCreatedFrom,
-            dateCreatedTo
+            dateCreatedTo,
+            showRetired
         } = get();
 
         return {
@@ -385,7 +389,8 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             modelFileType,
             idRoots,
             dateCreatedFrom,
-            dateCreatedTo
+            dateCreatedTo,
+            showRetired
         };
     },
     setCookieToState: (): void => {
@@ -404,6 +409,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             modelFileType,
             dateCreatedFrom,
             dateCreatedTo,
+            showRetired,
             idRoots
         } = getFilterState();
         const currentFilterState = {
@@ -420,6 +426,7 @@ export const useRepositoryStore = create<RepositoryStore>((set: SetState<Reposit
             modelFileType,
             dateCreatedFrom,
             dateCreatedTo,
+            showRetired,
             idRoots,
             rootPage,
             rootPageSize

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -856,6 +856,7 @@ export type GetObjectChildrenInput = {
   projects: Array<Scalars['Int']>;
   rows: Scalars['Int'];
   search: Scalars['String'];
+  showRetired?: InputMaybe<Scalars['Boolean']>;
   start?: InputMaybe<Scalars['Int']>;
   units: Array<Scalars['Int']>;
   variantType: Array<Scalars['Int']>;
@@ -1869,6 +1870,7 @@ export type NavigationResultEntry = {
   metadata: Array<Scalars['String']>;
   name: Scalars['String'];
   objectType: Scalars['Int'];
+  retired?: Maybe<Scalars['Boolean']>;
 };
 
 export type ObjectPropertyResult = {
@@ -3162,7 +3164,7 @@ export type GetObjectChildrenQueryVariables = Exact<{
 }>;
 
 
-export type GetObjectChildrenQuery = { __typename?: 'Query', getObjectChildren: { __typename?: 'GetObjectChildrenResult', success: boolean, error?: string | null, metadataColumns: Array<number>, cursorMark?: string | null, total?: number | null, entries: Array<{ __typename?: 'NavigationResultEntry', idSystemObject: number, name: string, objectType: number, idObject: number, metadata: Array<string> }> } };
+export type GetObjectChildrenQuery = { __typename?: 'Query', getObjectChildren: { __typename?: 'GetObjectChildrenResult', success: boolean, error?: string | null, metadataColumns: Array<number>, cursorMark?: string | null, total?: number | null, entries: Array<{ __typename?: 'NavigationResultEntry', idSystemObject: number, name: string, objectType: number, idObject: number, metadata: Array<string>, retired?: boolean | null }> } };
 
 export type GetIntermediaryFileQueryVariables = Exact<{
   input: GetIntermediaryFileInput;
@@ -5248,6 +5250,7 @@ export const GetObjectChildrenDocument = gql`
       objectType
       idObject
       metadata
+      retired
     }
     metadataColumns
     cursorMark

--- a/server/graphql/api/queries/repository/getObjectChildren.ts
+++ b/server/graphql/api/queries/repository/getObjectChildren.ts
@@ -11,6 +11,7 @@ const getObjectChildren = gql`
                 objectType
                 idObject
                 metadata
+                retired
             }
             metadataColumns
             cursorMark

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -775,6 +775,7 @@ input GetObjectChildrenInput {
   projects: [Int!]!
   rows: Int!
   search: String!
+  showRetired: Boolean
   start: Int
   units: [Int!]!
   variantType: [Int!]!
@@ -1598,6 +1599,7 @@ type NavigationResultEntry {
   metadata: [String!]!
   name: String!
   objectType: Int!
+  retired: Boolean
 }
 
 type ObjectPropertyResult {

--- a/server/graphql/schema/repository/queries.graphql
+++ b/server/graphql/schema/repository/queries.graphql
@@ -24,6 +24,7 @@ input GetObjectChildrenInput {
     rows: Int!
     cursorMark: String!
     start: Int
+    showRetired: Boolean
 }
 
 type NavigationResultEntry {
@@ -32,6 +33,7 @@ type NavigationResultEntry {
     objectType: Int!
     idObject: Int!
     metadata: [String!]!
+    retired: Boolean
 }
 
 type GetObjectChildrenResult {

--- a/server/graphql/schema/repository/resolvers/queries/getObjectChildren.ts
+++ b/server/graphql/schema/repository/resolvers/queries/getObjectChildren.ts
@@ -25,7 +25,8 @@ export default async function getObjectChildren(_: Parent, args: QueryGetObjectC
         dateCreatedTo,
         rows,
         cursorMark,
-        start
+        start,
+        showRetired
     } = args.input;
     const navigation: INavigation | null = await NavigationFactory.getInstance();
 
@@ -59,7 +60,8 @@ export default async function getObjectChildren(_: Parent, args: QueryGetObjectC
         dateCreatedTo: H.Helpers.safeDate(dateCreatedTo),       // convert ISO representation to Date
         rows,
         cursorMark,
-        start: start ?? undefined
+        start: start ?? undefined,
+        showRetired: showRetired ?? undefined
     };
 
     // Enforce authorization on the filter

--- a/server/graphql/schema/systemobject/resolvers/queries/getAssetDetailsForSystemObject.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getAssetDetailsForSystemObject.ts
@@ -49,7 +49,18 @@ export default async function getAssetDetailsForSystemObject(_: Parent, args: Qu
         eGridType = eAssetGridType.eScene;
         columns = AssetGridDetailScene.getColumns();
         await extractMetadata(idSystemObject, AssetGridDetailScene.getMetadataColumnNames(), metadataMetaMap);
-        await extractSceneAttachmentMetadata(SO.idScene, metadataMetaMap);
+        // Derivative models (downloads / AR / web-display) are separate SystemObjects linked to the scene
+        // via ModelSceneXref; their asset versions are not always bound into the scene's own
+        // SystemObjectVersion. Include them here so the grid is a complete overview of every asset
+        // associated with the scene, deduped against the versions already bound to the scene version.
+        const modelAssetVersions: DBAPI.AssetVersion[] = await extractSceneAttachmentMetadata(SO.idScene, metadataMetaMap);
+        const seenAssetVersions: Set<number> = new Set<number>(assetVersions.map(av => av.idAssetVersion));
+        for (const av of modelAssetVersions) {
+            if (!seenAssetVersions.has(av.idAssetVersion)) {
+                assetVersions.push(av);
+                seenAssetVersions.add(av.idAssetVersion);
+            }
+        }
     }
 
     let assetDetailPreferred: AssetGridDetailBase | null = null;
@@ -169,12 +180,15 @@ async function extractMetadata(idSystemObject: number, metadataColumns: string[]
     return true;
 }
 
-async function extractSceneAttachmentMetadata(idScene: number, metadataMetaMap: Map<number, Map<string, string>>): Promise<boolean> {
+async function extractSceneAttachmentMetadata(idScene: number, metadataMetaMap: Map<number, Map<string, string>>): Promise<DBAPI.AssetVersion[]> {
+    // Also returns the derivative-model asset versions collected here so the caller can include them
+    // as grid rows (not just apply metadata to rows that already exist).
+    const modelAssetVersions: DBAPI.AssetVersion[] = [];
     const MSXs: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromScene(idScene);
     // LOG.info(`getAssetDetailsForSystemObject MSXs ${H.Helpers.JSONStringify(MSXs)}`, LOG.LS.eGQL);
     if (!MSXs) {
         RK.logError(RK.LogSection.eGQL,'extract scene attachment metadata failed',`failed to fetch ModelSceneXref for scene ${idScene}`,{},'GraphQL.Schema.SystemObject');
-        return false;
+        return modelAssetVersions;
     }
 
     for (const MSX of MSXs) {
@@ -189,6 +203,7 @@ async function extractSceneAttachmentMetadata(idScene: number, metadataMetaMap: 
             continue;
 
         for (const assetVersion of assetVersions) {
+            modelAssetVersions.push(assetVersion);
             const SOIAV: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromAssetVersion(assetVersion);
             if (!SOIAV) {
                 RK.logError(RK.LogSection.eGQL,'extract scene attachment metadata failed','failed to fetch system object info for asset version',{ assetVersion },'GraphQL.Schema.SystemObject');
@@ -225,7 +240,7 @@ async function extractSceneAttachmentMetadata(idScene: number, metadataMetaMap: 
             // LOG.info(`getAssetDetailsForSystemObject metadataMap[${SOIAV.idSystemObject}]=${H.Helpers.JSONStringify(metadataMap)}`, LOG.LS.eGQL);
         }
     }
-    return true;
+    return modelAssetVersions;
 }
 
 function round(num: number): string {

--- a/server/http/routes/api/bulkOps/rebindSceneDerivatives.ts
+++ b/server/http/routes/api/bulkOps/rebindSceneDerivatives.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as DBAPI from '../../../../db';
+import { SceneHelpers } from '../../../../utils/sceneHelpers';
+import { RecordKeeper as RK } from '../../../../records/recordKeeper';
+import { BulkOperationDef, BulkOpRow, BulkOpGatherArgs, BulkOpReporter, BulkOpApplyResult } from './BulkOpTypes';
+
+async function sceneName(idSystemObject: number): Promise<string> {
+    const so = await DBAPI.SystemObject.fetch(idSystemObject);
+    if (so?.idScene) {
+        const scene = await DBAPI.Scene.fetch(so.idScene);
+        if (scene) return scene.Name;
+    }
+    return `SystemObject ${idSystemObject}`;
+}
+
+// The full candidate universe when the client does not scope the sweep to a project's scenes.
+async function candidateSystemObjectIds(): Promise<number[]> {
+    const scenes = await DBAPI.Scene.fetchAll();
+    if (!scenes) return [];
+    const ids: number[] = [];
+    for (const scene of scenes) {
+        const so = await DBAPI.SystemObject.fetchFromSceneID(scene.idScene);
+        if (so) ids.push(so.idSystemObject);
+    }
+    return ids;
+}
+
+// The derivative asset versions (idAsset) that are NOT bound to the scene's latest SystemObjectVersion.
+async function computeMissing(idSystemObject: number): Promise<{ derivativeCount: number; missing: DBAPI.AssetVersion[]; idLatestSOV: number } | null> {
+    const so = await DBAPI.SystemObject.fetch(idSystemObject);
+    if (!so || !so.idScene)
+        return null;
+    const latestSOV = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+    if (!latestSOV)
+        return null; // a scene with no version yet -- nothing to repair
+    const boundMap: Map<number, number> = (await DBAPI.SystemObjectVersionAssetVersionXref.fetchLatestAssetVersionMap(idSystemObject)) ?? new Map<number, number>();
+    const derivatives: DBAPI.AssetVersion[] = await SceneHelpers.getSceneDerivativeAssetVersions(idSystemObject);
+    const missing: DBAPI.AssetVersion[] = derivatives.filter(av => !boundMap.has(av.idAsset));
+    return { derivativeCount: derivatives.length, missing, idLatestSOV: latestSOV.idSystemObjectVersion };
+}
+
+// Read-only per-scene evaluation. Only scenes whose latest version is MISSING one or more current
+// derivative assets are shown (the ones needing repair); complete scenes are omitted.
+async function evaluateOne(idSystemObject: number): Promise<BulkOpRow | null> {
+    const gap = await computeMissing(idSystemObject);
+    if (!gap || gap.missing.length === 0)
+        return null;
+    const missingNames: string = gap.missing.map(av => av.FileName).sort().join(', ');
+    return {
+        id: idSystemObject,
+        name: await sceneName(idSystemObject),
+        isCandidate: true,
+        rowData: {
+            latestVersion: gap.idLatestSOV,
+            derivativeCount: gap.derivativeCount,
+            missingCount: gap.missing.length,
+            missing: missingNames || '—',
+        },
+    };
+}
+
+/**
+ * Repair scenes whose current version's asset manifest is missing derivative-model assets (downloads /
+ * AR / web) that are linked via ModelSceneXref. Gather sweeps scenes (all, or a client-scoped subset)
+ * and lists those with a gap; apply binds the missing derivatives into the scene's latest version
+ * in place -- no new version is created, so publish state is untouched.
+ */
+export const rebindSceneDerivatives: BulkOperationDef = {
+    key: 'rebindSceneDerivatives',
+    label: 'Rebind Scene Derivatives',
+    columns: [
+        { key: 'latestVersion', label: 'Latest Version' },
+        { key: 'derivativeCount', label: 'Derivatives (MSX)' },
+        { key: 'missingCount', label: 'Missing From Version' },
+        { key: 'missing', label: 'Missing Files' },
+    ],
+    rowSettings: [],
+    gather: async ({ scopedIds }: BulkOpGatherArgs, report: BulkOpReporter): Promise<BulkOpRow[]> => {
+        const ids: number[] = (scopedIds && scopedIds.length > 0) ? scopedIds : await candidateSystemObjectIds();
+        report(0, ids.length);
+        const rows: BulkOpRow[] = [];
+        let processed = 0;
+        for (const id of ids) {
+            const row = await evaluateOne(id);
+            if (row) rows.push(row);
+            report(++processed, ids.length);
+        }
+        return rows;
+    },
+    apply: async (idSystemObject: number, _rowSettings: any, idUser: number): Promise<BulkOpApplyResult> => {
+        const gap = await computeMissing(idSystemObject);
+        if (!gap)
+            return { success: false, message: 'not a scene, or no scene version to repair' };
+        if (gap.missing.length === 0)
+            return { success: true, message: 'already complete', rowData: { missingCount: 0, missing: '—' } };
+
+        const missingBefore: number = gap.missing.length;
+        // Bind into the current latest version in place (idempotent); no new SystemObjectVersion, so
+        // published state is not affected.
+        await SceneHelpers.ensureSceneDerivativeBindings(idSystemObject, gap.idLatestSOV);
+
+        const after = await computeMissing(idSystemObject);
+        const missingAfter: number = after ? after.missing.length : 0;
+        RK.logInfo(RK.LogSection.eHTTP,'rebind scene derivatives',`bound ${missingBefore - missingAfter} derivative(s) into scene version`,
+            { idSystemObject, idSystemObjectVersion: gap.idLatestSOV, missingBefore, missingAfter, idUser },'HTTP.Route.BulkOp');
+
+        return {
+            success: missingAfter === 0,
+            message: missingAfter === 0 ? `bound ${missingBefore} missing derivative(s)` : `bound ${missingBefore - missingAfter}, ${missingAfter} still missing`,
+            rowData: { missingCount: missingAfter, missing: after && after.missing.length > 0 ? after.missing.map(av => av.FileName).sort().join(', ') : '—' },
+        };
+    },
+};

--- a/server/http/routes/api/bulkOps/registry.ts
+++ b/server/http/routes/api/bulkOps/registry.ts
@@ -1,11 +1,13 @@
 import { BulkOperationDef } from './BulkOpTypes';
 import { fixDisplayUnits } from './fixDisplayUnits';
 import { syncFromEDAN } from './syncFromEDAN';
+import { rebindSceneDerivatives } from './rebindSceneDerivatives';
 
 // Registered bulk operations. A new op = a new entry here; the route and client are generic across all.
 export const OPERATIONS: Record<string, BulkOperationDef> = {
     [fixDisplayUnits.key]: fixDisplayUnits,
     [syncFromEDAN.key]: syncFromEDAN,
+    [rebindSceneDerivatives.key]: rebindSceneDerivatives,
 };
 
 export const OPERATION_LIST: { key: string; label: string }[] =

--- a/server/http/routes/api/object.ts
+++ b/server/http/routes/api/object.ts
@@ -28,7 +28,8 @@ type FieldStatus = {
     name: string,
     status: string,
     level: 'pass' | 'fail' | 'warn' | 'critical' | 'info',
-    notes: string
+    notes: string,
+    approvable?: boolean   // true when a reviewer may record a QC sign-off on this row (AR / Download derivatives that are present but not yet Verified)
 };
 
 const formatEdanResultField = (name: string, status: string, level: 'pass' | 'fail' | 'warn' | 'critical' | 'info', notes: string): FieldStatus => {
@@ -120,8 +121,8 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
     RK.profileEnd(profileKey);
 
     // helpers for determining state
-    const formatResultField = (name: string, status: string, level: 'pass' | 'fail' | 'warn' | 'critical' | 'info', notes: string): FieldStatus => {
-        return { name, status, level, notes };
+    const formatResultField = (name: string, status: string, level: 'pass' | 'fail' | 'warn' | 'critical' | 'info', notes: string, approvable?: boolean): FieldStatus => {
+        return { name, status, level, notes, approvable };
     };
     const getReviewedStatus = async (isReviewed: boolean): Promise<FieldStatus> => {
         const name = 'Is Reviewed';
@@ -335,12 +336,39 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         const date: Date = d instanceof Date ? d : new Date(String(d));
         return isNaN(date.getTime()) ? String(d) : date.toISOString().slice(0, 10);
     };
-    const getModelARStatus = async (status: string, licenseAllows: boolean): Promise<FieldStatus> => {
+    // Newest asset-version date across a derivative set (or null when empty), used to decide whether
+    // an approval still covers the current derivatives.
+    const latestDerivativeDate = (items: { dateModified: Date }[]): Date | null => {
+        let latest: Date | null = null;
+        for (const it of items) {
+            const d: Date = it.dateModified instanceof Date ? it.dateModified : new Date(String(it.dateModified));
+            if (!isNaN(d.getTime()) && (latest === null || d.getTime() > latest.getTime()))
+                latest = d;
+        }
+        return latest;
+    };
+    // An approval is honored only while it is at least as new as the newest derivative asset version.
+    // Regenerating a derivative after the sign-off makes the approval stale, reverting the row to the
+    // non-blocking "not yet approved" state until a reviewer approves again.
+    const isApprovalCurrent = (approvalDate: Date, latestDerivative: Date | null): boolean => {
+        if (latestDerivative === null)
+            return true;
+        const a: Date = approvalDate instanceof Date ? approvalDate : new Date(String(approvalDate));
+        return !isNaN(a.getTime()) && a.getTime() >= latestDerivative.getTime();
+    };
+    const getModelARStatus = async (status: string, licenseAllows: boolean, latestDerivative: Date | null): Promise<FieldStatus> => {
         const name = 'Models: AR';
 
         switch(status) {
-            case 'Good':
-                return { name, status: 'Found', level: 'pass', notes: 'all AR models found' };
+            case 'Good': {
+                // AR derivatives are present. Treat as pending QC until a reviewer signs off:
+                // a current approval audit row clears it to a neutral "Verified"; otherwise it stays a
+                // "Not yet approved" warning that still offers the approve action.
+                const approval = await DBAPI.Audit.fetchLastApproval(idSystemObject, DBAPI.eAuditType.eActionApproveARModels);
+                if (approval && isApprovalCurrent(approval.AuditDate, latestDerivative))
+                    return { name, status: 'Verified', level: 'pass', notes: `Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}` };
+                return { name, status: 'Found', level: 'warn', notes: 'all AR models found. Not yet approved — verify to record QC sign-off.', approvable: true };
+            }
             case 'Missing: WebAR':
                 return { name, status, level: 'fail', notes: 'WebXR models are generated with the scene. Try regenerating it from the source model page' };
             case 'Missing: NativeAR':
@@ -349,13 +377,13 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
                 return { name, status, level: (licenseAllows)?'fail':'warn', notes: 'no AR models found. Regenerate the scene and generate downloads' };
             default: {
                 if (status.startsWith('Error:')) {
-                    // Date-driven Outdated flag. Presence of an approval audit row clears it to a
-                    // neutral "Verified" state — no date comparison, no asset mutation. Non-date
-                    // failures fall through and are never cleared.
+                    // Date-driven Outdated flag. A current approval audit row clears it to a neutral
+                    // "Verified" state — no asset mutation. A stale approval (older than a regenerated
+                    // derivative) or non-date failures fall through and are not cleared.
                     const approval = await DBAPI.Audit.fetchLastApproval(idSystemObject, DBAPI.eAuditType.eActionApproveARModels);
-                    if (approval)
-                        return { name, status: 'Verified', level: 'info', notes: `Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}` };
-                    return { name, status: 'Outdated', level: 'warn', notes: `AR model may have material issues. Consider regenerating. (${status})` };
+                    if (approval && isApprovalCurrent(approval.AuditDate, latestDerivative))
+                        return { name, status: 'Verified', level: 'pass', notes: `Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}` };
+                    return { name, status: 'Outdated', level: 'warn', notes: `AR model may have material issues. Consider regenerating. (${status})`, approvable: true };
                 }
                 return { name, status: 'Error', level: 'critical', notes: `unexpected AR model status: ${status}` };
             }
@@ -369,14 +397,20 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         else
             return formatResultField(name,'Missing','fail',`${count}/${expected} base models found`);
     };
-    const getModelDownloadsStatus = async ( status: string, count: number, expected: number, licenseAllows: boolean): Promise<FieldStatus> => {
+    const getModelDownloadsStatus = async ( status: string, count: number, expected: number, licenseAllows: boolean, latestDerivative: Date | null): Promise<FieldStatus> => {
         const name = 'Download Models';
         const expectedCount = expected > 0 ? expected : 6;
 
         if(status === 'Good') {
-            if(licenseAllows===true)
-                return formatResultField(name,'Found','pass','all generated downloads found for scene and will be published');
-            else
+            if(licenseAllows===true) {
+                // Downloads are present and will publish. Treat as pending QC until a reviewer signs
+                // off: a current approval audit row clears it to "Verified"; otherwise it stays a
+                // "Not yet approved" warning that still offers the approve action.
+                const approval = await DBAPI.Audit.fetchLastApproval(idSystemObject, DBAPI.eAuditType.eActionApproveDownloadModels);
+                if(approval && isApprovalCurrent(approval.AuditDate, latestDerivative))
+                    return formatResultField(name,'Verified','pass',`Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}`);
+                return formatResultField(name,'Found','warn','all generated downloads found for scene and will be published. Not yet approved — verify to record QC sign-off.',true);
+            } else
                 return formatResultField(name,'Found','info','downloads exist but the license does not use them, so they <b><u>will not</u></b> be published. No action needed.');
         } else if(status === 'Missing') {
             // downloads are actually missing (count < 6)
@@ -386,14 +420,15 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
                 return formatResultField(name,'Missing','warn',`downloads not found (${count}/${expectedCount}). consider generating them.`);
         } else if(status === 'Error') {
             // downloads exist but may have material issues (created before June 14, 2024 Cook fix).
-            // Presence of an approval audit row clears the date flag to a neutral "Verified" state.
+            // A current approval audit row clears the date flag to a neutral "Verified" state; a stale
+            // approval (older than a regenerated download) falls through to the warning.
             const approval = await DBAPI.Audit.fetchLastApproval(idSystemObject, DBAPI.eAuditType.eActionApproveDownloadModels);
-            if(approval)
-                return formatResultField(name,'Verified','info',`Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}`);
+            if(approval && isApprovalCurrent(approval.AuditDate, latestDerivative))
+                return formatResultField(name,'Verified','pass',`Verified by ${approval.Name} on ${formatApprovalDate(approval.AuditDate)}`);
             if(licenseAllows===true)
-                return formatResultField(name,'Outdated','warn',`downloads found (${count}/${expectedCount}) but may have material issues. consider regenerating.`);
+                return formatResultField(name,'Outdated','warn',`downloads found (${count}/${expectedCount}) but may have material issues. consider regenerating.`,true);
             else
-                return formatResultField(name,'Outdated','warn',`downloads found (${count}/${expectedCount}) but may have issues. license does not allow publishing.`);
+                return formatResultField(name,'Outdated','warn',`downloads found (${count}/${expectedCount}) but may have issues. license does not allow publishing.`,true);
         } else {
             // fallback for unexpected status values
             if(licenseAllows===true)
@@ -497,9 +532,9 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         baseModels:
             getModelBaseStatus(sceneSummary.derivatives.models.status,sceneSummary.derivatives.models.items.length,sceneSummary.derivatives.models.expected ?? -1),
         downloads:
-            await getModelDownloadsStatus(sceneSummary.derivatives.downloads.status,sceneSummary.derivatives.downloads.items.length,sceneSummary.derivatives.downloads.expected ?? -1,doesLicenseAllowDownloads(licenseStatus.status)),
+            await getModelDownloadsStatus(sceneSummary.derivatives.downloads.status,sceneSummary.derivatives.downloads.items.length,sceneSummary.derivatives.downloads.expected ?? -1,doesLicenseAllowDownloads(licenseStatus.status),latestDerivativeDate(sceneSummary.derivatives.downloads.items)),
         arModels:
-            await getModelARStatus(sceneSummary.derivatives.ar.status,doesLicenseAllowDownloads(licenseStatus.status)),
+            await getModelARStatus(sceneSummary.derivatives.ar.status,doesLicenseAllowDownloads(licenseStatus.status),latestDerivativeDate(sceneSummary.derivatives.ar.items)),
         captureData:
             getCaptureDataStatus(sceneSummary.sources.captureData.items.length,sceneSummary.sources.captureData.expected ?? -1)
     };

--- a/server/http/routes/api/object.ts
+++ b/server/http/routes/api/object.ts
@@ -101,6 +101,11 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         return;
     }
 
+    // Retiring a scene cascades to its derivative models, which the summary then omits (they are
+    // excluded from publishing). Rather than reporting the derivatives as failing/Missing, a retired
+    // scene reframes those rows as a neutral "present but retired" state.
+    const sceneRetired: boolean = systemObject.Retired === true;
+
     // a scene must be linked to a parent Item (Media Group) to resolve its subject/project
     // ancestry; orphaned scenes (often legacy) cannot produce a QC summary. Detect this here so
     // the client receives a specific, actionable message instead of a generic build failure.
@@ -123,6 +128,15 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
     // helpers for determining state
     const formatResultField = (name: string, status: string, level: 'pass' | 'fail' | 'warn' | 'critical' | 'info', notes: string, approvable?: boolean): FieldStatus => {
         return { name, status, level, notes, approvable };
+    };
+    // Neutral (info-level) row for a retired scene: present derivatives read as "Found (retired)",
+    // absent ones as "None", and rows without a presence signal as "Retired" -- never a red failure.
+    const retiredRow = (name: string, present?: boolean): FieldStatus => {
+        if (present === true)
+            return { name, status: 'Found (retired)', level: 'info', notes: 'Present but retired; excluded from publishing.' };
+        if (present === false)
+            return { name, status: 'None', level: 'info', notes: 'Scene is retired; nothing to evaluate.' };
+        return { name, status: 'Retired', level: 'info', notes: 'Not evaluated while the scene is retired.' };
     };
     const getReviewedStatus = async (isReviewed: boolean): Promise<FieldStatus> => {
         const name = 'Is Reviewed';
@@ -501,10 +515,29 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
     const scaleResult = await computeSceneScaleStatus();
     //#endregion
 
+    // For a retired scene, determine which derivative kinds exist (retired or not) so the reframed rows
+    // can read "Found (retired)" vs "None". Uses ModelSceneXref usage/name directly, since the summary
+    // omits the (cascade-retired) models.
+    let hasBaseModels = false, hasDownloadModels = false, hasARModels = false;
+    if (sceneRetired) {
+        const retiredMSXs: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromScene(scene.idScene);
+        for (const msx of retiredMSXs ?? []) {
+            const usage: string = msx.Usage ?? '';
+            const quality: string = (msx.Quality ?? '').toLowerCase();
+            if (usage.includes('Web3D'))
+                hasBaseModels = true;
+            if (msx.isDownloadable())
+                hasDownloadModels = true;
+            if (usage === 'App3D' || usage === 'iOSApp3D' || (usage.includes('Web3D') && quality === 'ar'))
+                hasARModels = true;
+        }
+    }
+
     // return object structure
     const result = {
         idSystemObject: systemObject.idSystemObject,
         idScene: systemObject.idScene,
+        retired: sceneRetired,
 
         publishedUrl:
             getPublishedUrl(publishedStatus.status),
@@ -530,13 +563,17 @@ export async function getObjectStatus(req: Request, res: Response): Promise<void
         thumbnails:
             await getThumbnailsStatus(),
         baseModels:
-            getModelBaseStatus(sceneSummary.derivatives.models.status,sceneSummary.derivatives.models.items.length,sceneSummary.derivatives.models.expected ?? -1),
+            sceneRetired ? retiredRow('Models: Base', hasBaseModels)
+                : getModelBaseStatus(sceneSummary.derivatives.models.status,sceneSummary.derivatives.models.items.length,sceneSummary.derivatives.models.expected ?? -1),
         downloads:
-            await getModelDownloadsStatus(sceneSummary.derivatives.downloads.status,sceneSummary.derivatives.downloads.items.length,sceneSummary.derivatives.downloads.expected ?? -1,doesLicenseAllowDownloads(licenseStatus.status),latestDerivativeDate(sceneSummary.derivatives.downloads.items)),
+            sceneRetired ? retiredRow('Download Models', hasDownloadModels)
+                : await getModelDownloadsStatus(sceneSummary.derivatives.downloads.status,sceneSummary.derivatives.downloads.items.length,sceneSummary.derivatives.downloads.expected ?? -1,doesLicenseAllowDownloads(licenseStatus.status),latestDerivativeDate(sceneSummary.derivatives.downloads.items)),
         arModels:
-            await getModelARStatus(sceneSummary.derivatives.ar.status,doesLicenseAllowDownloads(licenseStatus.status),latestDerivativeDate(sceneSummary.derivatives.ar.items)),
+            sceneRetired ? retiredRow('Models: AR', hasARModels)
+                : await getModelARStatus(sceneSummary.derivatives.ar.status,doesLicenseAllowDownloads(licenseStatus.status),latestDerivativeDate(sceneSummary.derivatives.ar.items)),
         captureData:
-            getCaptureDataStatus(sceneSummary.sources.captureData.items.length,sceneSummary.sources.captureData.expected ?? -1)
+            sceneRetired ? retiredRow('Capture Data')
+                : getCaptureDataStatus(sceneSummary.sources.captureData.items.length,sceneSummary.sources.captureData.expected ?? -1)
     };
 
     // return success

--- a/server/navigation/impl/NavigationSolr/NavigationSolr.ts
+++ b/server/navigation/impl/NavigationSolr/NavigationSolr.ts
@@ -53,8 +53,9 @@ export class NavigationSolr implements NAV.INavigation {
     private async computeSolrNavQuery(filter: NAV.NavigationFilter): Promise<solr.Query> {
         let SQ: solr.Query = this._solrClientPackrat._client.query().edismax();    // use edismax query parser instead of lucene default
 
-        // For now, do not show retired assets to anyone:
-        SQ = SQ.matchFilter('CommonRetired', 0);
+        // Retired objects are hidden unless the caller opts in via the "Show retired" filter.
+        if (filter.showRetired !== true)
+            SQ = SQ.matchFilter('CommonRetired', 0);
 
         // search: string;                         // search string from the user -- for now, only apply to root-level queries, as well as queries of units, projects, and subjects
         if (filter.search && filter.idRoots.length === 0) {     // if we have a search string, apply it to root-level queries (i.e. with no specified filter root ID)
@@ -140,7 +141,7 @@ export class NavigationSolr implements NAV.INavigation {
         }
 
         // metadataColumns: COMMON.eMetadata[];           // empty array means give no metadata
-        const filterColumns: string[] = ['id', 'CommonObjectType', 'CommonidObject', 'CommonName']; // fetch standard fields // don't need ChildrenID
+        const filterColumns: string[] = ['id', 'CommonObjectType', 'CommonidObject', 'CommonName', 'CommonRetired']; // fetch standard fields // don't need ChildrenID
         for (const metadataColumn of filter.metadataColumns) {
             const filterColumn: string = COMMON.eMetadata[metadataColumn];
             if (filterColumn)
@@ -275,7 +276,8 @@ export class NavigationSolr implements NAV.INavigation {
                 name: doc.CommonName || '<UNKNOWN>',
                 objectType: DBAPI.SystemObjectNameToType(doc.CommonObjectType),
                 idObject: doc.CommonidObject,
-                metadata: this.computeNavMetadata(doc, filter.metadataColumns)
+                metadata: this.computeNavMetadata(doc, filter.metadataColumns),
+                retired: doc.CommonRetired === true
             };
 
             entries.push(entry);

--- a/server/navigation/interface/INavigation.ts
+++ b/server/navigation/interface/INavigation.ts
@@ -20,6 +20,7 @@ export type NavigationFilter = {
     rows: number;                           // max result row count; a value of 0 means "all"
     cursorMark: string;                     // a non-empty value indicates a cursor position through a set of result values, used to request the next set of values
     start?: number;                         // offset (Solr start) for numbered root-level pagination; used instead of cursorMark for root-level queries (idRoots empty)
+    showRetired?: boolean;                  // when true, include retired objects; otherwise retired objects are hidden (default)
 };
 
 export type NavigationResultEntry = {
@@ -28,6 +29,7 @@ export type NavigationResultEntry = {
     objectType: COMMON.eSystemObjectType;          // system object type of the entry (eProject, eUnit, eSubject, eItem, eCaptureData, etc.)
     idObject: number;                       // database ID of the object (e.g. Project.idProject, Unit.idUnit, Subject.idSubject, etc.)
     metadata: string[];                     // array of metadata values, in the order of NavigationResult.metadataColumns, matching the order of NavigationFilter.metadataColumns
+    retired?: boolean;                      // true when the object is retired; used to visually mark retired rows in the tree
 };
 
 export type NavigationResult = {

--- a/server/storage/interface/AssetStorageAdapter.ts
+++ b/server/storage/interface/AssetStorageAdapter.ts
@@ -485,6 +485,12 @@ export class AssetStorageAdapter {
         }
         IAR.systemObjectVersion = SOV;
 
+        // A scene version must include its current derivative-model assets (downloads / AR / web-display
+        // models linked via ModelSceneXref). cloneObjectAndXrefs only carries forward what its clone source
+        // held -- and starts from an empty set when assetsUnzipped -- so re-bind the current derivative set
+        // here. No-op for non-scene system objects.
+        await SceneHelpers.ensureSceneDerivativeBindings(ingestAssetInput.idSystemObject, SOV.idSystemObjectVersion);
+
         if (doNotUpdateParentVersion !== true) {
             // Complex system object version patch up step here
             // Scenes own Models, Models own Assets; those assets are *also* part of the scene's system object version
@@ -496,6 +502,8 @@ export class AssetStorageAdapter {
                         const SOV: DBAPI.SystemObjectVersion | null = await DBAPI.SystemObjectVersion.cloneObjectAndXrefs(idSystemObject, null, Comment, assetVersionOverrideMap, IAR.assetsUnzipped);
                         if (!SOV)
                             RK.logError(RK.LogSection.eSTR,'ingest asset failed','failed to create new SystemObjectVersion',{ ...context },'AssetStorageAdapter');
+                        else
+                            await SceneHelpers.ensureSceneDerivativeBindings(idSystemObject, SOV.idSystemObjectVersion);
                     }
                 }
             } else

--- a/server/tests/collections/BulkOpRebindSceneDerivatives.test.ts
+++ b/server/tests/collections/BulkOpRebindSceneDerivatives.test.ts
@@ -1,0 +1,166 @@
+import * as DBAPI from '../../db';
+import { SceneHelpers } from '../../utils/sceneHelpers';
+import { BulkOpJob } from '../../http/routes/api/bulkOps/BulkOpTypes';
+import { rebindSceneDerivatives } from '../../http/routes/api/bulkOps/rebindSceneDerivatives';
+
+const AV = (idAsset: number, idAssetVersion: number, FileName: string): DBAPI.AssetVersion =>
+    ({ idAsset, idAssetVersion, FileName } as DBAPI.AssetVersion);
+
+describe('SceneHelpers.getSceneDerivativeAssetVersions', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test('collects non-retired derivative asset versions, skipping retired models', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.ModelSceneXref, 'fetchFromScene').mockResolvedValue([
+            { idModel: 10 }, { idModel: 11 }, { idModel: 12 },
+        ] as unknown as DBAPI.ModelSceneXref[]);
+        jest.spyOn(DBAPI.SystemObject, 'fetchFromModelID').mockImplementation(async (idModel: number) => {
+            if (idModel === 10) return { idSystemObject: 100, Retired: false } as DBAPI.SystemObject;
+            if (idModel === 11) return { idSystemObject: 110, Retired: false } as DBAPI.SystemObject;
+            return { idSystemObject: 120, Retired: true } as DBAPI.SystemObject; // idModel 12 is retired
+        });
+        const av1 = AV(1, 11, 'a.glb');
+        const av2 = AV(2, 22, 'b.zip');
+        const fetchAV = jest.spyOn(DBAPI.AssetVersion, 'fetchLatestFromSystemObject').mockImplementation(async (idSO: number) => {
+            if (idSO === 100) return [av1];
+            if (idSO === 110) return [av2];
+            return null;
+        });
+
+        const result = await SceneHelpers.getSceneDerivativeAssetVersions(1000);
+        expect(result).toEqual([av1, av2]);
+        // the retired model's SystemObject (120) is never queried for assets
+        expect(fetchAV).not.toHaveBeenCalledWith(120);
+    });
+
+    test('returns [] for a non-scene system object', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: null } as unknown as DBAPI.SystemObject);
+        expect(await SceneHelpers.getSceneDerivativeAssetVersions(1000)).toEqual([]);
+    });
+});
+
+describe('SceneHelpers.ensureSceneDerivativeBindings', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test('binds only the derivatives missing from the version', async () => {
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions').mockResolvedValue([AV(1, 11, 'a.glb'), AV(2, 22, 'b.zip')]);
+        // av1 already bound to this version; av2 missing
+        jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'fetchAssetVersionMap')
+            .mockResolvedValue(new Map<number, number>([[1, 11]]));
+        const addOrUpdate = jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'addOrUpdate')
+            .mockResolvedValue({} as DBAPI.SystemObjectVersionAssetVersionXref);
+
+        const count = await SceneHelpers.ensureSceneDerivativeBindings(1000, 500);
+        expect(count).toBe(1);
+        expect(addOrUpdate).toHaveBeenCalledTimes(1);
+        expect(addOrUpdate).toHaveBeenCalledWith(500, 2, 22); // only the missing derivative
+    });
+
+    test('is a no-op when every derivative is already bound to that version', async () => {
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions').mockResolvedValue([AV(1, 11, 'a.glb')]);
+        jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'fetchAssetVersionMap')
+            .mockResolvedValue(new Map<number, number>([[1, 11]]));
+        const addOrUpdate = jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'addOrUpdate')
+            .mockResolvedValue({} as DBAPI.SystemObjectVersionAssetVersionXref);
+
+        const count = await SceneHelpers.ensureSceneDerivativeBindings(1000, 500);
+        expect(count).toBe(0);
+        expect(addOrUpdate).not.toHaveBeenCalled();
+    });
+
+    test('rebinds a derivative whose asset version changed', async () => {
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions').mockResolvedValue([AV(1, 12, 'a.glb')]); // now v12
+        jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'fetchAssetVersionMap')
+            .mockResolvedValue(new Map<number, number>([[1, 11]])); // version had the older v11
+        const addOrUpdate = jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'addOrUpdate')
+            .mockResolvedValue({} as DBAPI.SystemObjectVersionAssetVersionXref);
+
+        const count = await SceneHelpers.ensureSceneDerivativeBindings(1000, 500);
+        expect(count).toBe(1);
+        expect(addOrUpdate).toHaveBeenCalledWith(500, 1, 12);
+    });
+
+    test('returns 0 without touching bindings when there are no derivatives', async () => {
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions').mockResolvedValue([]);
+        const addOrUpdate = jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'addOrUpdate');
+        expect(await SceneHelpers.ensureSceneDerivativeBindings(1000, 500)).toBe(0);
+        expect(addOrUpdate).not.toHaveBeenCalled();
+    });
+});
+
+describe('Bulk op: Rebind Scene Derivatives', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test('gather lists only scenes whose latest version is missing derivatives', async () => {
+        jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue([{ idScene: 1 }, { idScene: 2 }] as unknown as DBAPI.Scene[]);
+        jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID')
+            .mockImplementation(async (idScene: number) => ({ idSystemObject: idScene * 1000 } as DBAPI.SystemObject));
+        jest.spyOn(DBAPI.SystemObject, 'fetch')
+            .mockImplementation(async (idSystemObject: number) => ({ idScene: idSystemObject / 1000 } as DBAPI.SystemObject));
+        jest.spyOn(DBAPI.Scene, 'fetch')
+            .mockImplementation(async (idScene: number) => ({ Name: `Scene ${idScene}` } as DBAPI.Scene));
+        jest.spyOn(DBAPI.SystemObjectVersion, 'fetchLatestFromSystemObject')
+            .mockImplementation(async (idSystemObject: number) => ({ idSystemObjectVersion: idSystemObject + 1 } as DBAPI.SystemObjectVersion));
+
+        // Scene 1 (idSO 1000): derivative b.zip present in MSX, bound set empty → missing.
+        // Scene 2 (idSO 2000): derivative c.glb present in MSX and bound → complete (omitted).
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions')
+            .mockImplementation(async (idSO: number) => (idSO === 1000 ? [AV(2, 22, 'b.zip')] : [AV(3, 33, 'c.glb')]));
+        jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'fetchLatestAssetVersionMap')
+            .mockImplementation(async (idSO: number) => (idSO === 1000 ? new Map<number, number>() : new Map<number, number>([[3, 33]])));
+
+        const started = await BulkOpJob.run(rebindSceneDerivatives, { params: {} });
+        expect(started).toBe(true);
+        expect(BulkOpJob.progress.phase).toBe('completed');
+        expect(BulkOpJob.progress.total).toBe(2); // both scenes swept
+
+        const rows = BulkOpJob.rows;
+        expect(rows).toHaveLength(1); // only the one needing repair is shown
+        const row = rows.find(r => r.id === 1000);
+        expect(row?.isCandidate).toBe(true);
+        expect(row?.rowData.derivativeCount).toBe(1);
+        expect(row?.rowData.missingCount).toBe(1);
+        expect(row?.rowData.missing).toBe('b.zip');
+        expect(row?.rowData.latestVersion).toBe(1001);
+    });
+
+    test('apply binds the missing derivatives into the latest version in place', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.SystemObjectVersion, 'fetchLatestFromSystemObject')
+            .mockResolvedValue({ idSystemObjectVersion: 1001 } as DBAPI.SystemObjectVersion);
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions').mockResolvedValue([AV(2, 22, 'b.zip')]);
+        // before apply: missing; after apply: bound
+        jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'fetchLatestAssetVersionMap')
+            .mockResolvedValueOnce(new Map<number, number>())
+            .mockResolvedValueOnce(new Map<number, number>([[2, 22]]));
+        const ensure = jest.spyOn(SceneHelpers, 'ensureSceneDerivativeBindings').mockResolvedValue(1);
+
+        const res = await rebindSceneDerivatives.apply(1000, {}, 1, {});
+        expect(ensure).toHaveBeenCalledWith(1000, 1001); // in place, into the latest version
+        expect(res.success).toBe(true);
+        expect(res.message).toContain('bound 1');
+        expect(res.rowData.missingCount).toBe(0);
+    });
+
+    test('apply is a no-op when the scene version is already complete', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.SystemObjectVersion, 'fetchLatestFromSystemObject')
+            .mockResolvedValue({ idSystemObjectVersion: 1001 } as DBAPI.SystemObjectVersion);
+        jest.spyOn(SceneHelpers, 'getSceneDerivativeAssetVersions').mockResolvedValue([AV(2, 22, 'b.zip')]);
+        jest.spyOn(DBAPI.SystemObjectVersionAssetVersionXref, 'fetchLatestAssetVersionMap')
+            .mockResolvedValue(new Map<number, number>([[2, 22]]));
+        const ensure = jest.spyOn(SceneHelpers, 'ensureSceneDerivativeBindings').mockResolvedValue(0);
+
+        const res = await rebindSceneDerivatives.apply(1000, {}, 1, {});
+        expect(res.success).toBe(true);
+        expect(res.message).toBe('already complete');
+        expect(ensure).not.toHaveBeenCalled();
+    });
+
+    test('apply fails cleanly for a non-scene system object', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: null } as unknown as DBAPI.SystemObject);
+        const res = await rebindSceneDerivatives.apply(1000, {}, 1, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toContain('not a scene');
+    });
+});

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -853,6 +853,7 @@ export type GetObjectChildrenInput = {
   projects: Array<Scalars['Int']>;
   rows: Scalars['Int'];
   search: Scalars['String'];
+  showRetired?: InputMaybe<Scalars['Boolean']>;
   start?: InputMaybe<Scalars['Int']>;
   units: Array<Scalars['Int']>;
   variantType: Array<Scalars['Int']>;
@@ -1866,6 +1867,7 @@ export type NavigationResultEntry = {
   metadata: Array<Scalars['String']>;
   name: Scalars['String'];
   objectType: Scalars['Int'];
+  retired?: Maybe<Scalars['Boolean']>;
 };
 
 export type ObjectPropertyResult = {

--- a/server/utils/sceneHelpers.ts
+++ b/server/utils/sceneHelpers.ts
@@ -879,6 +879,72 @@ export class SceneHelpers {
         return results;
     }
 
+    /**
+     * Ensure a scene SystemObjectVersion's asset manifest includes the current, non-retired
+     * derivative-model asset versions (downloads / AR / web-display models) linked via ModelSceneXref.
+     * Those models are separate SystemObjects, so their assets are not the scene's own assets and are
+     * only present in a scene version when explicitly bound. A freshly cloned scene version (e.g. from a
+     * WebDAV save, attachment ingest, SVX edit, re-ingest, or a zip rebuild) carries forward only what
+     * the clone source held; this re-binds the current derivative set so every new scene version is a
+     * complete snapshot. Idempotent (addOrUpdate) and additive. Returns the number of bindings written.
+     */
+    static async ensureSceneDerivativeBindings(idSceneSystemObject: number, idSystemObjectVersion: number): Promise<number> {
+        if (!idSceneSystemObject || !idSystemObjectVersion)
+            return 0;
+
+        const assetVersions: DBAPI.AssetVersion[] = await SceneHelpers.getSceneDerivativeAssetVersions(idSceneSystemObject);
+        if (assetVersions.length === 0)
+            return 0;
+
+        // Only write bindings that are missing or point at an older asset version -- keeps this a no-op on
+        // the hot re-version path (e.g. repeated WebDAV saves) once a scene's manifest is already complete.
+        const boundMap: Map<number, number> = (await DBAPI.SystemObjectVersionAssetVersionXref.fetchAssetVersionMap(idSystemObjectVersion)) ?? new Map<number, number>();
+        let count: number = 0;
+        for (const assetVersion of assetVersions) {
+            if (boundMap.get(assetVersion.idAsset) === assetVersion.idAssetVersion)
+                continue; // already bound to this exact version
+
+            const bound: DBAPI.SystemObjectVersionAssetVersionXref | null =
+                await DBAPI.SystemObjectVersionAssetVersionXref.addOrUpdate(idSystemObjectVersion, assetVersion.idAsset, assetVersion.idAssetVersion);
+            if (bound)
+                count++;
+            else
+                RK.logError(RK.LogSection.eSYS,'ensure scene derivative bindings','failed to bind derivative asset version to scene version',
+                    { idSceneSystemObject, idSystemObjectVersion, idAsset: assetVersion.idAsset, idAssetVersion: assetVersion.idAssetVersion },'Utils.Scene');
+        }
+        return count;
+    }
+
+    /**
+     * The current, non-retired derivative-model (ModelSceneXref-linked) asset versions for a scene:
+     * downloads, native AR, and web-display models. These belong to separate model SystemObjects, so
+     * they are the assets that must be re-bound into a scene version to make it a complete snapshot.
+     * Returns [] for a non-scene system object.
+     */
+    static async getSceneDerivativeAssetVersions(idSceneSystemObject: number): Promise<DBAPI.AssetVersion[]> {
+        const result: DBAPI.AssetVersion[] = [];
+        if (!idSceneSystemObject)
+            return result;
+        const SO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSceneSystemObject);
+        if (!SO || !SO.idScene)
+            return result; // only scenes carry ModelSceneXref-linked derivatives
+
+        const MSXs: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromScene(SO.idScene);
+        if (!MSXs)
+            return result;
+
+        for (const MSX of MSXs) {
+            const modelSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromModelID(MSX.idModel);
+            if (!modelSO || modelSO.Retired)
+                continue; // skip retired derivative models -- they are not part of the current snapshot
+
+            const assetVersions: DBAPI.AssetVersion[] | null = await DBAPI.AssetVersion.fetchLatestFromSystemObject(modelSO.idSystemObject);
+            if (assetVersions)
+                result.push(...assetVersions);
+        }
+        return result;
+    }
+
     /** idAssetVersion is the assetversion ID of the ingested object */
     static async handleComplexIngestionScene(scene: DBAPI.Scene, IAR: STORE.IngestAssetResult,
         idUser?: number | undefined, idAssetVersion?: number | undefined, modelSource?: DBAPI.Model | undefined): Promise<H.IOResults & { transformUpdated: boolean }> {


### PR DESCRIPTION
- Add Show/Hide Retired filter and remember the setting.
- Clearly style and label retired items in the repository.
- Show all model derivatives in the scene asset grid.
- Approve all present AR and download files from the scene.
- Reset approval when derivatives are regenerated.
- Re-link scene derivatives when content is re-versioned.
- Add a backfill tool for missing scene derivative links.
- Dry runs identify scenes with missing derivatives.
- ZIP re-ingest keeps existing downloads and AR files.
- Warn on unapproved derivatives without blocking.
- Show approved AR and download files as passed.
- Retired scenes show neutral QC messaging, not failures.
- Keep QC, Asset, and Related derivative status consistent.