### PR TITLE
DPO3DPKRT-1025/Cook Recipe Validation + Scene Basename Fix

### DIFF
--- a/server/http/routes/api/bulkOps/fixSceneBasenames.ts
+++ b/server/http/routes/api/bulkOps/fixSceneBasenames.ts
@@ -1,0 +1,252 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as DBAPI from '../../../../db';
+import * as STORE from '../../../../storage/interface';
+import { cookOutputSuffixes } from '../../../../job/impl/Cook/CookOutputContract';
+import { NameHelpers, UNKNOWN_NAME } from '../../../../utils/nameHelpers';
+import { RecordKeeper as RK } from '../../../../records/recordKeeper';
+import { BulkOperationDef, BulkOpRow, BulkOpGatherArgs, BulkOpReporter, BulkOpApplyResult } from './BulkOpTypes';
+
+const SRC = 'HTTP.Route.BulkOp.FixSceneBasenames';
+
+// The endsWith-form suffixes of every Cook-output asset (6 downloads + the .svx.json descriptor),
+// sourced from the shared CookOutputContract so this stays aligned with the guards it recovers from.
+const COOK_SUFFIXES: string[] = cookOutputSuffixes('si-generate-downloads');
+
+function matchingSuffix(fileName: string): string | undefined {
+    return COOK_SUFFIXES.find(s => fileName.endsWith(s));
+}
+
+// The classification of a scene's Cook-output basenames.
+//   fixable    — one uniform old basename that differs from the canonical Subject.Name; safe to rename.
+//   consistent — outputs already carry the canonical basename.
+//   mixed      — outputs carry more than one basename (a half-completed prior state); not a clean rename.
+//   unresolved — canonical Subject.Name can't be derived (multi-subject / ambiguous hierarchy); such
+//                scenes take the source-filename basename, which a subject rename does not change, so
+//                a uniform one is not "affected" by this issue.
+//   no-outputs — no Cook-output assets to evaluate.  not-scene — the object is not a scene.
+type SceneStatus = 'not-scene' | 'no-outputs' | 'consistent' | 'fixable' | 'mixed' | 'unresolved';
+
+interface StateInfo {
+    status: SceneStatus;
+    canonical: string | null;
+    bases: string[];                                              // distinct output basenames
+    fileCount: number;                                           // number of Cook-output assets
+    renames: { asset: DBAPI.Asset; from: string; to: string }[]; // populated only for 'fixable'
+    reason: string;                                             // human-readable, for the report / refusal
+}
+
+async function sceneFromSystemObject(idSystemObject: number): Promise<DBAPI.Scene | null> {
+    const so = await DBAPI.SystemObject.fetch(idSystemObject);
+    if (!so || !so.idScene)
+        return null;
+    return DBAPI.Scene.fetch(so.idScene);
+}
+
+async function sceneName(idSystemObject: number): Promise<string> {
+    const scene = await sceneFromSystemObject(idSystemObject);
+    return scene ? scene.Name : `SystemObject ${idSystemObject}`;
+}
+
+// The full candidate universe when the client does not scope the sweep to a project's scenes.
+async function candidateSceneSystemObjectIds(): Promise<number[]> {
+    const scenes = await DBAPI.Scene.fetchAll();
+    if (!scenes) return [];
+    const ids: number[] = [];
+    for (const scene of scenes) {
+        const so = await DBAPI.SystemObject.fetchFromSceneID(scene.idScene);
+        if (so) ids.push(so.idSystemObject);
+    }
+    return ids;
+}
+
+// The canonical scene basename Generate Downloads would derive right now: for a single-subject scene
+// this resolves to the Subject's Name (sceneDisplayName('', [MH]) -> subject.Name). Returns null for
+// every case where that is NOT confidently the Subject.Name — a master model that is absent/ambiguous,
+// an unresolvable hierarchy, or multiple subjects.
+async function computeCanonicalBaseName(idScene: number): Promise<string | null> {
+    const masters = await DBAPI.Model.fetchMasterFromScene(idScene);
+    if (!masters || masters.length !== 1)
+        return null;
+    const MH = await NameHelpers.computeModelHierarchy(masters[0]);
+    if (!MH)
+        return null;
+    if (!MH.subjects || MH.subjects.length !== 1)
+        return null;
+    const base: string = NameHelpers.sceneDisplayName('', [MH]); // '' = no user subtitle, matching generation
+    if (!base || base === UNKNOWN_NAME)
+        return null;
+    return NameHelpers.sanitizeFileName(base);
+}
+
+// Classify a scene by its Cook-output basenames vs the canonical Subject.Name.
+async function computeState(idSystemObject: number): Promise<StateInfo> {
+    const base = (status: SceneStatus, reason: string): StateInfo => ({ status, canonical: null, bases: [], fileCount: 0, renames: [], reason });
+
+    const scene = await sceneFromSystemObject(idSystemObject);
+    if (!scene)
+        return base('not-scene', 'not a scene');
+
+    const assets = await DBAPI.Asset.fetchFromScene(scene.idScene);
+    const outputs: { asset: DBAPI.Asset; suffix: string; base: string }[] = [];
+    for (const a of (assets ?? [])) {
+        const suffix = matchingSuffix(a.FileName);
+        if (suffix)
+            outputs.push({ asset: a, suffix, base: a.FileName.slice(0, a.FileName.length - suffix.length) });
+    }
+    if (outputs.length === 0)
+        return base('no-outputs', 'no Cook-output assets to evaluate');
+
+    const bases: string[] = [...new Set(outputs.map(o => o.base))];
+    const fileCount: number = outputs.length;
+    const canonical = await computeCanonicalBaseName(scene.idScene);
+
+    if (bases.length > 1)
+        return { status: 'mixed', canonical, bases, fileCount, renames: [],
+            reason: `outputs carry ${bases.length} distinct basenames (${bases.join(', ')}); not a single clean rename` };
+
+    // exactly one uniform output basename
+    if (!canonical)
+        return { status: 'unresolved', canonical: null, bases, fileCount, renames: [],
+            reason: 'canonical Subject.Name could not be resolved (multi-subject or ambiguous hierarchy)' };
+    if (bases[0] === canonical)
+        return { status: 'consistent', canonical, bases, fileCount, renames: [], reason: '' };
+
+    const renames = outputs.map(o => ({ asset: o.asset, from: o.asset.FileName, to: `${canonical}${o.suffix}` }));
+    return { status: 'fixable', canonical, bases, fileCount, renames, reason: `${bases[0]} → ${canonical}` };
+}
+
+function statusLabel(status: SceneStatus): string {
+    switch (status) {
+        case 'fixable':    return 'Fixable';
+        case 'mixed':      return 'Mixed basenames (manual)';
+        case 'consistent': return 'Consistent';
+        case 'unresolved': return 'Name unresolved (manual)';
+        default:           return status;
+    }
+}
+
+async function toRow(idSystemObject: number, state: StateInfo): Promise<BulkOpRow> {
+    const details: string = state.status === 'fixable'
+        ? state.renames.map(r => `${r.from} → ${r.to}`).sort().join(', ')
+        : state.reason;
+    return {
+        id: idSystemObject,
+        name: await sceneName(idSystemObject),
+        isCandidate: state.status === 'fixable', // only fixable rows are selectable; the rest are report-only
+        rowData: {
+            status: statusLabel(state.status),
+            canonicalName: state.canonical ?? '—',
+            currentBasename: state.bases.join(', '),
+            fileCount: state.fileCount,
+            details,
+        },
+    };
+}
+
+/**
+ * Recover a scene whose download/SVX asset filenames drifted from the current Subject.Name (the state
+ * that makes the Generate Downloads pre-flight guard and the scene-generation SVX check hard block
+ * after a subject is renamed). `apply` renames each Cook-output asset to the canonical basename via
+ * AssetStorageAdapter.renameAsset — an OCFL-aware rename creating a new, non-destructive AssetVersion.
+ *
+ * Scope param:
+ *   - `fixable`  (default) — list only scenes we can confidently repair (selectable).
+ *   - `affected` (report-only) — additionally list scenes that are affected but NOT auto-fixable
+ *     (mixed basenames), each with a Status + reason so the extent and cause are visible. Only
+ *     `fixable` rows are selectable; the report rows can be seen but not acted on.
+ *
+ * Confidence gate (both gather and apply): the op only acts on a single, uniform Subject.Name rename
+ * — canonical resolves to exactly one Subject.Name AND every Cook-output asset shares one old
+ * basename that differs from it. Multi-subject / ambiguous-hierarchy and mixed-basename scenes are
+ * refused, not guessed at. (Multi-subject scenes take the source-filename basename, which a subject
+ * rename does not change, so a uniform one is not affected and is not listed even in `affected`.)
+ *
+ * Scope boundary: renames the download and SVX *filenames* only. It does NOT rename derivative model
+ * records or re-point the SVX's internal `asset.uri` values, so it does not by itself clear the deeper
+ * scene-generation model-name fork. It unblocks Generate Downloads and the SVX-filename check.
+ */
+export const fixSceneBasenames: BulkOperationDef = {
+    key: 'fixSceneBasenames',
+    label: 'Fix Scene Basenames',
+    columns: [
+        { key: 'status', label: 'Status' },
+        { key: 'canonicalName', label: 'Canonical Name (Subject)' },
+        { key: 'currentBasename', label: 'Current Basename(s)' },
+        { key: 'fileCount', label: 'Cook Output Files' },
+        { key: 'details', label: 'Details' },
+    ],
+    rowSettings: [],
+    params: [{
+        key: 'mode',
+        label: 'Scope',
+        type: 'select',
+        options: [
+            { value: 'fixable', label: 'Fixable only' },
+            { value: 'affected', label: 'All affected (report-only)' },
+        ],
+        default: 'fixable',
+    }],
+    gather: async ({ scopedIds, params }: BulkOpGatherArgs, report: BulkOpReporter): Promise<BulkOpRow[]> => {
+        const mode: string = (params && params.mode === 'affected') ? 'affected' : 'fixable';
+        const ids: number[] = (scopedIds && scopedIds.length > 0) ? scopedIds : await candidateSceneSystemObjectIds();
+        report(0, ids.length);
+        const rows: BulkOpRow[] = [];
+        let processed = 0;
+        for (const id of ids) {
+            const state = await computeState(id);
+            const include: boolean = mode === 'affected'
+                ? (state.status === 'fixable' || state.status === 'mixed')
+                : (state.status === 'fixable');
+            if (include)
+                rows.push(await toRow(id, state));
+            report(++processed, ids.length);
+        }
+        return rows;
+    },
+    apply: async (idSystemObject: number, _rowSettings: any, idUser: number): Promise<BulkOpApplyResult> => {
+        const state = await computeState(idSystemObject);
+
+        if (state.status === 'consistent')
+            return { success: true, message: 'already consistent', rowData: { status: 'Consistent', fileCount: 0, details: '—' } };
+        if (state.status !== 'fixable')
+            return { success: false, message: `refused: ${state.reason || state.status}` };
+
+        const user = await DBAPI.User.fetch(idUser);
+        const opInfo: STORE.OperationInfo = {
+            message: `Fix scene basenames → ${state.canonical}`,
+            idUser,
+            userEmailAddress: user?.EmailAddress ?? '',
+            userName: user?.Name ?? '',
+        };
+
+        const renamed: string[] = [];
+        const failed: string[] = [];
+        for (const r of state.renames) {
+            const ASR = await STORE.AssetStorageAdapter.renameAsset(r.asset, r.to, opInfo);
+            if (ASR.success)
+                renamed.push(`${r.from} → ${r.to}`);
+            else {
+                failed.push(r.from);
+                RK.logError(RK.LogSection.eHTTP,'fix scene basenames','asset rename failed',
+                    { idSystemObject, from: r.from, to: r.to, error: ASR.error, idUser },SRC);
+            }
+        }
+
+        const after = await computeState(idSystemObject);
+        const remaining: number = after.status === 'fixable' ? after.renames.length : 0;
+        RK.logInfo(RK.LogSection.eHTTP,'fix scene basenames',`renamed ${renamed.length} asset(s), ${remaining} remaining`,
+            { idSystemObject, canonicalName: state.canonical, renamed, failed, idUser },SRC);
+
+        return {
+            success: failed.length === 0 && remaining === 0,
+            message: failed.length === 0
+                ? `renamed ${renamed.length} asset(s) to ${state.canonical}`
+                : `renamed ${renamed.length}, ${failed.length} failed`,
+            rowData: {
+                status: statusLabel(after.status),
+                fileCount: remaining,
+                details: after.status === 'fixable' ? after.renames.map(r => `${r.from} → ${r.to}`).sort().join(', ') : '—',
+            },
+        };
+    },
+};

--- a/server/http/routes/api/bulkOps/registry.ts
+++ b/server/http/routes/api/bulkOps/registry.ts
@@ -2,12 +2,14 @@ import { BulkOperationDef } from './BulkOpTypes';
 import { fixDisplayUnits } from './fixDisplayUnits';
 import { syncFromEDAN } from './syncFromEDAN';
 import { rebindSceneDerivatives } from './rebindSceneDerivatives';
+import { fixSceneBasenames } from './fixSceneBasenames';
 
 // Registered bulk operations. A new op = a new entry here; the route and client are generic across all.
 export const OPERATIONS: Record<string, BulkOperationDef> = {
     [fixDisplayUnits.key]: fixDisplayUnits,
     [syncFromEDAN.key]: syncFromEDAN,
     [rebindSceneDerivatives.key]: rebindSceneDerivatives,
+    [fixSceneBasenames.key]: fixSceneBasenames,
 };
 
 export const OPERATION_LIST: { key: string; label: string }[] =

--- a/server/job/impl/Cook/CookOutputContract.ts
+++ b/server/job/impl/Cook/CookOutputContract.ts
@@ -1,0 +1,70 @@
+import * as COMMON from '@dpo-packrat/common';
+
+// Recipe-aware description of the files a Cook run is expected to produce for a scene, and the
+// single basename rule shared by the pre-flight guard (before a job is submitted) and the post-Cook
+// verification (after a job returns). Keeping both paths on this one rule is the point of the file:
+// the pre-flight guard must not accept a run the post-Cook check will later reject.
+
+export type CookRecipeKey = 'si-generate-downloads' | 'si-voyager-scene';
+
+// The scene descriptor is expected alongside the downloads but is not itself a download. Its extname
+// is '.json', so it is not part of COMMON.cookDownloadSuffixes and must be listed explicitly.
+const SVX_SUFFIX: string = '.svx.json';
+
+export interface CookOutputPrediction {
+    filenames: string[];   // predicted output filenames, all sharing sceneBaseName
+    closed: boolean;       // true = the full output set is known (downloads); false = open set (scene gen)
+}
+
+export interface BasenameOffender {
+    suffix: string;        // the Cook suffix both files share
+    expected: string;      // the name the current run will produce (predicted, or Cook's actual output)
+    actual: string;        // the existing scene asset that carries the same suffix and differs
+}
+
+// The endsWith-form suffixes that identify a recipe's outputs. si-generate-downloads emits the six
+// CookDownloadDescriptors plus the SVX descriptor; si-voyager-scene's output set is open (1 SVX + N
+// SVX-named Web3D models) and only the SVX name is Packrat-dictated, so it is the only asserted name.
+export function cookOutputSuffixes(recipe: CookRecipeKey): string[] {
+    switch (recipe) {
+        case 'si-generate-downloads': return [...COMMON.cookDownloadSuffixes('full'), SVX_SUFFIX];
+        case 'si-voyager-scene':      return [SVX_SUFFIX];
+    }
+}
+
+// Predict the filenames a Cook run will produce for a scene, from its basename. Cook names every
+// output `${outputFileBaseName}${suffix}`, so the download set is fully predictable pre-submission.
+// Scene generation only predicts the SVX name; its derivative names are consumed verbatim from the
+// returned SVX and are never derived or asserted by Packrat.
+export function predictCookOutput(recipe: CookRecipeKey, sceneBaseName: string): CookOutputPrediction {
+    switch (recipe) {
+        case 'si-generate-downloads':
+            return {
+                filenames: [
+                    ...COMMON.cookDownloadSuffixes('full').map(suffix => `${sceneBaseName}${suffix}`),
+                    `${sceneBaseName}${SVX_SUFFIX}`,
+                ],
+                closed: true,
+            };
+        case 'si-voyager-scene':
+            return { filenames: [`${sceneBaseName}${SVX_SUFFIX}`], closed: false };
+    }
+}
+
+// The shared basename rule. For each candidate filename (a predicted name pre-flight, or a Cook
+// output post-Cook), find the existing scene asset that carries the same Cook suffix; if one exists
+// and its filename differs, that is an offender. Absence of a same-suffix asset is never an offender
+// (first-run and partial-set scenes must pass). Reports every offender, not just the first.
+export function findBasenameOffenders(recipe: CookRecipeKey, candidateFilenames: string[], existingFilenames: string[]): BasenameOffender[] {
+    const suffixes: string[] = cookOutputSuffixes(recipe);
+    const offenders: BasenameOffender[] = [];
+    for (const candidate of candidateFilenames) {
+        const suffix: string | undefined = suffixes.find(s => candidate.endsWith(s));
+        if (!suffix)
+            continue; // not a recognized output for this recipe; the basename rule does not apply
+        const existing: string | undefined = existingFilenames.find(f => f.endsWith(suffix));
+        if (existing && existing !== candidate)
+            offenders.push({ suffix, expected: candidate, actual: existing });
+    }
+    return offenders;
+}

--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 import { JobCook } from './JobCook';
 import { CookRecipe } from './CookRecipe';
+import { findBasenameOffenders, BasenameOffender } from './CookOutputContract';
 import { Config } from '../../../config';
 
 import * as JOB from '../../interface';
@@ -1108,24 +1109,20 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         const sceneAssetFilenames: string[] = sceneAssets.map(asset => asset.FileName);
         RK.logDebug(RK.LogSection.eJOB,'verify Cook data',undefined, { jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, sceneAssetFilenames, fileMap },'Job.GenerateDownloads');
 
-        // cycle through returned downloads seeing if we have a similar file already in the scene
-        // if so, then we check to see if they have the same basename. If not, then we fail and the
-        // scene needs to be rebuilt.
-        const assetsToReplace: string[] = [];
-        for(let i=0; i<incomingFilenames.length; i++) {
-            const filename: string = incomingFilenames[i];
-            const suffix: string | undefined = suffixes.find(s => filename.endsWith(s) );
-            if(!suffix)
-                return this.logError('verify Cook data','could not find suffix in verified filenames',{ fileName: filename });
+        // For each returned download, if the scene already holds an asset with the same Cook suffix,
+        // its basename must match. A mismatch means the scene/model was renamed and re-running Cook
+        // would orphan the old set. This delegates to the shared CookOutputContract rule that the
+        // pre-flight guard (WorkflowEngine.verifyDownloadBasenameConsistency) also runs, so the two
+        // paths cannot diverge. Absence of a same-suffix asset is not an offender.
+        const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', incomingFilenames, sceneAssetFilenames);
+        if(offenders.length > 0)
+            return this.logError('verify Cook data','incoming download has different basename than existing asset', { offenders });
 
-            // find the existing scene asset with the same suffix and check it's basename
-            const matchingAsset: DBAPI.Asset | undefined = sceneAssets.find(asset => asset.FileName.endsWith(suffix) );
-            if(matchingAsset)
-                if(filename!=matchingAsset.FileName)
-                    return this.logError('verify Cook data','incoming download has different basename than existing asset', { fileName: filename, matchingAsset });
-                else
-                    assetsToReplace.push(filename);
-        }
+        // count how many incoming downloads replace an existing same-suffix asset (for the info log)
+        const assetsToReplace: string[] = incomingFilenames.filter(filename => {
+            const suffix: string | undefined = suffixes.find(s => filename.endsWith(s));
+            return suffix !== undefined && sceneAssetFilenames.some(existing => existing.endsWith(suffix));
+        });
 
         RK.logInfo(RK.LogSection.eJOB,'verify Cook data','verified', { jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, logInfo: sceneSource.fetchLogInfo(), numFilesNew: (incomingFilenames.length-assetsToReplace.length), numFilesUpdated: assetsToReplace.length },'Job.GenerateDownloads');
         return { success: true };

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -183,8 +183,8 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
 
     constructor(jobEngine: JOB.IJobEngine, idAssetVersions: number[] | null, report: REP.IReport | null,
         parameters: JobCookSIVoyagerSceneParameters, dbJobRun: DBAPI.JobRun) {
-        super(jobEngine, Config.job.cookClientId, 'si-vogager-scene',
-            CookRecipe.getCookRecipeID('si-vogager-scene', '512211e5-f2e8-4723-93e9-e30116c88ab0'),
+        super(jobEngine, Config.job.cookClientId, 'si-voyager-scene',
+            CookRecipe.getCookRecipeID('si-voyager-scene', '512211e5-f2e8-4723-93e9-e30116c88ab0'),
             null, idAssetVersions, report, dbJobRun);
 
         if (parameters.skipJobCleanup) {
@@ -266,22 +266,34 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
         if (!scenes)
             return this.logError('create system objects failed','unable to fetch children scenes of model', { idModel: modelSource.idModel });
 
-        // If needed, create a new scene (if we have no scenes, or if we have multiple scenes, then create a new one);
-        // If we have just one scene, before reusing it, see if the model names all match up
-        let createScene: boolean = (scenes.length !== 1);
-        if (!createScene && scenes.length > 0 && svx.SvxExtraction.modelDetails) {
+        // Decide whether to create a new scene or reuse the single existing one. A model source with
+        // no child scene legitimately creates its first scene. Reusing an existing scene must never
+        // silently fork a duplicate against the same model source: a model-name mismatch means a
+        // rename propagated into Cook's derivative names, so we block rather than fork, and a model
+        // source that already carries multiple scenes is refused rather than compounded (each such
+        // run would otherwise fork again). Recovery from a rename is the Fix Scene Basenames op.
+        if (scenes.length > 1)
+            return this.logError('create system objects failed',
+                `model source has ${scenes.length} child scenes; refusing to create another to avoid compounding duplicates (manual remediation required)`,
+                { idModel: modelSource.idModel, sceneCount: scenes.length });
+
+        if (scenes.length === 1 && svx.SvxExtraction.modelDetails) {
             for (const MSX of svx.SvxExtraction.modelDetails) {
-                if (MSX.Name) {
-                    // look for existing models, children of our scene, that match this model's purpose
-                    const model: DBAPI.Model | null = await this.findMatchingModel(scenes[0], MSX.computeModelAutomationTag());
-                    if (!model || (model.Name !== MSX.Name)) {
-                        createScene = true;
-                        break;
-                    }
-                }
+                if (!MSX.Name)
+                    continue;
+                // match by automation tag (model purpose), which is stable across a display-name
+                // rename. A missing match is not a fork trigger: the reuse path below creates the
+                // model on the existing scene. Only a present model whose Name differs signals a
+                // rename that would otherwise fork.
+                const model: DBAPI.Model | null = await this.findMatchingModel(scenes[0], MSX.computeModelAutomationTag());
+                if (model && model.Name !== MSX.Name)
+                    return this.logError('create system objects failed',
+                        `existing scene model "${model.Name}" does not match Cook output "${MSX.Name}"; a rename was detected. Refusing to fork a duplicate scene (run Fix Scene Basenames to remediate)`,
+                        { idModel: modelSource.idModel, idScene: scenes[0].idScene, expectedModelName: MSX.Name, existingModelName: model.Name, automationTag: MSX.computeModelAutomationTag() });
             }
         }
 
+        const createScene: boolean = (scenes.length === 0);
         const scene: DBAPI.Scene = createScene ? svx.SvxExtraction.extractScene() : scenes[0];
 
         let asset: DBAPI.Asset | null = null;

--- a/server/job/impl/Cook/index.ts
+++ b/server/job/impl/Cook/index.ts
@@ -4,3 +4,4 @@ export * from './JobCookSIPackratInspect';
 export * from './JobCookSIVoyagerScene';
 export * from './CookRecipe';
 export * from './CookResource';
+export * from './CookOutputContract';

--- a/server/tests/collections/BulkOpFixSceneBasenames.test.ts
+++ b/server/tests/collections/BulkOpFixSceneBasenames.test.ts
@@ -1,0 +1,202 @@
+import * as DBAPI from '../../db';
+import * as STORE from '../../storage/interface';
+import { NameHelpers, ModelHierarchy } from '../../utils/nameHelpers';
+import { BulkOpJob } from '../../http/routes/api/bulkOps/BulkOpTypes';
+import { fixSceneBasenames } from '../../http/routes/api/bulkOps/fixSceneBasenames';
+
+// The full Cook-output set (6 downloads + SVX) for a scene, all sharing one basename.
+const outputSet = (base: string): string[] => [
+    `${base}-150k-4096_std.glb`, `${base}-100k-2048_std_draco.glb`, `${base}-100k-2048_std.usdz`,
+    `${base}-full_resolution-obj_std.zip`, `${base}-150k-4096-gltf_std.zip`, `${base}-150k-4096-obj_std.zip`,
+    `${base}.svx.json`,
+];
+
+// A messy set: outputs carry two different basenames (a half-completed prior state).
+const mixedSet = (): string[] => [
+    'OldName-150k-4096_std.glb', 'OldName-100k-2048_std_draco.glb', 'OldName-100k-2048_std.usdz',
+    'DifferentName-full_resolution-obj_std.zip', 'OldName-150k-4096-gltf_std.zip', 'OldName-150k-4096-obj_std.zip',
+    'OldName.svx.json',
+];
+
+const asAsset = (idAsset: number, FileName: string): DBAPI.Asset =>
+    ({ idAsset, FileName, StorageKey: `sk-${idAsset}` } as DBAPI.Asset);
+
+// Resolve the canonical Subject.Name confidently: one master, a hierarchy with exactly one subject,
+// and a display name that sanitizes to `canonical`.
+function stubCanonicalName(canonical: string): void {
+    jest.spyOn(DBAPI.Model, 'fetchMasterFromScene').mockResolvedValue([{ idModel: 7 } as DBAPI.Model]);
+    jest.spyOn(NameHelpers, 'computeModelHierarchy').mockResolvedValue({ subjects: [{ idSubject: 1 }] } as unknown as ModelHierarchy);
+    jest.spyOn(NameHelpers, 'sceneDisplayName').mockReturnValue(canonical);
+    jest.spyOn(NameHelpers, 'sanitizeFileName').mockImplementation((s: string) => s);
+}
+
+function stubMultiSubject(): void {
+    jest.spyOn(DBAPI.Model, 'fetchMasterFromScene').mockResolvedValue([{ idModel: 7 } as DBAPI.Model]);
+    jest.spyOn(NameHelpers, 'computeModelHierarchy').mockResolvedValue({ subjects: [{ idSubject: 1 }, { idSubject: 2 }] } as unknown as ModelHierarchy);
+}
+
+describe('Bulk op: Fix Scene Basenames', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test('fixable mode lists only scenes with a confident single Subject.Name rename', async () => {
+        jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue([{ idScene: 1 }, { idScene: 2 }] as unknown as DBAPI.Scene[]);
+        jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID')
+            .mockImplementation(async (idScene: number) => ({ idSystemObject: idScene * 1000 } as DBAPI.SystemObject));
+        jest.spyOn(DBAPI.SystemObject, 'fetch')
+            .mockImplementation(async (idSystemObject: number) => ({ idScene: idSystemObject / 1000 } as DBAPI.SystemObject));
+        jest.spyOn(DBAPI.Scene, 'fetch')
+            .mockImplementation(async (idScene: number) => ({ idScene, Name: `Scene ${idScene}` } as DBAPI.Scene));
+        stubCanonicalName('NewName');
+        // Scene 1: old uniform basename → fixable. Scene 2: already canonical → consistent (omitted).
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockImplementation(async (idScene: number) =>
+            (idScene === 1 ? outputSet('OldName') : outputSet('NewName')).map((fn, i) => asAsset(i + 1, fn)));
+
+        await BulkOpJob.run(fixSceneBasenames, { params: { mode: 'fixable' } });
+        const rows = BulkOpJob.rows;
+        expect(rows).toHaveLength(1);
+        const row = rows.find(r => r.id === 1000);
+        expect(row?.isCandidate).toBe(true);
+        expect(row?.rowData.status).toBe('Fixable');
+        expect(row?.rowData.canonicalName).toBe('NewName');
+        expect(row?.rowData.currentBasename).toBe('OldName');
+        expect(row?.rowData.fileCount).toBe(7);
+        expect(row?.rowData.details).toContain('OldName.svx.json → NewName.svx.json');
+    });
+
+    test('fixable mode omits a mixed-basename scene', async () => {
+        jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue([{ idScene: 1 }] as unknown as DBAPI.Scene[]);
+        jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID').mockResolvedValue({ idSystemObject: 1000 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        stubCanonicalName('NewName');
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(mixedSet().map((fn, i) => asAsset(i + 1, fn)));
+
+        await BulkOpJob.run(fixSceneBasenames, { params: { mode: 'fixable' } });
+        expect(BulkOpJob.rows).toHaveLength(0);
+    });
+
+    test('affected mode lists both fixable and mixed scenes; only fixable is selectable', async () => {
+        jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue([{ idScene: 1 }, { idScene: 2 }] as unknown as DBAPI.Scene[]);
+        jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID')
+            .mockImplementation(async (idScene: number) => ({ idSystemObject: idScene * 1000 } as DBAPI.SystemObject));
+        jest.spyOn(DBAPI.SystemObject, 'fetch')
+            .mockImplementation(async (idSystemObject: number) => ({ idScene: idSystemObject / 1000 } as DBAPI.SystemObject));
+        jest.spyOn(DBAPI.Scene, 'fetch')
+            .mockImplementation(async (idScene: number) => ({ idScene, Name: `Scene ${idScene}` } as DBAPI.Scene));
+        stubCanonicalName('NewName');
+        // Scene 1: fixable (uniform old base). Scene 2: mixed basenames.
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockImplementation(async (idScene: number) =>
+            (idScene === 1 ? outputSet('OldName') : mixedSet()).map((fn, i) => asAsset(i + 1, fn)));
+
+        await BulkOpJob.run(fixSceneBasenames, { params: { mode: 'affected' } });
+        const rows = BulkOpJob.rows;
+        expect(rows).toHaveLength(2);
+
+        const fixable = rows.find(r => r.id === 1000);
+        expect(fixable?.isCandidate).toBe(true);
+        expect(fixable?.rowData.status).toBe('Fixable');
+
+        const mixed = rows.find(r => r.id === 2000);
+        expect(mixed?.isCandidate).toBe(false); // report-only: visible but not selectable
+        expect(mixed?.rowData.status).toContain('Mixed');
+        expect(mixed?.rowData.details).toContain('distinct basenames');
+    });
+
+    test('affected mode still omits a uniform multi-subject scene (not affected by subject renames)', async () => {
+        jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue([{ idScene: 1 }] as unknown as DBAPI.Scene[]);
+        jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID').mockResolvedValue({ idSystemObject: 1000 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        stubMultiSubject();
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('WhateverBase').map((fn, i) => asAsset(i + 1, fn)));
+
+        await BulkOpJob.run(fixSceneBasenames, { params: { mode: 'affected' } });
+        expect(BulkOpJob.rows).toHaveLength(0);
+    });
+
+    test('apply renames each Cook-output asset to the canonical Subject.Name', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        jest.spyOn(DBAPI.User, 'fetch').mockResolvedValue({ idUser: 5, Name: 'Curator', EmailAddress: 'c@si.edu' } as DBAPI.User);
+        stubCanonicalName('NewName');
+
+        const drifted = outputSet('OldName').map((fn, i) => asAsset(i + 1, fn));
+        const fixed = outputSet('NewName').map((fn, i) => asAsset(i + 1, fn));
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene')
+            .mockResolvedValueOnce(drifted)   // first evaluation
+            .mockResolvedValueOnce(fixed);    // post-rename re-check
+
+        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset')
+            .mockResolvedValue({ success: true } as STORE.AssetStorageResult);
+
+        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
+        expect(rename).toHaveBeenCalledTimes(7);
+        for (const call of rename.mock.calls) {
+            expect((call[1] as string).startsWith('NewName')).toBe(true);
+            expect((call[2] as STORE.OperationInfo).userEmailAddress).toBe('c@si.edu');
+        }
+        expect(res.success).toBe(true);
+        expect(res.message).toContain('renamed 7');
+        expect(res.rowData.fileCount).toBe(0);
+    });
+
+    test('apply refuses a mixed-basename scene and renames nothing', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        stubCanonicalName('NewName');
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(mixedSet().map((fn, i) => asAsset(i + 1, fn)));
+        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset');
+
+        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toContain('refused');
+        expect(rename).not.toHaveBeenCalled();
+    });
+
+    test('apply refuses a multi-subject scene and renames nothing', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        stubMultiSubject();
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('WhateverBase').map((fn, i) => asAsset(i + 1, fn)));
+        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset');
+
+        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toContain('refused');
+        expect(rename).not.toHaveBeenCalled();
+    });
+
+    test('apply reports partial failure when a rename fails', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        jest.spyOn(DBAPI.User, 'fetch').mockResolvedValue({ idUser: 5, Name: 'Curator', EmailAddress: 'c@si.edu' } as DBAPI.User);
+        stubCanonicalName('NewName');
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('OldName').map((fn, i) => asAsset(i + 1, fn)));
+        jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset')
+            .mockResolvedValue({ success: false, error: 'storage locked' } as STORE.AssetStorageResult);
+
+        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toContain('failed');
+    });
+
+    test('apply refuses cleanly for a non-scene system object', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: null } as unknown as DBAPI.SystemObject);
+        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toContain('not a scene');
+    });
+
+    test('apply is a no-op when the scene is already consistent', async () => {
+        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
+        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
+        stubCanonicalName('NewName');
+        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('NewName').map((fn, i) => asAsset(i + 1, fn)));
+        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset');
+
+        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
+        expect(res.success).toBe(true);
+        expect(res.message).toBe('already consistent');
+        expect(rename).not.toHaveBeenCalled();
+    });
+});

--- a/server/tests/job/cookOutputContract.test.ts
+++ b/server/tests/job/cookOutputContract.test.ts
@@ -1,0 +1,108 @@
+import * as COMMON from '@dpo-packrat/common';
+import { predictCookOutput, findBasenameOffenders, cookOutputSuffixes, CookOutputPrediction, BasenameOffender } from '../../job/impl/Cook/CookOutputContract';
+
+// Pure-function coverage for the shared Cook output contract. No DB or Cook needed. Proves the
+// recipe-aware prediction and the single basename rule that both the pre-flight guard and the
+// post-Cook verification run.
+describe('Cook Output Contract', () => {
+    const BASE: string = 'MyUnit-MyObject-1';
+
+    describe('predictCookOutput', () => {
+        test('si-generate-downloads predicts the 6 download suffixes plus .svx.json, as a closed set', () => {
+            const prediction: CookOutputPrediction = predictCookOutput('si-generate-downloads', BASE);
+            expect(prediction.closed).toBe(true);
+            expect(prediction.filenames).toHaveLength(COMMON.CookDownloadDescriptors.length + 1);
+            for (const suffix of COMMON.cookDownloadSuffixes('full'))
+                expect(prediction.filenames).toContain(`${BASE}${suffix}`);
+            expect(prediction.filenames).toContain(`${BASE}.svx.json`);
+            // every predicted name shares the basename
+            for (const name of prediction.filenames)
+                expect(name.startsWith(BASE)).toBe(true);
+        });
+
+        test('si-voyager-scene predicts only the SVX name, as an open set (recipe-difference guard)', () => {
+            const prediction: CookOutputPrediction = predictCookOutput('si-voyager-scene', BASE);
+            expect(prediction.closed).toBe(false);
+            expect(prediction.filenames).toEqual([`${BASE}.svx.json`]);
+            // scene generation must NOT assert any of the 6 download suffixes
+            for (const suffix of COMMON.cookDownloadSuffixes('full'))
+                expect(prediction.filenames).not.toContain(`${BASE}${suffix}`);
+        });
+    });
+
+    describe('cookOutputSuffixes', () => {
+        test('downloads = full suffixes + .svx.json; scene = .svx.json only', () => {
+            expect([...cookOutputSuffixes('si-generate-downloads')].sort())
+                .toEqual([...COMMON.cookDownloadSuffixes('full'), '.svx.json'].sort());
+            expect(cookOutputSuffixes('si-voyager-scene')).toEqual(['.svx.json']);
+        });
+    });
+
+    describe('findBasenameOffenders (the shared rule)', () => {
+        const predicted = (base: string): string[] => predictCookOutput('si-generate-downloads', base).filenames;
+
+        test('first-run scene (no existing same-suffix assets) passes', () => {
+            const existing: string[] = ['MyUnit-MyObject-1.obj', 'diffuse.jpg']; // source assets only
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', predicted(BASE), existing);
+            expect(offenders).toEqual([]);
+        });
+
+        test('matching basename passes (re-run with no rename)', () => {
+            const existing: string[] = predicted(BASE); // scene already holds a full, matching set
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', predicted(BASE), existing);
+            expect(offenders).toEqual([]);
+        });
+
+        test('rename is blocked and every offender is reported, not just the first', () => {
+            const oldBase: string = 'OldName-1';
+            const existing: string[] = predicted(oldBase); // scene holds the stale full set
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', predicted(BASE), existing);
+            // one offender per shared suffix: the 6 downloads + the SVX descriptor
+            expect(offenders).toHaveLength(COMMON.CookDownloadDescriptors.length + 1);
+            for (const o of offenders) {
+                expect(o.expected.startsWith(BASE)).toBe(true);
+                expect(o.actual.startsWith(oldBase)).toBe(true);
+            }
+        });
+
+        test('the .svx.json descriptor is checked (the hole the old prefix guard missed)', () => {
+            // only the stale SVX is present; the prefix-only guard excluded .svx.json and would pass this
+            const existing: string[] = ['OldName-1.svx.json'];
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', predicted(BASE), existing);
+            expect(offenders).toHaveLength(1);
+            expect(offenders[0].suffix).toBe('.svx.json');
+            expect(offenders[0].expected).toBe(`${BASE}.svx.json`);
+            expect(offenders[0].actual).toBe('OldName-1.svx.json');
+        });
+
+        test('prefix-rename (Foo-Bar -> Foo) is now caught (old prefix guard passed it)', () => {
+            // existing set built for 'Foo-Bar'; new run is 'Foo'. Old guard accepted startsWith('Foo-').
+            const existing: string[] = predicted('Foo-Bar');
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', predicted('Foo'), existing);
+            expect(offenders.length).toBeGreaterThan(0);
+        });
+
+        test('post-Cook direction: Cook output vs existing stale asset yields an offender', () => {
+            const incoming: string[] = predicted(BASE);           // Cook actually produced the new-name set
+            const existing: string[] = ['OldName-1.svx.json'];    // scene still holds the old SVX
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', incoming, existing);
+            expect(offenders).toHaveLength(1);
+        });
+
+        test('scene-gen output is never evaluated against the download suffixes (recipe-difference guard)', () => {
+            // a scene with stale downloads under an old name, evaluated as si-voyager-scene, only ever
+            // asserts the SVX name — the 6 download suffixes are not part of the scene contract
+            const existing: string[] = predictCookOutput('si-generate-downloads', 'OldName-1').filenames;
+            const sceneCandidates: string[] = predictCookOutput('si-voyager-scene', BASE).filenames;
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-voyager-scene', sceneCandidates, existing);
+            // only the SVX is compared; OldName SVX differs -> exactly one offender, never six-plus
+            expect(offenders).toHaveLength(1);
+            expect(offenders[0].suffix).toBe('.svx.json');
+        });
+
+        test('candidate with an unrecognized suffix is ignored, not flagged', () => {
+            const offenders: BasenameOffender[] = findBasenameOffenders('si-generate-downloads', ['random.txt'], ['other.txt']);
+            expect(offenders).toEqual([]);
+        });
+    });
+});

--- a/server/workflow/impl/Packrat/WorkflowEngine.ts
+++ b/server/workflow/impl/Packrat/WorkflowEngine.ts
@@ -274,20 +274,14 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
         RK.logDebug(RK.LogSection.eWF,'generate downloads','compute names',{ sceneBaseName, modelBaseName },'Workflow.Engine');
 
         // Basename safeguard. Cook names every generated download
-        // `{sceneBaseName}-{variant}.{ext}` across .glb, .usdz and .zip outputs
-        // (model tiers, AR variants, OBJ/glTF bundles). If the scene already
-        // has downloads from a previous run, those basenames must match the
-        // basename we're about to send. A mismatch means the master model or
-        // scene was renamed and re-running Cook would orphan the old set
-        // instead of replacing it. Fail loudly. Source assets (master model,
-        // SVX scene file, texture maps) are excluded so they don't false-trip.
-        const sourceAssetVersionIds: Set<number> = new Set<number>();
-        if (CSIR.assetVersionGeometry)  sourceAssetVersionIds.add(CSIR.assetVersionGeometry.idAssetVersion);
-        if (CSIR.assetSVX)              sourceAssetVersionIds.add(CSIR.assetSVX.idAssetVersion);
-        if (CSIR.assetVersionDiffuse)   sourceAssetVersionIds.add(CSIR.assetVersionDiffuse.idAssetVersion);
-        if (CSIR.assetVersionRoughMetal) sourceAssetVersionIds.add(CSIR.assetVersionRoughMetal.idAssetVersion);
-        if (CSIR.assetVersionMTL)       sourceAssetVersionIds.add(CSIR.assetVersionMTL.idAssetVersion);
-        const basenameCheck: H.IOResults = await WorkflowEngine.verifyDownloadBasenameConsistency(sceneSO.idSystemObject, sceneBaseName, sourceAssetVersionIds);
+        // `{sceneBaseName}{suffix}` from the CookDownloadDescriptors set plus
+        // the `{sceneBaseName}.svx.json` descriptor. If the scene already holds
+        // an asset with one of those suffixes under a different basename, the
+        // master model or scene was renamed and re-running Cook would orphan the
+        // old set instead of replacing it. The same rule runs after Cook returns
+        // (JobCookSIGenerateDownloads.verifyIncomingCookData); block here so no
+        // Cook job is spent on a run that cannot be ingested.
+        const basenameCheck: H.IOResults = await WorkflowEngine.verifyDownloadBasenameConsistency(scene.idScene, sceneBaseName);
         if (!basenameCheck.success) {
             RK.logError(RK.LogSection.eWF,'generate downloads blocked','basename mismatch against existing downloads',
                 { idScene, sceneBaseName, error: basenameCheck.error }, 'Workflow.Engine');
@@ -482,26 +476,33 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
 
         // if we have a scene, we want to use it's SVX (if any) as the base for the recipe.
         // if we don't have a scene then the model may have just been ingested
-        const svxFilename: string = sceneBaseName + '.svx.json';
+        const svxFilename: string = COOK.predictCookOutput('si-voyager-scene', sceneBaseName).filenames[0];
         if(scene) {
             // get the asset version for the active voyager scene. only returns the most recent and does not support
             // multiple SVX files for a single scene
             const svxAssetVersion: DBAPI.AssetVersion | null = await DBAPI.AssetVersion.fetchActiveVoyagerSceneFromScene(scene.idScene);
             if(!svxAssetVersion)
                 RK.logWarning(RK.LogSection.eWF,'generate scene','no active SVX file found for scene',{ idModel, idScene },'Workflow.Engine');
-            else {
-                // compare filenames. if a match then add it to staged resources. otherwise, fail
-                // TODO: should we return on this failure?
-                if(svxAssetVersion.FileName !== svxFilename)
-                    RK.logWarning(RK.LogSection.eWF,'generate scene failed','basenames do not match',{ idModel, idScene, expected: svxFilename, observed: svxAssetVersion.FileName },'Workflow.Engine');
-                else {
-                    // grab our SystemObject since we need to feed it to the list of staged files
-                    const svxAssetVersionSO: DBAPI.SystemObject | null = await svxAssetVersion.fetchSystemObject();
-                    if(!svxAssetVersionSO)
-                        RK.logWarning(RK.LogSection.eWF,'generate scene failed','cannot get SystemObject for asset version',{ idModel, idScene, idAssetVersion: svxAssetVersion.idAssetVersion },'Workflow.Engine');
-                    else
-                        idSystemObjects.push(svxAssetVersionSO.idSystemObject);
-                }
+            else if(svxAssetVersion.FileName !== svxFilename) {
+                // Hard block. The existing scene's SVX descriptor has a different basename than the
+                // name this run will produce, so the scene/model was renamed. Re-running scene
+                // generation would fork a duplicate Scene against the same model source (see
+                // JobCookSIVoyagerScene.createSystemObjects) instead of updating this one. Block
+                // before a Cook job is spent; recovery is the Fix Scene Basenames bulk operation.
+                RK.logError(RK.LogSection.eWF,'generate scene blocked','existing scene SVX basename differs from current model',
+                    { idModel, idScene, expected: svxFilename, existing: svxAssetVersion.FileName },'Workflow.Engine');
+                return { success: false,
+                    message: `Scene generation blocked: the existing scene descriptor "${svxAssetVersion.FileName}" `
+                        + `does not match the current name "${svxFilename}". The model or scene was renamed and re-running `
+                        + 'would create a duplicate scene. Revert the name change or run Fix Scene Basenames before retrying.',
+                    data: { isValid: false } };
+            } else {
+                // grab our SystemObject since we need to feed it to the list of staged files
+                const svxAssetVersionSO: DBAPI.SystemObject | null = await svxAssetVersion.fetchSystemObject();
+                if(!svxAssetVersionSO)
+                    RK.logWarning(RK.LogSection.eWF,'generate scene failed','cannot get SystemObject for asset version',{ idModel, idScene, idAssetVersion: svxAssetVersion.idAssetVersion },'Workflow.Engine');
+                else
+                    idSystemObjects.push(svxAssetVersionSO.idSystemObject);
             }
         }
         //#endregion scene
@@ -923,51 +924,34 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
     }
 
     /**
-     * Verify that every existing Cook-output download asset under the scene's
-     * SystemObject has a basename consistent with the supplied `sceneBaseName`.
-     * Cook names downloads `{sceneBaseName}-{variant}.{ext}` across .glb (tier
-     * geometry), .usdz (AR variants) and .zip (OBJ / glTF bundles). Any
-     * download whose filename does not begin with `${sceneBaseName}` indicates
-     * the scene/model was renamed since the last run.
-     *
-     * `excludeIds` lists AssetVersion ids that are *source* assets attached to
-     * the scene (master model, SVX scene file, diffuse / rough-metal / MTL
-     * maps) so they don't false-trip the prefix check when they happen to be
-     * .glb or .zip. Returns success when no Cook downloads exist or every one
-     * is consistent.
+     * Pre-flight guard for Generate Downloads. Predicts the filenames Cook will
+     * produce for `sceneBaseName` and, using the shared CookOutputContract rule,
+     * blocks if the scene already holds an asset carrying one of those Cook
+     * suffixes under a different basename. That state means the scene/model was
+     * renamed since the last run and re-running Cook would orphan the old set.
+     * The identical rule runs post-Cook in
+     * JobCookSIGenerateDownloads.verifyIncomingCookData; both read scene assets
+     * via Asset.fetchFromScene so they cannot disagree. Returns success when no
+     * same-suffix asset exists (first run / partial set) or all match.
      */
-    private static readonly COOK_OUTPUT_EXTENSIONS: readonly string[] = ['.glb', '.usdz', '.zip'];
-
-    private static async verifyDownloadBasenameConsistency(idSceneSystemObject: number, sceneBaseName: string, excludeIds: Set<number>): Promise<H.IOResults> {
-        const assetVersions: DBAPI.AssetVersion[] | null = await DBAPI.AssetVersion.fetchFromSystemObject(idSceneSystemObject);
-        if (!assetVersions || assetVersions.length === 0)
+    private static async verifyDownloadBasenameConsistency(idScene: number, sceneBaseName: string): Promise<H.IOResults> {
+        const sceneAssets: DBAPI.Asset[] | null = await DBAPI.Asset.fetchFromScene(idScene);
+        if (!sceneAssets || sceneAssets.length === 0)
             return { success: true };
 
-        const offenders: string[] = [];
-        for (const av of assetVersions) {
-            if (excludeIds.has(av.idAssetVersion)) continue;
-
-            const ext: string = path.extname(av.FileName).toLowerCase();
-            if (!WorkflowEngine.COOK_OUTPUT_EXTENSIONS.includes(ext)) continue;
-
-            const stem: string = path.parse(av.FileName).name;
-            const prefix: string = `${sceneBaseName}-`;
-            const exactMatch: boolean = stem === sceneBaseName;
-            const variantMatch: boolean = stem.startsWith(prefix);
-            if (!exactMatch && !variantMatch)
-                offenders.push(av.FileName);
-        }
+        const existingFilenames: string[] = sceneAssets.map(asset => asset.FileName);
+        const prediction: COOK.CookOutputPrediction = COOK.predictCookOutput('si-generate-downloads', sceneBaseName);
+        const offenders: COOK.BasenameOffender[] = COOK.findBasenameOffenders('si-generate-downloads', prediction.filenames, existingFilenames);
 
         if (offenders.length === 0)
             return { success: true };
 
-        const sample: string = offenders.slice(0, 3).join(', ');
+        const detail: string = offenders.map(o => `${o.expected} → ${o.actual}`).join('; ');
         return {
             success: false,
-            error: 'Existing scene downloads have a different basename than the current model '
-                + `(expected prefix "${sceneBaseName}", got: ${sample}${offenders.length > 3 ? `, +${offenders.length - 3} more` : ''}). `
-                + 'Re-running Cook would orphan the existing downloads. Retire or rename the existing downloads, '
-                + 'or revert the model/scene name change before retrying.'
+            error: 'Existing scene downloads have a different basename than the current model. '
+                + `Re-running Cook would orphan the existing downloads (expected → existing: ${detail}). `
+                + 'Retire or rename the existing downloads, or revert the model/scene name change before retrying.'
         };
     }
 


### PR DESCRIPTION
**Cook Pre-Recipe Validation**

- Define expected Cook outputs by recipe.
- Enforce SVX-only scene output and full download sets.
- Add tests for output prediction and naming rules.
- Use one shared basename rule for all Cook checks.
- Catch SVX filename mismatches before Cook starts.
- Use the same asset source before and after Cook.
- Block scene generation on basename mismatches.
- Prevent scene reuse from forking on renames.
- Prevent forks when scenes have multiple scene records.
- Create missing models on the existing scene.
- Fix the si-voyager-scene recipe name typo.

**Fix Scene Basenames Bulk Op**

- Add a bulk tool to fix basenames after subject renames.
- Rename download and SVX assets to match the subject.
- Make renames versioned and rollback-safe through OCFL.
- Only auto-fix clear, single-subject rename cases.
- Support fixable-only and all-affected reports.
- Show report-only rows without allowing selection.
- Add the operation to the bulk operations harness.
- Add tests for scope modes and refusal cases.