### PR TITLE
DPO3DPKRT-1026/Structured Workflow Reports

### DIFF
--- a/client/src/pages/Workflow/components/WorkflowView/WorkflowList.tsx
+++ b/client/src/pages/Workflow/components/WorkflowView/WorkflowList.tsx
@@ -8,27 +8,16 @@ import { formatDateAndTime } from '../../../../utils/shared';
 import SetIcon from '../../../../assets/images/Workflow_Set_Icon.svg';
 import ReportIcon from '../../../../assets/images/Workflow_Report_Icon.svg';
 import JobIcon from '../../../../assets/images/Workflow_Job_Icon.svg';
-import { eWorkflowListSortColumns, IWorkflowReportSummary } from '@dpo-packrat/common';
+import { eWorkflowListSortColumns } from '@dpo-packrat/common';
 import { ePaginationChange } from '../../../../store';
 import { EmptyTable, NewTabLink } from '../../../../components';
 import { truncateWithEllipses } from '../../../../constants/helperfunctions';
 import { DataTableOptions } from '../../../../types/component';
 import { getDownloadValueForWorkflowReport, getDownloadValueForWorkflowSet, getDownloadValueForJob, getDetailsUrlForObject } from '../../../../utils/repository';
 import API from '../../../../api';
-import WorkflowReportViewer from './WorkflowReportViewer';
+import WorkflowReportViewer, { WorkflowReportHeader } from './WorkflowReportViewer';
+import { parseWorkflowSummary } from './workflowSummary';
 import clsx from 'clsx';
-
-/** Parse the compact per-row JSON summary (WorkflowReport.Name). Returns null for legacy/absent/invalid rows. */
-function parseWorkflowSummary(row: { Summary?: string | null; ReportMimeType?: string | null }): IWorkflowReportSummary | null {
-    if (!row || row.ReportMimeType !== 'application/json' || !row.Summary)
-        return null;
-    try {
-        const parsed = JSON.parse(row.Summary);
-        return (parsed && typeof parsed === 'object') ? parsed as IWorkflowReportSummary : null;
-    } catch {
-        return null;
-    }
-}
 
 interface WorkflowIconProps {
     reportType: eWorkflowLinkType;
@@ -196,7 +185,7 @@ function WorkflowList(): React.ReactElement {
 
     const count = calculateTotalRowCount();
 
-    const [reportViewer, setReportViewer] = React.useState<{ open: boolean; url: string; title: string }>({ open: false, url: '', title: '' });
+    const [reportViewer, setReportViewer] = React.useState<{ open: boolean; url: string; header: WorkflowReportHeader; mimeType: string | null }>({ open: false, url: '', header: { title: '' }, mimeType: null });
 
     const options: DataTableOptions = {
         filter: false,
@@ -322,57 +311,22 @@ function WorkflowList(): React.ReactElement {
                     const summary = parseWorkflowSummary(rows[dataIndex]);
                     if (!summary) return '';
                     const label = summary.scene || summary.subject || summary.mediaGroup || '';
+                    const type = summary.idScene ? 'Scene' : (summary.idModel ? 'Model' : (summary.idSubject ? 'Subject' : 'Object'));
                     const id = summary.idSystemObject;
                     if (id) {
-                        const text = truncateWithEllipses(label || `Object ${id}`, 24);
+                        const full = `[${type}] ${label || `Object ${id}`}`;
                         return (
-                            <Tooltip placement='top' title={label || `Object ${id}`} arrow>
+                            <Tooltip placement='top' title={full} arrow>
                                 <span>
-                                    <NewTabLink to={getDetailsUrlForObject(id)} className={classes.link}>{text}</NewTabLink>
+                                    <NewTabLink to={getDetailsUrlForObject(id)} className={classes.link}>{truncateWithEllipses(full, 30)}</NewTabLink>
                                 </span>
                             </Tooltip>
                         );
                     }
                     if (!label) return '';
                     return (
-                        <Tooltip placement='top' title={label} arrow>
-                            <div style={{ maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</div>
-                        </Tooltip>
-                    );
-                },
-                setCellProps: setCenterCell,
-                setCellHeaderProps: setCenterHeader
-            }
-        },
-        {
-            name: 'CookServer',
-            label: 'Cook Server',
-            options: {
-                sort: false,
-                customBodyRenderLite(dataIndex) {
-                    const summary = parseWorkflowSummary(rows[dataIndex]);
-                    if (!summary?.cookServer) return '';
-                    return (
-                        <Tooltip placement='top' title={summary.cookServer} arrow>
-                            <div style={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{summary.cookServer}</div>
-                        </Tooltip>
-                    );
-                },
-                setCellProps: setCenterCell,
-                setCellHeaderProps: setCenterHeader
-            }
-        },
-        {
-            name: 'CookJob',
-            label: 'Cook Job',
-            options: {
-                sort: false,
-                customBodyRenderLite(dataIndex) {
-                    const summary = parseWorkflowSummary(rows[dataIndex]);
-                    if (!summary?.cookJobId) return '';
-                    return (
-                        <Tooltip placement='top' title={summary.cookJobId} arrow>
-                            <div>{truncateWithEllipses(summary.cookJobId, 10)}</div>
+                        <Tooltip placement='top' title={`[${type}] ${label}`} arrow>
+                            <div style={{ maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{`[${type}] ${label}`}</div>
                         </Tooltip>
                     );
                 },
@@ -413,21 +367,24 @@ function WorkflowList(): React.ReactElement {
                     const value = row?.idWorkflowReport;
                     if (!value) return '';
                     const url = getDownloadValueForWorkflowReport(serverEndpoint, value);
-                    if (row.ReportMimeType === 'application/json') {
-                        const summary = parseWorkflowSummary(row);
-                        const title = `Workflow Report — ${summary?.scene || summary?.subject || row.Type || `#${value}`}`;
-                        return (
-                            <button
-                                type='button'
-                                onClick={() => setReportViewer({ open: true, url, title })}
-                                aria-label='Open workflow report'
-                                style={{ background: 'none', border: 0, padding: 0, cursor: 'pointer', display: 'flex', justifyContent: 'center', width: '100%' }}
-                            >
-                                <img src={ReportIcon} style={{ height: '20px', width: '20px' }} alt='This icon indicates a clickable report.' />
-                            </button>
-                        );
-                    }
-                    return <WorkflowIcon reportType={eWorkflowLinkType.eReport} path={url} />;
+                    const summary = parseWorkflowSummary(row);
+                    const header: WorkflowReportHeader = {
+                        title: summary?.scene || summary?.subject || row.Type || `Report #${value}`,
+                        recipe: summary?.recipe ?? undefined,
+                        cookJobId: summary?.cookJobId ?? undefined,
+                        cookServer: summary?.cookServer ?? undefined,
+                        started: row.DateStart ? formatDateAndTime(row.DateStart) : undefined
+                    };
+                    return (
+                        <button
+                            type='button'
+                            onClick={() => setReportViewer({ open: true, url, header, mimeType: row.ReportMimeType ?? null })}
+                            aria-label='Open workflow report'
+                            style={{ background: 'none', border: 0, padding: 0, cursor: 'pointer', display: 'flex', justifyContent: 'center', width: '100%' }}
+                        >
+                            <img src={ReportIcon} style={{ height: '20px', width: '20px' }} alt='This icon indicates a clickable report.' />
+                        </button>
+                    );
                 },
                 setCellProps: setCenterCell,
                 setCellHeaderProps: setCenterHeader,
@@ -486,9 +443,10 @@ function WorkflowList(): React.ReactElement {
             </Box>
             <WorkflowReportViewer
                 open={reportViewer.open}
-                onClose={() => setReportViewer({ open: false, url: '', title: '' })}
+                onClose={() => setReportViewer({ open: false, url: '', header: { title: '' }, mimeType: null })}
                 reportUrl={reportViewer.url}
-                title={reportViewer.title}
+                header={reportViewer.header}
+                mimeType={reportViewer.mimeType}
             />
         </MuiThemeProvider>
     );

--- a/client/src/pages/Workflow/components/WorkflowView/WorkflowList.tsx
+++ b/client/src/pages/Workflow/components/WorkflowView/WorkflowList.tsx
@@ -8,14 +8,27 @@ import { formatDateAndTime } from '../../../../utils/shared';
 import SetIcon from '../../../../assets/images/Workflow_Set_Icon.svg';
 import ReportIcon from '../../../../assets/images/Workflow_Report_Icon.svg';
 import JobIcon from '../../../../assets/images/Workflow_Job_Icon.svg';
-import { eWorkflowListSortColumns } from '@dpo-packrat/common';
+import { eWorkflowListSortColumns, IWorkflowReportSummary } from '@dpo-packrat/common';
 import { ePaginationChange } from '../../../../store';
-import { EmptyTable } from '../../../../components';
+import { EmptyTable, NewTabLink } from '../../../../components';
 import { truncateWithEllipses } from '../../../../constants/helperfunctions';
 import { DataTableOptions } from '../../../../types/component';
-import { getDownloadValueForWorkflowReport, getDownloadValueForWorkflowSet, getDownloadValueForJob } from '../../../../utils/repository';
+import { getDownloadValueForWorkflowReport, getDownloadValueForWorkflowSet, getDownloadValueForJob, getDetailsUrlForObject } from '../../../../utils/repository';
 import API from '../../../../api';
+import WorkflowReportViewer from './WorkflowReportViewer';
 import clsx from 'clsx';
+
+/** Parse the compact per-row JSON summary (WorkflowReport.Name). Returns null for legacy/absent/invalid rows. */
+function parseWorkflowSummary(row: { Summary?: string | null; ReportMimeType?: string | null }): IWorkflowReportSummary | null {
+    if (!row || row.ReportMimeType !== 'application/json' || !row.Summary)
+        return null;
+    try {
+        const parsed = JSON.parse(row.Summary);
+        return (parsed && typeof parsed === 'object') ? parsed as IWorkflowReportSummary : null;
+    } catch {
+        return null;
+    }
+}
 
 interface WorkflowIconProps {
     reportType: eWorkflowLinkType;
@@ -183,6 +196,8 @@ function WorkflowList(): React.ReactElement {
 
     const count = calculateTotalRowCount();
 
+    const [reportViewer, setReportViewer] = React.useState<{ open: boolean; url: string; title: string }>({ open: false, url: '', title: '' });
+
     const options: DataTableOptions = {
         filter: false,
         filterType: 'dropdown',
@@ -299,6 +314,73 @@ function WorkflowList(): React.ReactElement {
             }
         },
         {
+            name: 'Object',
+            label: 'Object',
+            options: {
+                sort: false,
+                customBodyRenderLite(dataIndex) {
+                    const summary = parseWorkflowSummary(rows[dataIndex]);
+                    if (!summary) return '';
+                    const label = summary.scene || summary.subject || summary.mediaGroup || '';
+                    const id = summary.idSystemObject;
+                    if (id) {
+                        const text = truncateWithEllipses(label || `Object ${id}`, 24);
+                        return (
+                            <Tooltip placement='top' title={label || `Object ${id}`} arrow>
+                                <span>
+                                    <NewTabLink to={getDetailsUrlForObject(id)} className={classes.link}>{text}</NewTabLink>
+                                </span>
+                            </Tooltip>
+                        );
+                    }
+                    if (!label) return '';
+                    return (
+                        <Tooltip placement='top' title={label} arrow>
+                            <div style={{ maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</div>
+                        </Tooltip>
+                    );
+                },
+                setCellProps: setCenterCell,
+                setCellHeaderProps: setCenterHeader
+            }
+        },
+        {
+            name: 'CookServer',
+            label: 'Cook Server',
+            options: {
+                sort: false,
+                customBodyRenderLite(dataIndex) {
+                    const summary = parseWorkflowSummary(rows[dataIndex]);
+                    if (!summary?.cookServer) return '';
+                    return (
+                        <Tooltip placement='top' title={summary.cookServer} arrow>
+                            <div style={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{summary.cookServer}</div>
+                        </Tooltip>
+                    );
+                },
+                setCellProps: setCenterCell,
+                setCellHeaderProps: setCenterHeader
+            }
+        },
+        {
+            name: 'CookJob',
+            label: 'Cook Job',
+            options: {
+                sort: false,
+                customBodyRenderLite(dataIndex) {
+                    const summary = parseWorkflowSummary(rows[dataIndex]);
+                    if (!summary?.cookJobId) return '';
+                    return (
+                        <Tooltip placement='top' title={summary.cookJobId} arrow>
+                            <div>{truncateWithEllipses(summary.cookJobId, 10)}</div>
+                        </Tooltip>
+                    );
+                },
+                setCellProps: setCenterCell,
+                setCellHeaderProps: setCenterHeader
+            }
+        },
+        {
             name: 'DateStart',
             label: 'Start',
             options: {
@@ -326,9 +408,26 @@ function WorkflowList(): React.ReactElement {
             name: 'idWorkflowReport',
             label: 'Report',
             options: {
-                customBodyRender(value) {
+                customBodyRenderLite(dataIndex) {
+                    const row = rows[dataIndex];
+                    const value = row?.idWorkflowReport;
                     if (!value) return '';
-                    return <WorkflowIcon reportType={eWorkflowLinkType.eReport} path={getDownloadValueForWorkflowReport(serverEndpoint, value)} />;
+                    const url = getDownloadValueForWorkflowReport(serverEndpoint, value);
+                    if (row.ReportMimeType === 'application/json') {
+                        const summary = parseWorkflowSummary(row);
+                        const title = `Workflow Report — ${summary?.scene || summary?.subject || row.Type || `#${value}`}`;
+                        return (
+                            <button
+                                type='button'
+                                onClick={() => setReportViewer({ open: true, url, title })}
+                                aria-label='Open workflow report'
+                                style={{ background: 'none', border: 0, padding: 0, cursor: 'pointer', display: 'flex', justifyContent: 'center', width: '100%' }}
+                            >
+                                <img src={ReportIcon} style={{ height: '20px', width: '20px' }} alt='This icon indicates a clickable report.' />
+                            </button>
+                        );
+                    }
+                    return <WorkflowIcon reportType={eWorkflowLinkType.eReport} path={url} />;
                 },
                 setCellProps: setCenterCell,
                 setCellHeaderProps: setCenterHeader,
@@ -385,6 +484,12 @@ function WorkflowList(): React.ReactElement {
             <Box className={classes.tableContainer}>
                 <MUIDataTable title='' data={rows} columns={columns} options={options} />
             </Box>
+            <WorkflowReportViewer
+                open={reportViewer.open}
+                onClose={() => setReportViewer({ open: false, url: '', title: '' })}
+                reportUrl={reportViewer.url}
+                title={reportViewer.title}
+            />
         </MuiThemeProvider>
     );
 }

--- a/client/src/pages/Workflow/components/WorkflowView/WorkflowReportViewer.tsx
+++ b/client/src/pages/Workflow/components/WorkflowView/WorkflowReportViewer.tsx
@@ -1,0 +1,189 @@
+/**
+ * WorkflowReportViewer
+ *
+ * Minimal viewer for a structured (application/json) workflow report. Fetches the report body from
+ * the /download endpoint, parses the JSON event array, and renders a legible timeline. Entity
+ * references embedded in an event's `data` render as safe links (built from ids, never from free
+ * text). A legacy text/html report is not opened here — the caller falls back to a raw tab.
+ */
+import React, { useEffect, useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, IconButton, Box, Typography, Link } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import CloseIcon from '@material-ui/icons/Close';
+import { IWorkflowReportEvent } from '@dpo-packrat/common';
+import { NewTabLink } from '../../../../components';
+import { getDetailsUrlForObject } from '../../../../utils/repository';
+import { formatDateAndTime } from '../../../../utils/shared';
+
+interface WorkflowReportViewerProps {
+    open: boolean;
+    onClose: () => void;
+    reportUrl: string;
+    title: string;
+}
+
+const useStyles = makeStyles(({ palette }) => ({
+    content: {
+        minWidth: 640,
+        maxWidth: 900
+    },
+    event: {
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '6px 8px',
+        borderBottom: '1px solid #e0e0e0',
+        fontSize: '0.8rem'
+    },
+    eventError: {
+        backgroundColor: '#fdecea'
+    },
+    eventWarn: {
+        backgroundColor: '#fff4e5'
+    },
+    meta: {
+        color: palette.primary.dark,
+        opacity: 0.7,
+        fontSize: '0.72rem',
+        marginBottom: 2
+    },
+    msg: {
+        color: palette.primary.dark,
+        wordBreak: 'break-word'
+    },
+    refs: {
+        marginTop: 2
+    },
+    data: {
+        marginTop: 2,
+        color: '#666',
+        fontFamily: 'monospace',
+        fontSize: '0.7rem',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word'
+    },
+    status: {
+        padding: 16,
+        color: palette.primary.dark
+    }
+}));
+
+type ReportRef = { name?: string; idSystemObject?: number };
+
+function isRef(value: unknown): value is ReportRef {
+    return typeof value === 'object' && value !== null && ('idSystemObject' in value || 'name' in value);
+}
+
+function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElement {
+    const { open, onClose, reportUrl, title } = props;
+    const classes = useStyles();
+    const [events, setEvents] = useState<IWorkflowReportEvent[] | null>(null);
+    const [status, setStatus] = useState<string>('Loading report…');
+
+    useEffect(() => {
+        if (!open) return;
+        let cancelled = false;
+        setEvents(null);
+        setStatus('Loading report…');
+
+        (async () => {
+            try {
+                const response = await fetch(reportUrl, { credentials: 'include' });
+                const text = await response.text();
+                let parsed: unknown = null;
+                try {
+                    parsed = JSON.parse(text);
+                } catch {
+                    parsed = null;
+                }
+                if (cancelled) return;
+                if (Array.isArray(parsed)) {
+                    setEvents(parsed as IWorkflowReportEvent[]);
+                    if (parsed.length === 0) setStatus('Report is empty.');
+                } else {
+                    setEvents(null);
+                    setStatus('This report is not a structured JSON report.');
+                }
+            } catch (error) {
+                if (!cancelled) setStatus(`Unable to load report: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        })();
+
+        return () => { cancelled = true; };
+    }, [open, reportUrl]);
+
+    const renderRefs = (data: { [key: string]: unknown } | undefined): React.ReactNode => {
+        if (!data) return null;
+        const nodes: React.ReactNode[] = [];
+        for (const [key, value] of Object.entries(data)) {
+            if (isRef(value) && typeof value.idSystemObject === 'number') {
+                nodes.push(
+                    <NewTabLink
+                        key={key}
+                        to={getDetailsUrlForObject(value.idSystemObject)}
+                        style={{ marginRight: 12 }}
+                    >
+                        {value.name ?? key}
+                    </NewTabLink>
+                );
+            } else if (key === 'href' && typeof value === 'string') {
+                nodes.push(
+                    <Link
+                        key={key}
+                        href={value}
+                        target='_blank'
+                        rel='noreferrer noopener'
+                        style={{ marginRight: 12 }}
+                    >
+                        Cook Job Output
+                    </Link>
+                );
+            }
+        }
+        return nodes.length > 0 ? <Box className={classes.refs}>{nodes}</Box> : null;
+    };
+
+    const renderData = (data: { [key: string]: unknown } | undefined): React.ReactNode => {
+        if (!data) return null;
+        const plain: { [key: string]: unknown } = {};
+        for (const [key, value] of Object.entries(data)) {
+            if (key === 'href' || isRef(value)) continue; // rendered as links above
+            plain[key] = value;
+        }
+        const keys = Object.keys(plain);
+        return keys.length > 0 ? <Box className={classes.data}>{JSON.stringify(plain)}</Box> : null;
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth='md'>
+            <DialogTitle disableTypography>
+                <Box display='flex' justifyContent='space-between' alignItems='center'>
+                    <Typography variant='h6'>{title}</Typography>
+                    <IconButton size='small' onClick={onClose} aria-label='close'>
+                        <CloseIcon />
+                    </IconButton>
+                </Box>
+            </DialogTitle>
+            <DialogContent dividers className={classes.content}>
+                {events && events.length > 0 ? (
+                    events.map((event, index) => (
+                        <Box
+                            key={index}
+                            className={`${classes.event} ${event.level === 'error' ? classes.eventError : ''} ${event.level === 'warn' ? classes.eventWarn : ''}`}
+                        >
+                            <span className={classes.meta}>
+                                {(event.ts ? formatDateAndTime(event.ts) : '')} · {event.phase} · {event.code}
+                            </span>
+                            <span className={classes.msg}>{event.msg}</span>
+                            {renderRefs(event.data)}
+                            {renderData(event.data)}
+                        </Box>
+                    ))
+                ) : (
+                    <Typography className={classes.status}>{status}</Typography>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default WorkflowReportViewer;

--- a/client/src/pages/Workflow/components/WorkflowView/WorkflowReportViewer.tsx
+++ b/client/src/pages/Workflow/components/WorkflowView/WorkflowReportViewer.tsx
@@ -2,30 +2,45 @@
  * WorkflowReportViewer
  *
  * Minimal viewer for a structured (application/json) workflow report. Fetches the report body from
- * the /download endpoint, parses the JSON event array, and renders a legible timeline. Entity
- * references embedded in an event's `data` render as safe links (built from ids, never from free
- * text). A legacy text/html report is not opened here — the caller falls back to a raw tab.
+ * the /download endpoint, parses the JSON event array, and renders a legible timeline (newest first).
+ * Entity references embedded in an event's `data` render as safe links (built from ids, never from
+ * free text). A legacy text/html report is not opened here — the caller falls back to a raw tab.
  */
 import React, { useEffect, useState } from 'react';
 import { Dialog, DialogTitle, DialogContent, IconButton, Box, Typography, Link } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
-import { IWorkflowReportEvent } from '@dpo-packrat/common';
+import { IWorkflowReportEvent, IWorkflowReportRef } from '@dpo-packrat/common';
 import { NewTabLink } from '../../../../components';
 import { getDetailsUrlForObject } from '../../../../utils/repository';
 import { formatDateAndTime } from '../../../../utils/shared';
+
+export interface WorkflowReportHeader {
+    title: string;
+    recipe?: string;
+    cookJobId?: string;
+    cookServer?: string;
+    started?: string;
+}
 
 interface WorkflowReportViewerProps {
     open: boolean;
     onClose: () => void;
     reportUrl: string;
-    title: string;
+    header: WorkflowReportHeader;
+    mimeType?: string | null;
 }
 
 const useStyles = makeStyles(({ palette }) => ({
     content: {
         minWidth: 640,
         maxWidth: 900
+    },
+    subtitle: {
+        color: palette.primary.dark,
+        opacity: 0.75,
+        fontSize: '0.72rem',
+        lineHeight: 1.4
     },
     event: {
         display: 'flex',
@@ -51,7 +66,17 @@ const useStyles = makeStyles(({ palette }) => ({
         wordBreak: 'break-word'
     },
     refs: {
-        marginTop: 2
+        marginTop: 3,
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '14px'
+    },
+    refLink: {
+        fontSize: '0.78rem'
+    },
+    refText: {
+        fontSize: '0.78rem',
+        color: palette.primary.dark
     },
     data: {
         marginTop: 2,
@@ -64,44 +89,67 @@ const useStyles = makeStyles(({ palette }) => ({
     status: {
         padding: 16,
         color: palette.primary.dark
+    },
+    legacyFrame: {
+        width: '100%',
+        height: '60vh',
+        border: 0,
+        backgroundColor: '#ffffff'
     }
 }));
 
-type ReportRef = { name?: string; idSystemObject?: number };
-
-function isRef(value: unknown): value is ReportRef {
+function isRef(value: unknown): value is IWorkflowReportRef {
     return typeof value === 'object' && value !== null && ('idSystemObject' in value || 'name' in value);
 }
 
+/** Label the object type of a reference, from most to least specific, for the [Type] link tag. */
+function refTypeLabel(ref: IWorkflowReportRef): string {
+    if (typeof ref.idScene === 'number') return 'Scene';
+    if (typeof ref.idModel === 'number') return 'Model';
+    if (typeof ref.idSubject === 'number') return 'Subject';
+    if (typeof ref.idAssetVersion === 'number' || typeof ref.idAsset === 'number') return 'Asset';
+    return 'Object';
+}
+
 function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElement {
-    const { open, onClose, reportUrl, title } = props;
+    const { open, onClose, reportUrl, header, mimeType } = props;
     const classes = useStyles();
     const [events, setEvents] = useState<IWorkflowReportEvent[] | null>(null);
+    const [legacyHtml, setLegacyHtml] = useState<string | null>(null);
     const [status, setStatus] = useState<string>('Loading report…');
 
     useEffect(() => {
         if (!open) return;
         let cancelled = false;
         setEvents(null);
+        setLegacyHtml(null);
         setStatus('Loading report…');
 
         (async () => {
             try {
                 const response = await fetch(reportUrl, { credentials: 'include' });
                 const text = await response.text();
-                let parsed: unknown = null;
-                try {
-                    parsed = JSON.parse(text);
-                } catch {
-                    parsed = null;
-                }
                 if (cancelled) return;
-                if (Array.isArray(parsed)) {
-                    setEvents(parsed as IWorkflowReportEvent[]);
-                    if (parsed.length === 0) setStatus('Report is empty.');
+
+                if (mimeType === 'application/json') {
+                    let parsed: unknown = null;
+                    try {
+                        parsed = JSON.parse(text);
+                    } catch {
+                        parsed = null;
+                    }
+                    if (Array.isArray(parsed)) {
+                        setEvents(parsed as IWorkflowReportEvent[]);
+                        if (parsed.length === 0) setStatus('Report is empty.');
+                    } else {
+                        // unexpected non-array JSON body — fall back to the safe raw render
+                        setLegacyHtml(text.trim().length ? text : null);
+                        if (!text.trim().length) setStatus('Report is empty.');
+                    }
                 } else {
-                    setEvents(null);
-                    setStatus('This report is not a structured JSON report.');
+                    // legacy text/html (or unknown) — render inertly in a sandboxed iframe (no scripts)
+                    setLegacyHtml(text.trim().length ? text : null);
+                    if (!text.trim().length) setStatus('Report is empty.');
                 }
             } catch (error) {
                 if (!cancelled) setStatus(`Unable to load report: ${error instanceof Error ? error.message : String(error)}`);
@@ -109,21 +157,32 @@ function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElem
         })();
 
         return () => { cancelled = true; };
-    }, [open, reportUrl]);
+    }, [open, reportUrl, mimeType]);
 
     const renderRefs = (data: { [key: string]: unknown } | undefined): React.ReactNode => {
         if (!data) return null;
         const nodes: React.ReactNode[] = [];
         for (const [key, value] of Object.entries(data)) {
-            if (isRef(value) && typeof value.idSystemObject === 'number') {
+            if (isRef(value)) {
+                if (typeof value.idSystemObject === 'number')
+                    nodes.push(
+                        <NewTabLink key={key} to={getDetailsUrlForObject(value.idSystemObject)} className={classes.refLink}>
+                            {`[${refTypeLabel(value)}] ${value.name ?? key}`}
+                        </NewTabLink>
+                    );
+                else if (value.name)
+                    nodes.push(<span key={key} className={classes.refText}>{`[${refTypeLabel(value)}] ${value.name}`}</span>);
+            } else if (key === 'output' && typeof value === 'string') {
                 nodes.push(
-                    <NewTabLink
+                    <Link
                         key={key}
-                        to={getDetailsUrlForObject(value.idSystemObject)}
-                        style={{ marginRight: 12 }}
+                        href={value}
+                        target='_blank'
+                        rel='noreferrer noopener'
+                        className={classes.refLink}
                     >
-                        {value.name ?? key}
-                    </NewTabLink>
+                        Cook Job Output
+                    </Link>
                 );
             } else if (key === 'href' && typeof value === 'string') {
                 nodes.push(
@@ -132,9 +191,9 @@ function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElem
                         href={value}
                         target='_blank'
                         rel='noreferrer noopener'
-                        style={{ marginRight: 12 }}
+                        className={classes.refLink}
                     >
-                        Cook Job Output
+                        Download
                     </Link>
                 );
             }
@@ -146,18 +205,31 @@ function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElem
         if (!data) return null;
         const plain: { [key: string]: unknown } = {};
         for (const [key, value] of Object.entries(data)) {
-            if (key === 'href' || isRef(value)) continue; // rendered as links above
+            if (key === 'href' || key === 'output' || isRef(value)) continue; // rendered as links above
             plain[key] = value;
         }
-        const keys = Object.keys(plain);
-        return keys.length > 0 ? <Box className={classes.data}>{JSON.stringify(plain)}</Box> : null;
+        return Object.keys(plain).length > 0 ? <Box className={classes.data}>{JSON.stringify(plain)}</Box> : null;
     };
+
+    const subtitleLines: string[] = [];
+    if (header.cookJobId) subtitleLines.push(`Cook Job: ${header.cookJobId}`);
+    if (header.recipe) subtitleLines.push(`Recipe: ${header.recipe}`);
+    if (header.started) subtitleLines.push(`Started: ${header.started}`);
+    if (header.cookServer) subtitleLines.push(`Cook Server: ${header.cookServer}`);
+
+    // newest-first
+    const ordered = events ? events.map((event, index) => ({ event, index })).reverse() : [];
 
     return (
         <Dialog open={open} onClose={onClose} maxWidth='md'>
             <DialogTitle disableTypography>
-                <Box display='flex' justifyContent='space-between' alignItems='center'>
-                    <Typography variant='h6'>{title}</Typography>
+                <Box display='flex' justifyContent='space-between' alignItems='flex-start'>
+                    <Box>
+                        <Typography variant='h6'>{header.title}</Typography>
+                        {subtitleLines.map((line, i) => (
+                            <div key={i} className={classes.subtitle}>{line}</div>
+                        ))}
+                    </Box>
                     <IconButton size='small' onClick={onClose} aria-label='close'>
                         <CloseIcon />
                     </IconButton>
@@ -165,7 +237,7 @@ function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElem
             </DialogTitle>
             <DialogContent dividers className={classes.content}>
                 {events && events.length > 0 ? (
-                    events.map((event, index) => (
+                    ordered.map(({ event, index }) => (
                         <Box
                             key={index}
                             className={`${classes.event} ${event.level === 'error' ? classes.eventError : ''} ${event.level === 'warn' ? classes.eventWarn : ''}`}
@@ -173,11 +245,18 @@ function WorkflowReportViewer(props: WorkflowReportViewerProps): React.ReactElem
                             <span className={classes.meta}>
                                 {(event.ts ? formatDateAndTime(event.ts) : '')} · {event.phase} · {event.code}
                             </span>
-                            <span className={classes.msg}>{event.msg}</span>
+                            {event.msg && event.msg.trim().length > 0 && <span className={classes.msg}>{event.msg}</span>}
                             {renderRefs(event.data)}
                             {renderData(event.data)}
                         </Box>
                     ))
+                ) : legacyHtml ? (
+                    <iframe
+                        title='Workflow report (legacy)'
+                        sandbox='allow-popups allow-popups-to-escape-sandbox'
+                        srcDoc={legacyHtml}
+                        className={classes.legacyFrame}
+                    />
                 ) : (
                     <Typography className={classes.status}>{status}</Typography>
                 )}

--- a/client/src/pages/Workflow/components/WorkflowView/workflowSummary.test.ts
+++ b/client/src/pages/Workflow/components/WorkflowView/workflowSummary.test.ts
@@ -1,0 +1,30 @@
+import { parseWorkflowSummary } from './workflowSummary';
+
+describe('parseWorkflowSummary', () => {
+    test('parses a valid JSON summary from an application/json row', () => {
+        const summary = { subject: 'DPO Testing', idSystemObject: 12178, cookServer: 'Cook Server: 1', cookJobId: 'abc' };
+        const result = parseWorkflowSummary({ ReportMimeType: 'application/json', Summary: JSON.stringify(summary) });
+        expect(result).not.toBeNull();
+        expect(result?.idSystemObject).toBe(12178);
+        expect(result?.cookServer).toBe('Cook Server: 1');
+    });
+
+    test('returns null for legacy (non-JSON) rows', () => {
+        const result = parseWorkflowSummary({ ReportMimeType: 'text/html', Summary: '{"idSystemObject":1}' });
+        expect(result).toBeNull();
+    });
+
+    test('returns null when the summary is absent', () => {
+        expect(parseWorkflowSummary({ ReportMimeType: 'application/json', Summary: null })).toBeNull();
+        expect(parseWorkflowSummary({ ReportMimeType: 'application/json' })).toBeNull();
+    });
+
+    test('returns null for invalid JSON rather than throwing', () => {
+        expect(parseWorkflowSummary({ ReportMimeType: 'application/json', Summary: 'not json' })).toBeNull();
+    });
+
+    test('returns null for null/undefined rows', () => {
+        expect(parseWorkflowSummary(null)).toBeNull();
+        expect(parseWorkflowSummary(undefined)).toBeNull();
+    });
+});

--- a/client/src/pages/Workflow/components/WorkflowView/workflowSummary.ts
+++ b/client/src/pages/Workflow/components/WorkflowView/workflowSummary.ts
@@ -1,0 +1,17 @@
+import { IWorkflowReportSummary } from '@dpo-packrat/common';
+
+/**
+ * Parse the compact per-row JSON summary (WorkflowReport.Name, surfaced as WorkflowListResult.Summary).
+ * Returns null for legacy rows (non-JSON MimeType), absent summaries, or invalid JSON so the table
+ * renders a blank cell rather than throwing.
+ */
+export function parseWorkflowSummary(row: { Summary?: string | null; ReportMimeType?: string | null } | null | undefined): IWorkflowReportSummary | null {
+    if (!row || row.ReportMimeType !== 'application/json' || !row.Summary)
+        return null;
+    try {
+        const parsed = JSON.parse(row.Summary);
+        return (parsed && typeof parsed === 'object') ? parsed as IWorkflowReportSummary : null;
+    } catch {
+        return null;
+    }
+}

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -2811,7 +2811,9 @@ export type WorkflowListResult = {
   JobRun?: Maybe<JobRun>;
   Owner?: Maybe<User>;
   ProjectName?: Maybe<Scalars['String']>;
+  ReportMimeType?: Maybe<Scalars['String']>;
   State?: Maybe<Scalars['String']>;
+  Summary?: Maybe<Scalars['String']>;
   Type?: Maybe<Scalars['String']>;
   UserInitiator?: Maybe<User>;
   Workflow?: Maybe<Workflow>;
@@ -3377,7 +3379,7 @@ export type GetWorkflowListQueryVariables = Exact<{
 }>;
 
 
-export type GetWorkflowListQuery = { __typename?: 'Query', getWorkflowList: { __typename?: 'GetWorkflowListResult', WorkflowList?: Array<{ __typename?: 'WorkflowListResult', idWorkflow: number, idWorkflowSet?: number | null, idWorkflowReport?: number | null, idJobRun?: number | null, Type?: string | null, State?: string | null, DateStart?: any | null, DateLast?: any | null, Error?: string | null, ProjectName?: string | null, Owner?: { __typename?: 'User', Name: string } | null } | null> | null } };
+export type GetWorkflowListQuery = { __typename?: 'Query', getWorkflowList: { __typename?: 'GetWorkflowListResult', WorkflowList?: Array<{ __typename?: 'WorkflowListResult', idWorkflow: number, idWorkflowSet?: number | null, idWorkflowReport?: number | null, idJobRun?: number | null, Type?: string | null, State?: string | null, DateStart?: any | null, DateLast?: any | null, Error?: string | null, ProjectName?: string | null, Summary?: string | null, ReportMimeType?: string | null, Owner?: { __typename?: 'User', Name: string } | null } | null> | null } };
 
 
 export const DiscardUploadedAssetVersionsDocument = gql`
@@ -6872,6 +6874,8 @@ export const GetWorkflowListDocument = gql`
       DateLast
       Error
       ProjectName
+      Summary
+      ReportMimeType
     }
   }
 }

--- a/common/index.ts
+++ b/common/index.ts
@@ -4,3 +4,4 @@
 
 export * from './constants';
 export * from './packageValidation';
+export * from './report';

--- a/common/report.ts
+++ b/common/report.ts
@@ -67,6 +67,8 @@ export const WorkflowReportCode = {
     InspectInvalid: 'inspect.invalid',
     SceneNote: 'scene.note',
     SceneIngested: 'scene.ingested',
+    ModelNote: 'model.note',
+    ModelIngested: 'model.ingested',
     DownloadNote: 'download.note',
     DownloadIngested: 'download.ingested',
     IngestNote: 'ingest.note',

--- a/common/report.ts
+++ b/common/report.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared, engine-agnostic format for workflow reports.
+ *
+ * A report body (WorkflowReport.Data) is a JSON array of IWorkflowReportEvent; a compact
+ * IWorkflowReportSummary is stored in WorkflowReport.Name to drive the workflow table cheaply.
+ * These types are the stable contract between whatever produces reports and whatever renders
+ * them, so they live here with no external dependencies.
+ */
+
+export type WorkflowReportPhase = 'engine' | 'cook' | 'ingest' | 'storage' | 'system';
+export type WorkflowReportLevel = 'info' | 'warn' | 'error';
+
+/** A reference to a Packrat object embedded in an event's data, carrying id(s) so a viewer can
+ * build a safe link instead of parsing one out of free text. */
+export interface IWorkflowReportRef {
+    name: string;
+    idSystemObject?: number;
+    idAsset?: number;
+    idAssetVersion?: number;
+    idModel?: number;
+    idScene?: number;
+    idSubject?: number;
+}
+
+/** One entry in the report body (WorkflowReport.Data JSON array). */
+export interface IWorkflowReportEvent {
+    ts: string;                             // ISO-8601 timestamp
+    phase: WorkflowReportPhase;
+    code: string;                           // a WorkflowReportCode value
+    level?: WorkflowReportLevel;            // defaults to 'info'
+    msg: string;
+    data?: { [key: string]: unknown };      // small, code-specific payload (may hold IWorkflowReportRef)
+}
+
+/** Compact summary stored in WorkflowReport.Name (VARCHAR 512). All fields optional and populated
+ * as they become known; the table renders a blank cell for anything absent. */
+export interface IWorkflowReportSummary {
+    subject?: string;
+    idSubject?: number;
+    scene?: string;
+    idScene?: number;
+    idModel?: number;
+    idSystemObject?: number;
+    mediaGroup?: string;
+    cookServer?: string;
+    cookJobId?: string;
+    input?: string;
+    recipe?: string;
+}
+
+/** Stable string codes for events. New codes append here; renderers key off these. */
+export const WorkflowReportCode = {
+    JobCreate: 'job.create',
+    JobRun: 'job.run',
+    JobSchedule: 'job.schedule',
+    JobCreated: 'job.created',
+    JobWaiting: 'job.waiting',
+    JobStart: 'job.start',
+    JobSuccess: 'job.success',
+    JobFailure: 'job.failure',
+    JobCancel: 'job.cancel',
+    JobWarning: 'job.warning',
+    JobLog: 'job.log',
+    CookMatched: 'cook.matched',
+    CookLog: 'cook.log',
+    InspectNote: 'inspect.note',
+    InspectInvalid: 'inspect.invalid',
+    SceneNote: 'scene.note',
+    SceneIngested: 'scene.ingested',
+    DownloadNote: 'download.note',
+    DownloadIngested: 'download.ingested',
+    IngestNote: 'ingest.note',
+    LegacyText: 'legacy.text',
+} as const;
+
+export type WorkflowReportCodeType = typeof WorkflowReportCode[keyof typeof WorkflowReportCode];
+
+/** Max serialized length of the summary (WorkflowReport.Name is VARCHAR 512). */
+export const WorkflowReportSummaryMaxLength: number = 512;

--- a/server/db/api/composite/WorkflowListResult.ts
+++ b/server/db/api/composite/WorkflowListResult.ts
@@ -17,6 +17,8 @@ export class WorkflowListResult {
     DateLast: Date = new Date();
     Error: string = '';
     ProjectName: string | null = null;
+    Summary: string | null = null;
+    ReportMimeType: string | null = null;
 
     static async search(idVWorkflowType: number[] | undefined | null, idVJobType: number[] | undefined | null, State: number[] | undefined | null,
         DateFrom: Date | undefined | null, DateTo: Date | undefined | null, idUserInitiator: number[] | undefined | null, idUserOwner: number[] | undefined | null,
@@ -142,7 +144,9 @@ export class WorkflowListResult {
                 CASE IFNULL(JOB.JobStatus, WFL.WFState) WHEN 0 THEN 'Uninitialized' WHEN 1 THEN 'Created' WHEN 2 THEN 'Running' WHEN 3 THEN 'Waiting' WHEN 4 THEN 'Done' WHEN 5 THEN 'Error' WHEN 6 THEN 'Canceled' ELSE 'Uninitialized' END AS 'State',
                 WF.idUserInitiator AS 'idUserInitiator', WFL.idWFSOwner AS 'idOwner', WF.DateInitiated AS 'DateStart', WF.DateUpdated AS 'DateLast',
                 JOB.JobError AS 'Error',
-                P.Name AS 'ProjectName'
+                P.Name AS 'ProjectName',
+                WR.Name AS 'Summary',
+                WR.MimeType AS 'ReportMimeType'
             FROM Workflow AS WF
             LEFT JOIN Vocabulary AS VWF ON (WF.idVWorkflowType = VWF.idVocabulary)
             LEFT JOIN WFLast AS WFL ON (WF.idWorkflow = WFL.idWorkflow)

--- a/server/graphql/api/queries/workflow/getWorkflowList.ts
+++ b/server/graphql/api/queries/workflow/getWorkflowList.ts
@@ -17,6 +17,8 @@ const getWorkflowList = gql`
                 DateLast
                 Error
                 ProjectName
+                Summary
+                ReportMimeType
             }
         }
     }

--- a/server/graphql/schema.graphql
+++ b/server/graphql/schema.graphql
@@ -2277,7 +2277,9 @@ type WorkflowListResult {
   JobRun: JobRun
   Owner: User
   ProjectName: String
+  ReportMimeType: String
   State: String
+  Summary: String
   Type: String
   UserInitiator: User
   Workflow: Workflow

--- a/server/graphql/schema/ResolverBase.ts
+++ b/server/graphql/schema/ResolverBase.ts
@@ -10,6 +10,21 @@ export interface IWorkflowHelper extends H.IOResults {
     workflowReport?: REP.IReport | null | undefined;
 }
 
+/** Reduce a legacy HTML-ish report line to plain text: drop tags, decode the few common entities,
+ * collapse whitespace. Keeps the structured JSON body free of markup (and of its XSS surface). */
+function stripReportHtml(content: string): string {
+    return content
+        .replace(/<[^>]+>/g, '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, '\'')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/[ \t]+/g, ' ')
+        .trim();
+}
+
 export class ResolverBase {
     protected workflowHelper: IWorkflowHelper | undefined = undefined;
     private buffer: COMMON.IWorkflowReportEvent[] = [];
@@ -30,7 +45,7 @@ export class ResolverBase {
             phase: 'ingest',
             code: COMMON.WorkflowReportCode.IngestNote,
             level: (error === true) ? 'error' : 'info',
-            msg: content
+            msg: stripReportHtml(content)
         };
 
         if (!(this?.workflowHelper?.workflowReport)) {

--- a/server/graphql/schema/ResolverBase.ts
+++ b/server/graphql/schema/ResolverBase.ts
@@ -1,6 +1,7 @@
 import * as WF from '../../workflow/interface';
 import * as REP from '../../report/interface';
 import * as H from '../../utils/helpers';
+import * as COMMON from '@dpo-packrat/common';
 import { RecordKeeper as RK } from '../../records/recordKeeper';
 
 export interface IWorkflowHelper extends H.IOResults {
@@ -11,7 +12,7 @@ export interface IWorkflowHelper extends H.IOResults {
 
 export class ResolverBase {
     protected workflowHelper: IWorkflowHelper | undefined = undefined;
-    private buffer: string = '';
+    private buffer: COMMON.IWorkflowReportEvent[] = [];
 
     protected async appendToWFReport(content: string, log?: boolean | undefined, error?: boolean | undefined): Promise<H.IOResults> {
         if (log && log===true) {
@@ -24,14 +25,24 @@ export class ResolverBase {
         if (this.workflowHelper && !this.workflowHelper.workflowReport)
             this.workflowHelper.workflowReport = await REP.ReportFactory.getReport();
 
-        const seperator: string = (this.buffer) ? '<br/>\n' : '';
+        const event: COMMON.IWorkflowReportEvent = {
+            ts: new Date().toISOString(),
+            phase: 'ingest',
+            code: COMMON.WorkflowReportCode.IngestNote,
+            level: (error === true) ? 'error' : 'info',
+            msg: content
+        };
+
         if (!(this?.workflowHelper?.workflowReport)) {
-            this.buffer += seperator + content;
+            this.buffer.push(event);
             RK.logDebug(RK.LogSection.eGQL,'append to WorkflowReport deferred','no active WorkflowReport yet, buffering content',{ ...this.workflowHelper },'GraphQL.Resolver');
             return { success: true };
         }
-        const ret: H.IOResults = await this.workflowHelper.workflowReport.append(this.buffer + seperator + content);
-        this.buffer = '';
-        return ret;
+
+        for (const buffered of this.buffer)
+            await RK.reportEvent(buffered, this.workflowHelper.workflowReport);
+        this.buffer = [];
+        const result = await RK.reportEvent(event, this.workflowHelper.workflowReport);
+        return { success: result.success, error: result.success ? undefined : result.message };
     }
 }

--- a/server/graphql/schema/workflow/types.graphql
+++ b/server/graphql/schema/workflow/types.graphql
@@ -87,6 +87,8 @@ type WorkflowListResult {
     DateLast: DateTime
     Error: String
     ProjectName: String
+    Summary: String
+    ReportMimeType: String
     UserInitiator: User
     Owner: User
     Workflow: Workflow

--- a/server/http/routes/api/bulkOps/fixSceneBasenames.ts
+++ b/server/http/routes/api/bulkOps/fixSceneBasenames.ts
@@ -1,12 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as DBAPI from '../../../../db';
-import * as STORE from '../../../../storage/interface';
 import { cookOutputSuffixes } from '../../../../job/impl/Cook/CookOutputContract';
 import { NameHelpers, UNKNOWN_NAME } from '../../../../utils/nameHelpers';
-import { RecordKeeper as RK } from '../../../../records/recordKeeper';
 import { BulkOperationDef, BulkOpRow, BulkOpGatherArgs, BulkOpReporter, BulkOpApplyResult } from './BulkOpTypes';
-
-const SRC = 'HTTP.Route.BulkOp.FixSceneBasenames';
 
 // The endsWith-form suffixes of every Cook-output asset (6 downloads + the .svx.json descriptor),
 // sourced from the shared CookOutputContract so this stays aligned with the guards it recovers from.
@@ -117,7 +113,7 @@ async function computeState(idSystemObject: number): Promise<StateInfo> {
 
 function statusLabel(status: SceneStatus): string {
     switch (status) {
-        case 'fixable':    return 'Fixable';
+        case 'fixable':    return 'Affected (manual)';
         case 'mixed':      return 'Mixed basenames (manual)';
         case 'consistent': return 'Consistent';
         case 'unresolved': return 'Name unresolved (manual)';
@@ -132,7 +128,7 @@ async function toRow(idSystemObject: number, state: StateInfo): Promise<BulkOpRo
     return {
         id: idSystemObject,
         name: await sceneName(idSystemObject),
-        isCandidate: state.status === 'fixable', // only fixable rows are selectable; the rest are report-only
+        isCandidate: false, // review-only: every row is report-only; no row is selectable / auto-correctable
         rowData: {
             status: statusLabel(state.status),
             canonicalName: state.canonical ?? '—',
@@ -144,30 +140,30 @@ async function toRow(idSystemObject: number, state: StateInfo): Promise<BulkOpRo
 }
 
 /**
- * Recover a scene whose download/SVX asset filenames drifted from the current Subject.Name (the state
- * that makes the Generate Downloads pre-flight guard and the scene-generation SVX check hard block
- * after a subject is renamed). `apply` renames each Cook-output asset to the canonical basename via
- * AssetStorageAdapter.renameAsset — an OCFL-aware rename creating a new, non-destructive AssetVersion.
+ * REVIEW-ONLY. Reports scenes whose download/SVX asset filenames drifted from the current Subject.Name
+ * — the state that makes the Generate Downloads pre-flight guard and the scene-generation SVX check
+ * hard block after a subject is renamed — and classifies each. It performs NO correction.
  *
- * Scope param:
- *   - `fixable`  (default) — list only scenes we can confidently repair (selectable).
- *   - `affected` (report-only) — additionally list scenes that are affected but NOT auto-fixable
- *     (mixed basenames), each with a Status + reason so the extent and cause are visible. Only
- *     `fixable` rows are selectable; the report rows can be seen but not acted on.
+ * Why no automated rename: a safe correction is a three-part transaction — rename the storage assets,
+ * rewrite the SVX's internal `asset.uri` references, AND update the derivative model/asset DB records.
+ * Renaming the files alone would break the published/viewed SVX (its internal URIs would point at
+ * filenames that no longer exist) and leave the DB inconsistent. So remediation is manual for now (or
+ * a future correction op that performs all three). The scene-generation and Generate Downloads hard
+ * blocks are what prevent NEW drift from being created; this op only surfaces existing drift.
  *
- * Confidence gate (both gather and apply): the op only acts on a single, uniform Subject.Name rename
- * — canonical resolves to exactly one Subject.Name AND every Cook-output asset shares one old
- * basename that differs from it. Multi-subject / ambiguous-hierarchy and mixed-basename scenes are
- * refused, not guessed at. (Multi-subject scenes take the source-filename basename, which a subject
- * rename does not change, so a uniform one is not affected and is not listed even in `affected`.)
+ * Scope param (both are report scopes; nothing is selectable):
+ *   - `fixable`  (default) — list only cleanly-identifiable single Subject.Name drift.
+ *   - `affected` — additionally list scenes affected but not cleanly classifiable (mixed basenames),
+ *     each with a Status + reason so the extent and cause are visible.
  *
- * Scope boundary: renames the download and SVX *filenames* only. It does NOT rename derivative model
- * records or re-point the SVX's internal `asset.uri` values, so it does not by itself clear the deeper
- * scene-generation model-name fork. It unblocks Generate Downloads and the SVX-filename check.
+ * Classification gate: a scene is flagged only when canonical resolves to exactly one Subject.Name AND
+ * every Cook-output asset shares one old basename that differs from it. Multi-subject / ambiguous and
+ * mixed-basename scenes are reported (or omitted), never guessed at. (Multi-subject scenes take the
+ * source-filename basename, which a subject rename does not change, so a uniform one is not affected.)
  */
 export const fixSceneBasenames: BulkOperationDef = {
     key: 'fixSceneBasenames',
-    label: 'Fix Scene Basenames',
+    label: 'Review Scene Basenames',
     columns: [
         { key: 'status', label: 'Status' },
         { key: 'canonicalName', label: 'Canonical Name (Subject)' },
@@ -203,50 +199,14 @@ export const fixSceneBasenames: BulkOperationDef = {
         }
         return rows;
     },
-    apply: async (idSystemObject: number, _rowSettings: any, idUser: number): Promise<BulkOpApplyResult> => {
-        const state = await computeState(idSystemObject);
-
-        if (state.status === 'consistent')
-            return { success: true, message: 'already consistent', rowData: { status: 'Consistent', fileCount: 0, details: '—' } };
-        if (state.status !== 'fixable')
-            return { success: false, message: `refused: ${state.reason || state.status}` };
-
-        const user = await DBAPI.User.fetch(idUser);
-        const opInfo: STORE.OperationInfo = {
-            message: `Fix scene basenames → ${state.canonical}`,
-            idUser,
-            userEmailAddress: user?.EmailAddress ?? '',
-            userName: user?.Name ?? '',
-        };
-
-        const renamed: string[] = [];
-        const failed: string[] = [];
-        for (const r of state.renames) {
-            const ASR = await STORE.AssetStorageAdapter.renameAsset(r.asset, r.to, opInfo);
-            if (ASR.success)
-                renamed.push(`${r.from} → ${r.to}`);
-            else {
-                failed.push(r.from);
-                RK.logError(RK.LogSection.eHTTP,'fix scene basenames','asset rename failed',
-                    { idSystemObject, from: r.from, to: r.to, error: ASR.error, idUser },SRC);
-            }
-        }
-
-        const after = await computeState(idSystemObject);
-        const remaining: number = after.status === 'fixable' ? after.renames.length : 0;
-        RK.logInfo(RK.LogSection.eHTTP,'fix scene basenames',`renamed ${renamed.length} asset(s), ${remaining} remaining`,
-            { idSystemObject, canonicalName: state.canonical, renamed, failed, idUser },SRC);
-
+    // Review-only: no automated correction. A safe rename must also rewrite the SVX internal asset
+    // references and the model/asset DB records (see the header), so it is left to manual remediation.
+    // No row is selectable, so the harness never invokes this; it refuses defensively if ever called.
+    apply: async (): Promise<BulkOpApplyResult> => {
         return {
-            success: failed.length === 0 && remaining === 0,
-            message: failed.length === 0
-                ? `renamed ${renamed.length} asset(s) to ${state.canonical}`
-                : `renamed ${renamed.length}, ${failed.length} failed`,
-            rowData: {
-                status: statusLabel(after.status),
-                fileCount: remaining,
-                details: after.status === 'fixable' ? after.renames.map(r => `${r.from} → ${r.to}`).sort().join(', ') : '—',
-            },
+            success: false,
+            message: 'Review Scene Basenames is review-only: a safe rename must also rewrite the SVX '
+                + 'internal asset references and the model DB records, so correction is manual.',
         };
     },
 };

--- a/server/http/routes/download.ts
+++ b/server/http/routes/download.ts
@@ -238,6 +238,25 @@ export class Downloader {
         const mimeType: string = WFReports[0].MimeType;
         const idWorkflowReport: number = WFReports[0].idWorkflowReport;
 
+        // JSON reports merge as a single JSON array of parsed bodies; legacy text/html reports keep the <br/> join
+        if (mimeType === 'application/json') {
+            this.response.setHeader('Content-disposition', `inline; filename=WorkflowReport.${idWorkflowReport}.json`);
+            this.response.setHeader('Content-type', 'application/json');
+            const merged: unknown[] = [];
+            for (const report of WFReports) {
+                try {
+                    const parsed: unknown = JSON.parse(report.Data || '[]');
+                    merged.push(parsed);
+                } catch {
+                    merged.push(report.Data); // preserve an unparseable body rather than fail the whole set
+                }
+            }
+            // a single report emits its own body directly; a set emits an array of report bodies
+            this.response.write(JSON.stringify(merged.length === 1 ? merged[0] : merged));
+            this.response.end();
+            return true;
+        }
+
         this.response.setHeader('Content-disposition', `inline; filename=WorkflowReport.${idWorkflowReport}.htm`);
         if (mimeType)
             this.response.setHeader('Content-type', mimeType);

--- a/server/http/routes/download.ts
+++ b/server/http/routes/download.ts
@@ -3,6 +3,7 @@ import * as CACHE from '../../cache';
 import * as H from '../../utils/helpers';
 import * as ZIP from '../../utils/zipStream';
 import * as STORE from '../../storage/interface';
+import * as REP from '../../report/interface';
 import { AuditFactory } from '../../audit/interface/AuditFactory';
 import { eEventKey } from '../../event/interface/EventEnums';
 import { DownloaderParser, DownloaderParserResults, eDownloadMode } from './DownloaderParser';
@@ -238,21 +239,11 @@ export class Downloader {
         const mimeType: string = WFReports[0].MimeType;
         const idWorkflowReport: number = WFReports[0].idWorkflowReport;
 
-        // JSON reports merge as a single JSON array of parsed bodies; legacy text/html reports keep the <br/> join
+        // JSON reports merge as a single JSON body (a set becomes an array); legacy text/html keeps the <br/> join
         if (mimeType === 'application/json') {
             this.response.setHeader('Content-disposition', `inline; filename=WorkflowReport.${idWorkflowReport}.json`);
             this.response.setHeader('Content-type', 'application/json');
-            const merged: unknown[] = [];
-            for (const report of WFReports) {
-                try {
-                    const parsed: unknown = JSON.parse(report.Data || '[]');
-                    merged.push(parsed);
-                } catch {
-                    merged.push(report.Data); // preserve an unparseable body rather than fail the whole set
-                }
-            }
-            // a single report emits its own body directly; a set emits an array of report bodies
-            this.response.write(JSON.stringify(merged.length === 1 ? merged[0] : merged));
+            this.response.write(REP.ReportFormat.mergeJSONReports(WFReports.map(report => report.Data)));
             this.response.end();
             return true;
         }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -8,6 +8,7 @@ import { Config } from '../../../config';
 import * as H from '../../../utils/helpers';
 import * as COOKRES from '../../../job/impl/Cook/CookResource';
 import { RecordKeeper as RK } from '../../../records/recordKeeper';
+import * as COMMON from '@dpo-packrat/common';
 
 import { Actor } from '../../../audit/Actor';
 import { withActor } from '../../../audit/resolveActor';
@@ -86,6 +87,7 @@ export abstract class JobCook<T> extends JobPackrat {
 
     // TODO: additional error reporting out to generated report
 
+    protected reportPhase: COMMON.WorkflowReportPhase = 'cook';
     private _configuration: JobCookConfiguration;
     protected _idAssetVersions: number[] | null;
     protected _skipCleanup: boolean = false;
@@ -150,7 +152,7 @@ export abstract class JobCook<T> extends JobPackrat {
         // TODO: debug mode outputting all considered resources and the one chosen
         const bestFit: COOKRES.CookResourceInfo = cookResources.resources[this._configuration.cookServerURLIndex];
         const reportMsg: string = `Matched ${cookResources.resources.length} Cook resources. The best fit is ${COOKRES.getResourceInfoString(bestFit,job)}`;
-        this.appendToReportAndLog(reportMsg);
+        this.appendToReportAndLog(reportMsg, undefined, { code: COMMON.WorkflowReportCode.CookMatched, data: { matched: cookResources.resources.length, cookServer: bestFit.name, recipe: job } });
 
         // return success
         this._initialized = true;

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -37,6 +37,7 @@ type CookIOResults = H.IOResults & {
 class JobCookConfiguration {
     clientId: string;
     jobName: string;
+    recipeName: string;
     recipeId: string;
     jobId: string;
     cookServerURLs: string[];
@@ -44,6 +45,7 @@ class JobCookConfiguration {
 
     constructor(clientId: string, jobName: string, recipeId: string, jobId: string | null, dbJobRun: DBAPI.JobRun, serverURL: string[] | null) {
         this.clientId = clientId;
+        this.recipeName = jobName;
         this.jobName = `${jobName}: ${dbJobRun.idJobRun}`;
         this.recipeId = recipeId;
         this.jobId = jobId || uuidv4(); // create a new JobID if we haven't provided one
@@ -305,6 +307,9 @@ export abstract class JobCook<T> extends JobPackrat {
         try {
             // get our parameters
             const sceneParams = await this.getParameters();
+
+            // write an initial report summary now that domain context is available (refined at start/terminal)
+            await this.writeReportSummary();
 
             // Create job via POST to /job
             let requestUrl: string = this.CookServerURL() + 'job';
@@ -886,6 +891,34 @@ export abstract class JobCook<T> extends JobPackrat {
         );
     }
 
+    //#region report summary
+    /** Subclasses provide domain-specific summary fields; merged with the base Cook fields below. */
+    protected reportSummaryContext(): Partial<COMMON.IWorkflowReportSummary> {
+        return {};
+    }
+
+    /** Write the compact, table-driving report summary. Progressive: called at start and terminal, so
+     * later writes refine fields (e.g. an ingested scene) that were not yet known at start. */
+    protected async writeReportSummary(): Promise<void> {
+        if (!this._report)
+            return;
+        const summary: COMMON.IWorkflowReportSummary = {
+            cookServer: this.CookServerURL(),
+            cookJobId: this._configuration.jobId,
+            recipe: this._configuration.recipeName,
+            ...this.reportSummaryContext(),
+        };
+        await RK.reportSetSummary(summary, this._report);
+    }
+    //#endregion
+
+    protected async recordStart(idJob: string): Promise<boolean> {
+        const updated: boolean = await super.recordStart(idJob);
+        if (updated)
+            await this.writeReportSummary();
+        return updated;
+    }
+
     protected async recordSuccess(output: string): Promise<boolean> {
 
         // make sure underlying job has updated
@@ -894,6 +927,7 @@ export abstract class JobCook<T> extends JobPackrat {
         // if it did update that means we had success and finished job specific cleanup
         // so it should be safe to remove the cook resources used
         if(updated) {
+            await this.writeReportSummary();
             if (this._skipCleanup) {
                 RK.logInfo(RK.LogSection.eJOB, 'Cook cleanup skipped', 'skipJobCleanup flag is set', { ...this._configuration }, 'Job.Cook');
             } else {

--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -460,6 +460,19 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
         };
     }
 
+    protected reportSummaryContext(): Partial<COMMON.IWorkflowReportSummary> {
+        const sph = this.sceneParameterHelper;
+        return {
+            subject: sph?.OG?.subject?.[0]?.Name,
+            idSubject: sph?.OG?.subject?.[0]?.idSubject,
+            scene: sph?.sceneName,
+            idScene: this.idScene ?? undefined,
+            idModel: sph?.SOModelSource?.idModel ?? undefined,
+            idSystemObject: sph?.SOModelSource?.idSystemObject,
+            input: this.parameters?.svxFile,
+        };
+    }
+
     protected async recordSuccess(output: string): Promise<boolean> {
         const updated: boolean = await super.recordSuccess(output);
         if (updated) {

--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -614,13 +614,12 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
         // build out our report details and add
         const assetVersion: DBAPI.AssetVersion | null = (IAR.assetVersions && IAR.assetVersions.length > 0) ? IAR.assetVersions[0] : null;
-        const pathObject: string = idSystemObjectModel ? RouteBuilder.RepositoryDetails(idSystemObjectModel, eHrefMode.ePrependClientURL) : '';
-        const hrefObject: string = H.Helpers.computeHref(pathObject, model.Name);
         const pathDownload: string = assetVersion ? RouteBuilder.DownloadAssetVersion(assetVersion.idAssetVersion, eHrefMode.ePrependServerURL) : '';
-        const hrefDownload: string = pathDownload ? ': ' + H.Helpers.computeHref(pathDownload, 'Download') : '';
+        const modelRef: COMMON.IWorkflowReportRef = { name: model.Name, idModel: model.idModel, idSystemObject: idSystemObjectModel ?? undefined, idAssetVersion: assetVersion?.idAssetVersion };
 
-        RK.logInfo(RK.LogSection.eJOB,'process model','ingested generated download model',{ jobName: this.name(), pathObject, pathDownload },'Job.GenerateDownloads');
-        await this.appendToReportAndLog(`${this.name()} ingested generated download model ${hrefObject}${hrefDownload}`);
+        RK.logInfo(RK.LogSection.eJOB,'process model','ingested generated download model',{ jobName: this.name(), idSystemObjectModel, pathDownload },'Job.GenerateDownloads');
+        await this.appendToReportAndLog(`${this.name()} ingested generated download model ${model.Name}`, undefined,
+            { code: COMMON.WorkflowReportCode.DownloadIngested, data: { model: modelRef, href: pathDownload || undefined } });
 
         // currently not passed in. how is this used?
         const assetVersionOverrideMap: Map< number, number> = new Map<number, number>();
@@ -970,13 +969,12 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
         const SOI: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromScene(scene);
         const assetVersion: DBAPI.AssetVersion | null = (IAR.assetVersions && IAR.assetVersions.length > 0) ? IAR.assetVersions[0] : null;
-        const pathObject: string = SOI ? RouteBuilder.RepositoryDetails(SOI.idSystemObject, eHrefMode.ePrependClientURL) : '';
-        const hrefObject: string = H.Helpers.computeHref(pathObject, scene.Name);
         const pathDownload: string = assetVersion ? RouteBuilder.DownloadAssetVersion(assetVersion.idAssetVersion, eHrefMode.ePrependServerURL) : '';
-        const hrefDownload: string = pathDownload ? ': ' + H.Helpers.computeHref(pathDownload, 'Download') : '';
+        const sceneRef: COMMON.IWorkflowReportRef = { name: scene.Name, idScene: scene.idScene, idSystemObject: SOI?.idSystemObject, idAssetVersion: assetVersion?.idAssetVersion };
 
-        RK.logInfo(RK.LogSection.eJOB,'process scene','ingested scene', { jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathObject, pathDownload },'Job.GenerateDownloads');
-        await this.appendToReportAndLog(`${this.name()} ingested scene ${hrefObject}${hrefDownload}`);
+        RK.logInfo(RK.LogSection.eJOB,'process scene','ingested scene', { jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, idSystemObject: SOI?.idSystemObject, pathDownload },'Job.GenerateDownloads');
+        await this.appendToReportAndLog(`${this.name()} ingested scene ${scene.Name}`, undefined,
+            { code: COMMON.WorkflowReportCode.SceneIngested, data: { scene: sceneRef, href: pathDownload || undefined } });
 
         //#region legacy
         // previous version handled all models while working with the scene. Order of operations prevents this from working

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -299,7 +299,13 @@ export class JobCookSIPackratInspectOutput implements H.IOResults {
         const JCOutput: JobCookSIPackratInspectOutput = await JobCookSIPackratInspectOutput.extractWorker(output, fileName, dateCreated);
         const report: REP.IReport | null = await REP.ReportFactory.getReport();
         if (report)
-            report.append(`Cook si-packrat-inspect ${JCOutput.success ? 'succeeded' : 'failed: ' + JCOutput.error}`);
+            await RK.reportEvent({
+                ts: new Date().toISOString(),
+                phase: 'cook',
+                code: COMMON.WorkflowReportCode.InspectNote,
+                level: JCOutput.success ? 'info' : 'error',
+                msg: `Cook si-packrat-inspect ${JCOutput.success ? 'succeeded' : 'failed: ' + JCOutput.error}`
+            }, report);
         return JCOutput;
     }
 
@@ -880,11 +886,20 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         }
     }
 
+    // Report an inspection outcome as a coded event (invalid → error-tinted). RK error logging is
+    // handled at each call site, so this only sets the event level, not another RK.logError.
+    private async reportInspect(msg: string, invalid: boolean): Promise<void> {
+        await this.appendToReportAndLog(msg, undefined, {
+            code: invalid ? COMMON.WorkflowReportCode.InspectInvalid : COMMON.WorkflowReportCode.InspectNote,
+            level: invalid ? 'error' : 'info'
+        });
+    }
+
     protected async verifyRequest(): Promise<JobIOResults> {
         const superResult: JobIOResults = await super.verifyRequest();
         if(superResult.success===false) {
             RK.logError(RK.LogSection.eJOB,'verify request failed',`request is invalid: ${superResult.error}`,{ sourceMeshFile: this.parameters.sourceMeshFile, jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-            this.appendToReportAndLog(`[CookJob:Inspection] request is invalid. ${superResult.error} (${this.parameters.sourceMeshFile})`);
+            this.reportInspect(`[CookJob:Inspection] request is invalid. ${superResult.error} (${this.parameters.sourceMeshFile})`, true);
             return superResult;
         }
 
@@ -897,7 +912,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
 
         // we're good to continue
         RK.logDebug(RK.LogSection.eJOB,'verify request success','request is valid. sending to Cook...',{ sourceMeshFile: this.parameters.sourceMeshFile, jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-        this.appendToReportAndLog(`[CookJob:Inspection] request is valid. sending to Cook... (${this.parameters.sourceMeshFile})`);
+        this.reportInspect(`[CookJob:Inspection] request is valid. sending to Cook... (${this.parameters.sourceMeshFile})`, false);
         return { success: true, allowRetry: false };
     }
 
@@ -911,7 +926,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         // does not consolidate the log messages.
         if(!cookJobReport.steps['inspect-mesh'] || !cookJobReport.steps['inspect-mesh'].log) {
             RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: missing inspect-mesh and/or log objects',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. missing inspect-mesh and/or log objects');
+            this.reportInspect('[CookJob:Inspection] response is invalid. missing inspect-mesh and/or log objects', true);
             return { success: false, error: 'missing log objects in Cook report', allowRetry: false };
         }
         const logs = cookJobReport.steps['inspect-mesh'].log;
@@ -934,14 +949,14 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             }
 
             RK.logError(RK.LogSection.eJOB,'verify response failed',`response is invalid: ${superResult.error}`,{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-            this.appendToReportAndLog(`[CookJob:Inspection] response is invalid. ${superResult.error}`);
+            this.reportInspect(`[CookJob:Inspection] response is invalid. ${superResult.error}`, true);
             return superResult;
         }
 
         // check for ZIP processing errors
         if(logContains(logs,'Error: Unsupported file type: .zip')===true) {
             RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: Zip package incomplete or corrupt.',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Zip package incomplete or corrupt.');
+            this.reportInspect('[CookJob:Inspection] response is invalid. Zip package incomplete or corrupt.', true);
             return { success: false, error: 'Zip package incomplete or corrupt.', allowRetry: false };
         }
 
@@ -957,7 +972,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             if(errors.length>0) {
                 const errorMsg = errors.join(' | ');
                 RK.logError(RK.LogSection.eJOB,'verify response failed',`response is invalid: ${errorMsg}`,{  jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, inspectionRoot },'Job.PackratInspect');
-                this.appendToReportAndLog(`[CookJob:Inspection] response is invalid: ${errorMsg}`);
+                this.reportInspect(`[CookJob:Inspection] response is invalid: ${errorMsg}`, true);
                 return { success: false, error: errorMsg, allowRetry: false };
             }
         }
@@ -965,7 +980,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         // get our geometry results
         if (!inspectionRoot?.meshes) {
             RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: Missing meshes in inspection result.',{  jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, inspectionRoot },'Job.PackratInspect');
-            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Missing meshes in inspection result.');
+            this.reportInspect('[CookJob:Inspection] response is invalid. Missing meshes in inspection result.', true);
             return { success: false, error: 'Missing meshes in Cook report', allowRetry: false };
         }
 
@@ -973,19 +988,19 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         const sizeSum = inspectionRoot.scene.geometry.size.reduce((acc, num) => acc + num, 0);
         if(sizeSum <= 0) {
             RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: Mesh size is zero.',{  jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, inspectionRoot },'Job.PackratInspect');
-            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Mesh size is zero.');
+            this.reportInspect('[CookJob:Inspection] response is invalid. Mesh size is zero.', true);
             return { success: false, error: 'Invalid mesh. Size is zero.', allowRetry: false };
         }
 
         // check for invalid geometry counts
         if(inspectionRoot.scene.statistics.numFaces<=0 || inspectionRoot.scene.statistics.numVertices<=0 || inspectionRoot.scene.statistics.numEdges<=0 || inspectionRoot.scene.statistics.numTriangles<=0 || logContains(logs,'Invalid vertex index')===true) {
             RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: Mesh missing vertices and/or faces.',{  jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, inspectionRoot },'Job.PackratInspect');
-            this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Mesh missing vertices and/or faces.');
+            this.reportInspect('[CookJob:Inspection] response is invalid. Mesh missing vertices and/or faces.', true);
             return { success: false, error: 'Invalid mesh. Missing vertices/faces.', allowRetry: false };
         }
         if(logContains(logs,'Invalid vertex index')===true) {
             RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: Mesh size is zero.',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-            this.appendToReportAndLog('[CookJob:Inspection] response is invalid: Missing vertices/faces.');
+            this.reportInspect('[CookJob:Inspection] response is invalid: Missing vertices/faces.', true);
             return { success: false, error: 'Invalid mesh. Missing vertices/faces.', allowRetry: false };
         }
 
@@ -994,7 +1009,7 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
             // NOTE: just looking at first mesh. multi-model inspection will need special handling
             if(inspectionRoot.meshes[0].statistics.hasTexCoords===false) {
                 RK.logError(RK.LogSection.eJOB,'verify response failed','response is invalid: Mesh missing UVs for included texture.',{  jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, ...inspectionRoot.scene.statistics },'Job.PackratInspect');
-                this.appendToReportAndLog('[CookJob:Inspection] response is invalid. Mesh missing UVs for included texture.');
+                this.reportInspect('[CookJob:Inspection] response is invalid. Mesh missing UVs for included texture.', true);
                 return { success: false, error: 'Invalid mesh. Missing UVs for included texture.', allowRetry: false };
             }
         }

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -398,11 +398,10 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
 
         const SOI: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromScene(scene);
         const assetVersion: DBAPI.AssetVersion | null = (IAR.assetVersions && IAR.assetVersions.length > 0) ? IAR.assetVersions[0] : null;
-        const pathObject: string = SOI ? RouteBuilder.RepositoryDetails(SOI.idSystemObject, eHrefMode.ePrependClientURL) : '';
-        const hrefObject: string = H.Helpers.computeHref(pathObject, scene.Name);
         const pathDownload: string = assetVersion ? RouteBuilder.DownloadAssetVersion(assetVersion.idAssetVersion, eHrefMode.ePrependServerURL) : '';
-        const hrefDownload: string = pathDownload ? ': ' + H.Helpers.computeHref(pathDownload, 'Download') : '';
-        await this.appendToReportAndLog(`${this.name()} ingested scene ${hrefObject}${hrefDownload}`);
+        const sceneRef: COMMON.IWorkflowReportRef = { name: scene.Name, idScene: scene.idScene, idSystemObject: SOI?.idSystemObject, idAssetVersion: assetVersion?.idAssetVersion };
+        await this.appendToReportAndLog(`${this.name()} ingested scene ${scene.Name}`, undefined,
+            { code: COMMON.WorkflowReportCode.SceneIngested, data: { scene: sceneRef, href: pathDownload || undefined } });
 
         const SOV: DBAPI.SystemObjectVersion | null | undefined = IAR.systemObjectVersion; // SystemObjectVersion for updated 'scene', with new version of scene asset
         // LOG.info(`JobCookSIVoyagerScene.createSystemObjects[${svxFile}] wire ingestStreamOrFile: ${JSON.stringify(ISI, H.Helpers.stringifyMapsAndBigints)}`, LOG.LS.eJOB);
@@ -635,7 +634,7 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
             RK.logError(RK.LogSection.eJOB,'scene generation failed','post-processing failed after Cook success',undefined,'Job.VoyagerScene');
             await this.sendJobNotification({
                 success: false, titlePrefix: 'Scene Generation', ...this.notificationContext,
-                extraContent: `<p><b>Parameters</b>: ${this.parameters}<p>`
+                extraContent: `<p><b>Parameters</b>: ${JSON.stringify(this.parameters)}<p>`
             });
         }
         return updated;
@@ -647,7 +646,7 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
             RK.logError(RK.LogSection.eJOB,'scene generation failed',undefined,undefined,'Job.VoyagerScene');
             await this.sendJobNotification({
                 success: false, titlePrefix: 'Scene Generation', ...this.notificationContext,
-                extraContent: `<p><b>Parameters</b>: ${this.parameters}<p>`
+                extraContent: `<p><b>Parameters</b>: ${JSON.stringify(this.parameters)}<p>`
             });
         }
         return updated;

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -176,6 +176,7 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
     private parameters: JobCookSIVoyagerSceneParameters;
     private parameterHelper: JobCookSIVoyagerSceneParameterHelper | null;
     private cleanupCalled: boolean = false;
+    private reportScene: { idScene?: number; idSystemObject?: number; name?: string } | undefined = undefined;
 
     private static vocabVoyagerSceneModel: DBAPI.Vocabulary | undefined = undefined;
     private static vocabAssetTypeScene: DBAPI.Vocabulary | undefined = undefined;
@@ -400,6 +401,7 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
         const assetVersion: DBAPI.AssetVersion | null = (IAR.assetVersions && IAR.assetVersions.length > 0) ? IAR.assetVersions[0] : null;
         const pathDownload: string = assetVersion ? RouteBuilder.DownloadAssetVersion(assetVersion.idAssetVersion, eHrefMode.ePrependServerURL) : '';
         const sceneRef: COMMON.IWorkflowReportRef = { name: scene.Name, idScene: scene.idScene, idSystemObject: SOI?.idSystemObject, idAssetVersion: assetVersion?.idAssetVersion };
+        this.reportScene = { idScene: scene.idScene, idSystemObject: SOI?.idSystemObject, name: scene.Name };
         await this.appendToReportAndLog(`${this.name()} ingested scene ${scene.Name}`, undefined,
             { code: COMMON.WorkflowReportCode.SceneIngested, data: { scene: sceneRef, href: pathDownload || undefined } });
 
@@ -621,6 +623,19 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
             successUrl: this.parameterHelper
                 ? RouteBuilder.RepositoryDetails(this.parameterHelper.SOModelSource.idSystemObject, eHrefMode.ePrependClientURL)
                 : undefined,
+        };
+    }
+
+    protected reportSummaryContext(): Partial<COMMON.IWorkflowReportSummary> {
+        const ph = this.parameterHelper;
+        return {
+            subject: ph?.OG?.subject?.[0]?.Name,
+            idSubject: ph?.OG?.subject?.[0]?.idSubject,
+            scene: this.reportScene?.name ?? ph?.sceneName,
+            idScene: this.reportScene?.idScene,
+            idModel: ph?.SOModelSource?.idModel ?? undefined,
+            idSystemObject: this.reportScene?.idSystemObject ?? ph?.SOModelSource?.idSystemObject,
+            input: this.parameters?.sourceMeshFile,
         };
     }
 

--- a/server/job/impl/Cook/JobCookSIVoyagerScene.ts
+++ b/server/job/impl/Cook/JobCookSIVoyagerScene.ts
@@ -494,11 +494,10 @@ export class JobCookSIVoyagerScene extends JobCook<JobCookSIVoyagerSceneParamete
 
                     const SOI: DBAPI.SystemObjectInfo | undefined = await CACHE.SystemObjectCache.getSystemFromModel(model);
                     const assetVersion: DBAPI.AssetVersion | null = (IAR.assetVersions && IAR.assetVersions.length > 0) ? IAR.assetVersions[0] : null;
-                    const pathObject: string = SOI ? RouteBuilder.RepositoryDetails(SOI.idSystemObject, eHrefMode.ePrependClientURL) : '';
-                    const hrefObject: string = H.Helpers.computeHref(pathObject, model.Name);
                     const pathDownload: string = assetVersion ? RouteBuilder.DownloadAssetVersion(assetVersion.idAssetVersion, eHrefMode.ePrependServerURL) : '';
-                    const hrefDownload: string = pathDownload ? ': ' + H.Helpers.computeHref(pathDownload, 'Download') : '';
-                    await this.appendToReportAndLog(`${this.name()} ingested model ${hrefObject}${hrefDownload}`);
+                    const modelRef: COMMON.IWorkflowReportRef = { name: model.Name, idModel: model.idModel, idSystemObject: SOI?.idSystemObject, idAssetVersion: assetVersion?.idAssetVersion };
+                    await this.appendToReportAndLog(`${this.name()} ingested model ${model.Name}`, undefined,
+                        { code: COMMON.WorkflowReportCode.ModelIngested, data: { model: modelRef, href: pathDownload || undefined } });
 
                     // if an asset version was created for ingestion of this model, and if a system object version was created for scene ingestion,
                     // associate the asset version with the scene's system object version (enabling a scene package to be downloaded, even if some assets

--- a/server/job/impl/NS/JobEngine.ts
+++ b/server/job/impl/NS/JobEngine.ts
@@ -169,12 +169,12 @@ export class JobEngine implements JOB.IJobEngine {
         if (frequency === '') { // empty frequency means run it once, now
             RK.logInfo(RK.LogSection.eJOB,'create job','immediate job start',{ idJobRun: dbJobRun.idJobRun, jobType: COMMON.eVocabularyID[eJobType] ?? 'undefined', parameters },'Job.Engine');
             if (report)
-                await report.append(`JobEngine running ${job.name()}`);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: 'engine', code: COMMON.WorkflowReportCode.JobRun, msg: `Running ${job.name()}` }, report);
             job.executeJob(new Date()); // do not use await here, so that we remain unblocked while the job starts
         } else {                 // non-empty frequency means run job on schedule
             const nsJob: NS.Job = NS.scheduleJob(job.name(), frequency, job.executeJob);
             if (report)
-                await report.append(`JobEngine scheduling ${job.name()}`);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: 'engine', code: COMMON.WorkflowReportCode.JobSchedule, msg: `Scheduling ${job.name()}`, data: { frequency } }, report);
             job.setNSJob(nsJob);
         }
         return job;
@@ -184,7 +184,6 @@ export class JobEngine implements JOB.IJobEngine {
         parameters: any, dbJobRun: DBAPI.JobRun): Promise<JobPackrat | null> {
         let job: JobPackrat | null = null;
         let expectedJob: string = '';
-        const context: string = `: ${JSON.stringify(parameters, H.Helpers.saferStringify)}`;
         switch (eJobType) {
             case COMMON.eVocabularyID.eJobJobTypeCookSIPackratInspect:
                 expectedJob = 'Cook si-packrat-inspect';
@@ -214,7 +213,7 @@ export class JobEngine implements JOB.IJobEngine {
         if (!job)
             RK.logError(RK.LogSection.eJOB,'create job worker failed','called with parameters not consistent with job type',{ idJobRun: dbJobRun.idJobRun, expectedJob, parameters },'Job.Engine');
         else if (report)
-            await report.append(`JobEngine creating ${expectedJob}${context}`);
+            await RK.reportEvent({ ts: new Date().toISOString(), phase: 'engine', code: COMMON.WorkflowReportCode.JobCreate, msg: `Creating ${expectedJob}`, data: { recipe: expectedJob } }, report);
 
         return job;
     }

--- a/server/job/impl/NS/JobPackrat.ts
+++ b/server/job/impl/NS/JobPackrat.ts
@@ -145,7 +145,7 @@ export abstract class JobPackrat implements JOB.IJob {
     protected reportPhase: COMMON.WorkflowReportPhase = 'engine';
 
     protected async appendToReportAndLog(content: string, error?: boolean | undefined,
-        opts?: { code?: string; phase?: COMMON.WorkflowReportPhase; data?: { [key: string]: unknown } }): Promise<H.IOResults> {
+        opts?: { code?: string; phase?: COMMON.WorkflowReportPhase; level?: COMMON.WorkflowReportLevel; data?: { [key: string]: unknown } }): Promise<H.IOResults> {
         if (error)
             RK.logError(RK.LogSection.eJOB,'job error',content,{ idJobRun: this._dbJobRun.idJobRun },'Job.Packrat');
         else
@@ -159,7 +159,7 @@ export abstract class JobPackrat implements JOB.IJob {
             ts: new Date().toISOString(),
             phase: opts?.phase ?? this.reportPhase,
             code: opts?.code ?? COMMON.WorkflowReportCode.JobLog,
-            level: error ? 'error' : 'info',
+            level: opts?.level ?? (error ? 'error' : 'info'),
             msg: content,
             data: opts?.data
         }, this._report);
@@ -267,7 +267,7 @@ export abstract class JobPackrat implements JOB.IJob {
             // add url for output to the report
             const pathDownload: string = RouteBuilder.DownloadJobRun(this._dbJobRun.idJobRun , eHrefMode.ePrependServerURL);
             if (this._report)
-                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: 'Cook Job Output', data: { href: pathDownload } }, this._report);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: '', data: { output: pathDownload } }, this._report);
             else
                 RK.logWarning(RK.LogSection.eJOB,'job record success','no report to append results',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathDownload, output: this._dbJobRun.Output },'Job.Packrat');
 
@@ -311,7 +311,7 @@ export abstract class JobPackrat implements JOB.IJob {
             const pathDownload: string = RouteBuilder.DownloadJobRun(this._dbJobRun.idJobRun , eHrefMode.ePrependServerURL);
 
             if (this._report)
-                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: 'Cook Job Output', data: { href: pathDownload } }, this._report);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: '', data: { output: pathDownload } }, this._report);
             else
                 RK.logWarning(RK.LogSection.eJOB,'job record failure','no report to append results',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathDownload, output: this._dbJobRun.Output },'Job.Packrat');
 
@@ -353,7 +353,7 @@ export abstract class JobPackrat implements JOB.IJob {
             const pathDownload: string = RouteBuilder.DownloadJobRun(this._dbJobRun.idJobRun , eHrefMode.ePrependServerURL);
 
             if (this._report)
-                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: 'Cook Job Output', data: { href: pathDownload } }, this._report);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: '', data: { output: pathDownload } }, this._report);
             else
                 RK.logWarning(RK.LogSection.eJOB,'job record cancel','no report to append results',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathDownload, output: this._dbJobRun.Output },'Job.Packrat');
 

--- a/server/job/impl/NS/JobPackrat.ts
+++ b/server/job/impl/NS/JobPackrat.ts
@@ -141,7 +141,11 @@ export abstract class JobPackrat implements JOB.IJob {
     }
 
     // #region JobPackrat helper methods
-    protected async appendToReportAndLog(content: string, error?: boolean | undefined): Promise<H.IOResults> {
+    // Phase attributed to report events emitted by this job; Cook subclasses override to 'cook'.
+    protected reportPhase: COMMON.WorkflowReportPhase = 'engine';
+
+    protected async appendToReportAndLog(content: string, error?: boolean | undefined,
+        opts?: { code?: string; phase?: COMMON.WorkflowReportPhase; data?: { [key: string]: unknown } }): Promise<H.IOResults> {
         if (error)
             RK.logError(RK.LogSection.eJOB,'job error',content,{ idJobRun: this._dbJobRun.idJobRun },'Job.Packrat');
         else
@@ -151,7 +155,15 @@ export abstract class JobPackrat implements JOB.IJob {
             RK.logWarning(RK.LogSection.eJOB,'append report error',`no active report: ${content}`,{ idJobRun: this._dbJobRun.idJobRun },'Job.Packrat');
             return { success: false, error: 'No Active WorkflowReport' };
         }
-        return await this._report.append(content);
+        const result = await RK.reportEvent({
+            ts: new Date().toISOString(),
+            phase: opts?.phase ?? this.reportPhase,
+            code: opts?.code ?? COMMON.WorkflowReportCode.JobLog,
+            level: error ? 'error' : 'info',
+            msg: content,
+            data: opts?.data
+        }, this._report);
+        return { success: result.success, error: result.success ? undefined : result.message };
     }
 
     protected async updateJobOutput(output: string, updateEngines: boolean=false): Promise<void> {
@@ -165,7 +177,7 @@ export abstract class JobPackrat implements JOB.IJob {
     protected async recordCreated(): Promise<boolean> {
         const updated: boolean = (this._dbJobRun.getStatus() == COMMON.eWorkflowJobRunStatus.eUnitialized);
         if (updated) {
-            this.appendToReportAndLog(`JobPackrat [${this.name()}] Created`);
+            this.appendToReportAndLog(`JobPackrat [${this.name()}] Created`, undefined, { code: COMMON.WorkflowReportCode.JobCreated });
 
             this._dbJobRun.DateStart = new Date();
             this._dbJobRun.setStatus(COMMON.eWorkflowJobRunStatus.eCreated);
@@ -190,7 +202,7 @@ export abstract class JobPackrat implements JOB.IJob {
     protected async recordWaiting(): Promise<boolean> {
         const updated: boolean = (this._dbJobRun.getStatus() != COMMON.eWorkflowJobRunStatus.eWaiting);
         if (updated) {
-            this.appendToReportAndLog(`JobPackrat [${this.name()}] Waiting`);
+            this.appendToReportAndLog(`JobPackrat [${this.name()}] Waiting`, undefined, { code: COMMON.WorkflowReportCode.JobWaiting });
             this._dbJobRun.setStatus(COMMON.eWorkflowJobRunStatus.eWaiting);
 
             // update the status/values of our job
@@ -213,7 +225,7 @@ export abstract class JobPackrat implements JOB.IJob {
     protected async recordStart(idJob: string): Promise<boolean> {
         const updated: boolean = (this._dbJobRun.getStatus() != COMMON.eWorkflowJobRunStatus.eRunning);
         if (updated) {
-            this.appendToReportAndLog(`JobPackrat [${this.name()}] Starting (CookJobId: ${idJob})`);
+            this.appendToReportAndLog(`JobPackrat [${this.name()}] Starting (CookJobId: ${idJob})`, undefined, { code: COMMON.WorkflowReportCode.JobStart, data: { cookJobId: idJob } });
             this._dbJobRun.DateStart = new Date();
             this._dbJobRun.setStatus(COMMON.eWorkflowJobRunStatus.eRunning);
 
@@ -237,7 +249,7 @@ export abstract class JobPackrat implements JOB.IJob {
     protected async recordSuccess(output: string): Promise<boolean> {
         const updated: boolean = (this._dbJobRun.getStatus() != COMMON.eWorkflowJobRunStatus.eDone);
         if (updated) {
-            this.appendToReportAndLog(`JobPackrat [${this.name()}] Success`);
+            this.appendToReportAndLog(`JobPackrat [${this.name()}] Success`, undefined, { code: COMMON.WorkflowReportCode.JobSuccess });
 
             this._results = { success: true };   // do this before we await this._dbJobRun.update()
             this._dbJobRun.DateEnd = new Date();
@@ -254,9 +266,8 @@ export abstract class JobPackrat implements JOB.IJob {
 
             // add url for output to the report
             const pathDownload: string = RouteBuilder.DownloadJobRun(this._dbJobRun.idJobRun , eHrefMode.ePrependServerURL);
-            const hrefDownload: string = H.Helpers.computeHref(pathDownload, 'Cook Job Output');
             if (this._report)
-                await this._report.append(`${hrefDownload}<br/>\n`);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: 'Cook Job Output', data: { href: pathDownload } }, this._report);
             else
                 RK.logWarning(RK.LogSection.eJOB,'job record success','no report to append results',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathDownload, output: this._dbJobRun.Output },'Job.Packrat');
 
@@ -280,7 +291,7 @@ export abstract class JobPackrat implements JOB.IJob {
     protected async recordFailure(output: string | null, errorMsg?: string): Promise<boolean> {
         const updated: boolean = (this._dbJobRun.getStatus() != COMMON.eWorkflowJobRunStatus.eError);
         if (updated) {
-            this.appendToReportAndLog(`JobPackrat [${this.name()}] Failure: ${errorMsg}`, true);
+            this.appendToReportAndLog(`JobPackrat [${this.name()}] Failure: ${errorMsg}`, true, { code: COMMON.WorkflowReportCode.JobFailure });
 
             this._results = { success: false, error: errorMsg }; // do this before we await this._dbJobRun.update()
             this._dbJobRun.DateEnd = new Date();
@@ -298,10 +309,9 @@ export abstract class JobPackrat implements JOB.IJob {
 
             // add url for output to the report
             const pathDownload: string = RouteBuilder.DownloadJobRun(this._dbJobRun.idJobRun , eHrefMode.ePrependServerURL);
-            const hrefDownload: string = H.Helpers.computeHref(pathDownload, 'Cook Job Output');
 
             if (this._report)
-                await this._report.append(`${hrefDownload}<br/>\n`);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: 'Cook Job Output', data: { href: pathDownload } }, this._report);
             else
                 RK.logWarning(RK.LogSection.eJOB,'job record failure','no report to append results',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathDownload, output: this._dbJobRun.Output },'Job.Packrat');
 
@@ -321,10 +331,10 @@ export abstract class JobPackrat implements JOB.IJob {
         const updated: boolean = (this._dbJobRun.getStatus() != COMMON.eWorkflowJobRunStatus.eCancelled);
         if (updated) {
             if (errorMsg) {
-                this.appendToReportAndLog(`JobPackrat [${this.name()}] Cancel: ${errorMsg}`, true);
+                this.appendToReportAndLog(`JobPackrat [${this.name()}] Cancel: ${errorMsg}`, true, { code: COMMON.WorkflowReportCode.JobCancel });
                 this._dbJobRun.Error = errorMsg;
             } else
-                this.appendToReportAndLog(`JobPackrat [${this.name()}] Cancel`, true);
+                this.appendToReportAndLog(`JobPackrat [${this.name()}] Cancel`, true, { code: COMMON.WorkflowReportCode.JobCancel });
 
             this._results = { success: false, error: 'Job Cancelled' + (errorMsg ? ` ${errorMsg}` : '') }; // do this before we await this._dbJobRun.update()
             this._dbJobRun.DateEnd = new Date();
@@ -341,10 +351,9 @@ export abstract class JobPackrat implements JOB.IJob {
 
             // add url for output to the report
             const pathDownload: string = RouteBuilder.DownloadJobRun(this._dbJobRun.idJobRun , eHrefMode.ePrependServerURL);
-            const hrefDownload: string = H.Helpers.computeHref(pathDownload, 'Cook Job Output');
 
             if (this._report)
-                await this._report.append(`${hrefDownload}<br/>\n`);
+                await RK.reportEvent({ ts: new Date().toISOString(), phase: this.reportPhase, code: COMMON.WorkflowReportCode.JobLog, msg: 'Cook Job Output', data: { href: pathDownload } }, this._report);
             else
                 RK.logWarning(RK.LogSection.eJOB,'job record cancel','no report to append results',{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun, pathDownload, output: this._dbJobRun.Output },'Job.Packrat');
 

--- a/server/records/recordKeeper.ts
+++ b/server/records/recordKeeper.ts
@@ -5,6 +5,8 @@ import { Config, ENVIRONMENT_TYPE } from '../config';
 import { ASL, LocalStore } from '../utils/localStore';
 import { Logger as LOG, LogSection, LogLevel  } from './logger/log';
 import { Notify as NOTIFY, NotifyUserGroup, NotifyType, NotifyPackage, SlackChannel } from './notify/notify';
+import * as REP from '../report/interface';
+import * as COMMON from '@dpo-packrat/common';
 
 // temp definition for where IOResults will be
 export type IOResults = {
@@ -134,6 +136,7 @@ export class RecordKeeper {
 
     static async shutdown(): Promise<IOResults> {
 
+        await RecordKeeper.reportWaitForEmptyQueue();
         await LOG.shutdown();
 
         return { success: true, message: 'record keeper cleaned up' };
@@ -449,6 +452,29 @@ export class RecordKeeper {
     }
     //#endregion
 
+    //#region REPORT
+    // Single entry point for workflow-report writes, mirroring the log facade. Unlike logs, a report
+    // has a per-workflow target: pass the report handle when you hold one (jobs run detached/scheduled,
+    // outside the request's ASL context, so they cannot resolve the target from LocalStore); omit it to
+    // resolve the active report from LocalStore (resolvers/ingest). All writes serialize per report in
+    // the report queue (see report/impl/ReportQueue).
+    static async reportEvent(event: COMMON.IWorkflowReportEvent, report?: REP.IReport | null): Promise<IOResults> {
+        const target: REP.IReport | null = report ?? await REP.ReportFactory.getReport();
+        if (!target)
+            return { success: false, message: 'no active WorkflowReport' };
+        return RecordKeeper.convertResults(await target.appendEvent(event));
+    }
+    static async reportSetSummary(summary: COMMON.IWorkflowReportSummary, report?: REP.IReport | null): Promise<IOResults> {
+        const target: REP.IReport | null = report ?? await REP.ReportFactory.getReport();
+        if (!target)
+            return { success: false, message: 'no active WorkflowReport' };
+        return RecordKeeper.convertResults(await target.setSummary(summary));
+    }
+    static async reportWaitForEmptyQueue(timeout: number = 10000): Promise<IOResults> {
+        return RecordKeeper.convertResults(await REP.ReportQueue.waitForQueueToDrain(timeout));
+    }
+    //#endregion
+
     //#region UTILITY
     static convertResults(src: any, message?: string, data?: any): IOResults {
         if(!src)
@@ -478,6 +504,9 @@ export class RecordKeeper {
 
         result = await RecordKeeper.slackWaitForEmptyQueue(timeout);
         if(!result.success) errors.push(`slack: ${result.message}`);
+
+        result = await RecordKeeper.reportWaitForEmptyQueue(timeout);
+        if(!result.success) errors.push(`report: ${result.message}`);
 
         if(errors.length === 0)
             return { success: true, message: 'all queues drained' };

--- a/server/report/impl/Report.ts
+++ b/server/report/impl/Report.ts
@@ -1,6 +1,8 @@
 import { IReport } from '../interface/IReport';
 import { WorkflowReport } from '../../db';
+import { ReportQueue } from './ReportQueue';
 import * as H from '../../utils/helpers';
+import * as COMMON from '@dpo-packrat/common';
 
 export class Report implements IReport {
     workflowReport: WorkflowReport;
@@ -10,10 +12,14 @@ export class Report implements IReport {
     }
 
     async append(content: string): Promise<H.IOResults> {
-        const seperator: string = (this.workflowReport.Data) ? '<br/>\n' : '';
-        this.workflowReport.Data += seperator + content;
-        if (await this.workflowReport.update())
-            return { success: true };
-        return { success: false, error: 'Database error persisting WorkflowReport' };
+        return this.appendEvent({ ts: new Date().toISOString(), phase: 'system', code: COMMON.WorkflowReportCode.LegacyText, msg: content });
+    }
+
+    async appendEvent(event: COMMON.IWorkflowReportEvent): Promise<H.IOResults> {
+        return ReportQueue.appendEvent(this.workflowReport, event);
+    }
+
+    async setSummary(summary: COMMON.IWorkflowReportSummary): Promise<H.IOResults> {
+        return ReportQueue.setSummary(this.workflowReport, summary);
     }
 }

--- a/server/report/impl/ReportFormat.ts
+++ b/server/report/impl/ReportFormat.ts
@@ -1,0 +1,52 @@
+import * as COMMON from '@dpo-packrat/common';
+
+/**
+ * Pure (de)serialization helpers for the structured report format. Kept separate from the write
+ * queue so they can be unit-tested in isolation and reused.
+ */
+export class ReportFormat {
+    /** Parse a report body into events. Empty ⇒ []; a non-empty, non-array body is preserved as a
+     * single legacy.text event rather than throwing, so a malformed body never blocks new events. */
+    static parseEvents(data: string): COMMON.IWorkflowReportEvent[] {
+        if (!data)
+            return [];
+        try {
+            const parsed: unknown = JSON.parse(data);
+            if (Array.isArray(parsed))
+                return parsed as COMMON.IWorkflowReportEvent[];
+        } catch { /* fall through and preserve as legacy text */ }
+        return [{ ts: new Date().toISOString(), phase: 'system', code: COMMON.WorkflowReportCode.LegacyText, msg: data }];
+    }
+
+    /** Serialize the summary to <= WorkflowReportSummaryMaxLength by shortening name VALUES first
+     * (numeric ids retained), never by slicing the serialized JSON (which would break it). */
+    static serializeSummary(summary: COMMON.IWorkflowReportSummary): string {
+        const max: number = COMMON.WorkflowReportSummaryMaxLength;
+        let serialized: string = JSON.stringify(summary);
+        if (serialized.length <= max)
+            return serialized;
+
+        const clone: { [key: string]: unknown } = { ...summary };
+        const stringKeys: string[] = Object.keys(clone)
+            .filter((k) => typeof clone[k] === 'string')
+            .sort((a, b) => String(clone[b]).length - String(clone[a]).length);
+
+        for (const key of stringKeys) {
+            while (JSON.stringify(clone).length > max && String(clone[key]).length > 1)
+                clone[key] = String(clone[key]).slice(0, Math.max(1, Math.floor(String(clone[key]).length / 2)));
+            if (JSON.stringify(clone).length <= max)
+                break;
+        }
+
+        serialized = JSON.stringify(clone);
+        if (serialized.length <= max)
+            return serialized;
+
+        // last resort: keep only numeric ids (well under the cap), dropping all names
+        const idsOnly: { [key: string]: unknown } = {};
+        for (const key of Object.keys(clone))
+            if (typeof clone[key] === 'number')
+                idsOnly[key] = clone[key];
+        return JSON.stringify(idsOnly);
+    }
+}

--- a/server/report/impl/ReportFormat.ts
+++ b/server/report/impl/ReportFormat.ts
@@ -18,6 +18,21 @@ export class ReportFormat {
         return [{ ts: new Date().toISOString(), phase: 'system', code: COMMON.WorkflowReportCode.LegacyText, msg: data }];
     }
 
+    /** Merge one or more JSON report bodies into a single JSON string for /download. A single report
+     * emits its own body; a set emits an array of bodies. An unparseable body is preserved verbatim
+     * rather than failing the whole set. */
+    static mergeJSONReports(bodies: string[]): string {
+        const merged: unknown[] = [];
+        for (const data of bodies) {
+            try {
+                merged.push(JSON.parse(data || '[]'));
+            } catch {
+                merged.push(data);
+            }
+        }
+        return JSON.stringify(merged.length === 1 ? merged[0] : merged);
+    }
+
     /** Serialize the summary to <= WorkflowReportSummaryMaxLength by shortening name VALUES first
      * (numeric ids retained), never by slicing the serialized JSON (which would break it). */
     static serializeSummary(summary: COMMON.IWorkflowReportSummary): string {

--- a/server/report/impl/ReportQueue.ts
+++ b/server/report/impl/ReportQueue.ts
@@ -1,0 +1,66 @@
+import * as DBAPI from '../../db';
+import * as H from '../../utils/helpers';
+import * as COMMON from '@dpo-packrat/common';
+import { ReportFormat } from './ReportFormat';
+
+/**
+ * Serializes all writes to a given WorkflowReport (keyed by idWorkflowReport) so concurrent
+ * appendEvent/setSummary calls cannot interleave, lose an event, corrupt the JSON body, or
+ * clobber each other's column. Writes to different reports still run concurrently. Owned here in
+ * the report module; RecordKeeper exposes it as a first-class subsystem (drain-on-shutdown).
+ *
+ * Single-writer-per-report assumption (matches existing behavior): the WorkflowReport instance
+ * passed in is treated as authoritative for the duration of its serialized slot.
+ */
+export class ReportQueue {
+    private static chains: Map<number, Promise<H.IOResults>> = new Map();
+
+    static async appendEvent(workflowReport: DBAPI.WorkflowReport, event: COMMON.IWorkflowReportEvent): Promise<H.IOResults> {
+        return ReportQueue.run(workflowReport, (wr) => {
+            const events: COMMON.IWorkflowReportEvent[] = ReportFormat.parseEvents(wr.Data);
+            events.push(event);
+            wr.Data = JSON.stringify(events);
+            if (wr.MimeType !== 'application/json')
+                wr.MimeType = 'application/json';
+        });
+    }
+
+    static async setSummary(workflowReport: DBAPI.WorkflowReport, summary: COMMON.IWorkflowReportSummary): Promise<H.IOResults> {
+        return ReportQueue.run(workflowReport, (wr) => {
+            wr.Name = ReportFormat.serializeSummary(summary);
+        });
+    }
+
+    /** Await all in-flight report writes (used on shutdown, mirrors the log/notify queues). */
+    static async waitForQueueToDrain(timeout: number = 10000): Promise<H.IOResults> {
+        const chains: Promise<H.IOResults>[] = Array.from(ReportQueue.chains.values());
+        if (chains.length === 0)
+            return { success: true };
+
+        let timer: NodeJS.Timeout | undefined = undefined;
+        const timedOut: Promise<boolean> = new Promise<boolean>((resolve) => { timer = setTimeout(() => resolve(false), timeout); });
+        const drained: Promise<boolean> = Promise.allSettled(chains).then(() => true);
+        const ok: boolean = await Promise.race([drained, timedOut]);
+        if (timer)
+            clearTimeout(timer);
+        return ok ? { success: true } : { success: false, error: 'report queue drain timeout' };
+    }
+
+    private static run(workflowReport: DBAPI.WorkflowReport, mutate: (wr: DBAPI.WorkflowReport) => void): Promise<H.IOResults> {
+        const id: number = workflowReport.idWorkflowReport;
+        const prior: Promise<unknown> = ReportQueue.chains.get(id) ?? Promise.resolve();
+        const next: Promise<H.IOResults> = prior.catch(() => undefined).then(async () => {
+            try {
+                mutate(workflowReport);
+                if (await workflowReport.update())
+                    return { success: true };
+                return { success: false, error: 'Database error persisting WorkflowReport' };
+            } catch (error) {
+                return { success: false, error: `WorkflowReport write failed: ${H.Helpers.getErrorString(error)}` };
+            }
+        });
+        ReportQueue.chains.set(id, next);
+        next.finally(() => { if (ReportQueue.chains.get(id) === next) ReportQueue.chains.delete(id); });
+        return next;
+    }
+}

--- a/server/report/interface/IReport.ts
+++ b/server/report/interface/IReport.ts
@@ -1,5 +1,11 @@
 import * as H from '../../utils/helpers';
+import * as COMMON from '@dpo-packrat/common';
 
 export interface IReport {
+    /** Legacy shim: wraps arbitrary text as a single 'legacy.text' event. Prefer appendEvent. */
     append(content: string): Promise<H.IOResults>;
+    /** Append a structured event to the report body (JSON array). */
+    appendEvent(event: COMMON.IWorkflowReportEvent): Promise<H.IOResults>;
+    /** Write the compact table-driving summary into WorkflowReport.Name. */
+    setSummary(summary: COMMON.IWorkflowReportSummary): Promise<H.IOResults>;
 }

--- a/server/report/interface/ReportFactory.ts
+++ b/server/report/interface/ReportFactory.ts
@@ -26,8 +26,8 @@ export class ReportFactory {
             else {
                 workflowReport = new DBAPI.WorkflowReport({
                     idWorkflow,
-                    MimeType: 'text/html',
-                    Data: '',
+                    MimeType: 'application/json',
+                    Data: '[]',
                     idWorkflowReport: 0,
                     Name: ''
                 });

--- a/server/report/interface/index.ts
+++ b/server/report/interface/index.ts
@@ -1,2 +1,4 @@
 export * from './IReport';
 export * from './ReportFactory';
+export * from '../impl/ReportQueue';
+export * from '../impl/ReportFormat';

--- a/server/tests/collections/BulkOpFixSceneBasenames.test.ts
+++ b/server/tests/collections/BulkOpFixSceneBasenames.test.ts
@@ -55,8 +55,8 @@ describe('Bulk op: Fix Scene Basenames', () => {
         const rows = BulkOpJob.rows;
         expect(rows).toHaveLength(1);
         const row = rows.find(r => r.id === 1000);
-        expect(row?.isCandidate).toBe(true);
-        expect(row?.rowData.status).toBe('Fixable');
+        expect(row?.isCandidate).toBe(false); // review-only: reported, not selectable
+        expect(row?.rowData.status).toBe('Affected (manual)');
         expect(row?.rowData.canonicalName).toBe('NewName');
         expect(row?.rowData.currentBasename).toBe('OldName');
         expect(row?.rowData.fileCount).toBe(7);
@@ -75,7 +75,7 @@ describe('Bulk op: Fix Scene Basenames', () => {
         expect(BulkOpJob.rows).toHaveLength(0);
     });
 
-    test('affected mode lists both fixable and mixed scenes; only fixable is selectable', async () => {
+    test('affected mode lists both affected and mixed scenes; none selectable (review-only)', async () => {
         jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue([{ idScene: 1 }, { idScene: 2 }] as unknown as DBAPI.Scene[]);
         jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID')
             .mockImplementation(async (idScene: number) => ({ idSystemObject: idScene * 1000 } as DBAPI.SystemObject));
@@ -92,9 +92,9 @@ describe('Bulk op: Fix Scene Basenames', () => {
         const rows = BulkOpJob.rows;
         expect(rows).toHaveLength(2);
 
-        const fixable = rows.find(r => r.id === 1000);
-        expect(fixable?.isCandidate).toBe(true);
-        expect(fixable?.rowData.status).toBe('Fixable');
+        const affected = rows.find(r => r.id === 1000);
+        expect(affected?.isCandidate).toBe(false); // review-only: reported, not selectable
+        expect(affected?.rowData.status).toBe('Affected (manual)');
 
         const mixed = rows.find(r => r.id === 2000);
         expect(mixed?.isCandidate).toBe(false); // report-only: visible but not selectable
@@ -114,89 +114,11 @@ describe('Bulk op: Fix Scene Basenames', () => {
         expect(BulkOpJob.rows).toHaveLength(0);
     });
 
-    test('apply renames each Cook-output asset to the canonical Subject.Name', async () => {
-        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
-        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
-        jest.spyOn(DBAPI.User, 'fetch').mockResolvedValue({ idUser: 5, Name: 'Curator', EmailAddress: 'c@si.edu' } as DBAPI.User);
-        stubCanonicalName('NewName');
-
-        const drifted = outputSet('OldName').map((fn, i) => asAsset(i + 1, fn));
-        const fixed = outputSet('NewName').map((fn, i) => asAsset(i + 1, fn));
-        jest.spyOn(DBAPI.Asset, 'fetchFromScene')
-            .mockResolvedValueOnce(drifted)   // first evaluation
-            .mockResolvedValueOnce(fixed);    // post-rename re-check
-
-        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset')
-            .mockResolvedValue({ success: true } as STORE.AssetStorageResult);
-
-        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
-        expect(rename).toHaveBeenCalledTimes(7);
-        for (const call of rename.mock.calls) {
-            expect((call[1] as string).startsWith('NewName')).toBe(true);
-            expect((call[2] as STORE.OperationInfo).userEmailAddress).toBe('c@si.edu');
-        }
-        expect(res.success).toBe(true);
-        expect(res.message).toContain('renamed 7');
-        expect(res.rowData.fileCount).toBe(0);
-    });
-
-    test('apply refuses a mixed-basename scene and renames nothing', async () => {
-        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
-        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
-        stubCanonicalName('NewName');
-        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(mixedSet().map((fn, i) => asAsset(i + 1, fn)));
+    test('apply is review-only: refuses and performs no rename', async () => {
         const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset');
-
         const res = await fixSceneBasenames.apply(1000, {}, 5, {});
         expect(res.success).toBe(false);
-        expect(res.message).toContain('refused');
-        expect(rename).not.toHaveBeenCalled();
-    });
-
-    test('apply refuses a multi-subject scene and renames nothing', async () => {
-        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
-        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
-        stubMultiSubject();
-        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('WhateverBase').map((fn, i) => asAsset(i + 1, fn)));
-        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset');
-
-        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
-        expect(res.success).toBe(false);
-        expect(res.message).toContain('refused');
-        expect(rename).not.toHaveBeenCalled();
-    });
-
-    test('apply reports partial failure when a rename fails', async () => {
-        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
-        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
-        jest.spyOn(DBAPI.User, 'fetch').mockResolvedValue({ idUser: 5, Name: 'Curator', EmailAddress: 'c@si.edu' } as DBAPI.User);
-        stubCanonicalName('NewName');
-        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('OldName').map((fn, i) => asAsset(i + 1, fn)));
-        jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset')
-            .mockResolvedValue({ success: false, error: 'storage locked' } as STORE.AssetStorageResult);
-
-        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
-        expect(res.success).toBe(false);
-        expect(res.message).toContain('failed');
-    });
-
-    test('apply refuses cleanly for a non-scene system object', async () => {
-        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: null } as unknown as DBAPI.SystemObject);
-        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
-        expect(res.success).toBe(false);
-        expect(res.message).toContain('not a scene');
-    });
-
-    test('apply is a no-op when the scene is already consistent', async () => {
-        jest.spyOn(DBAPI.SystemObject, 'fetch').mockResolvedValue({ idScene: 1 } as DBAPI.SystemObject);
-        jest.spyOn(DBAPI.Scene, 'fetch').mockResolvedValue({ idScene: 1, Name: 'Scene 1' } as DBAPI.Scene);
-        stubCanonicalName('NewName');
-        jest.spyOn(DBAPI.Asset, 'fetchFromScene').mockResolvedValue(outputSet('NewName').map((fn, i) => asAsset(i + 1, fn)));
-        const rename = jest.spyOn(STORE.AssetStorageAdapter, 'renameAsset');
-
-        const res = await fixSceneBasenames.apply(1000, {}, 5, {});
-        expect(res.success).toBe(true);
-        expect(res.message).toBe('already consistent');
+        expect(res.message).toMatch(/review-only/i);
         expect(rename).not.toHaveBeenCalled();
     });
 });

--- a/server/tests/jest.config.js
+++ b/server/tests/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     // collectCoverage: true,
     testMatch: [
         // The complete test suite, on one line, to aid in quick commenting out
-        '**/tests/audit/**/*.test.ts', '**/tests/auth/**', '**/tests/cache/cache.test.ts', '**/tests/collections/*.test.ts', '**/tests/db/**/*.test.ts', '**/tests/graphql/graphql.test.ts', '**/tests/metadata/*.test.ts', '**/tests/job/**/*.test.ts', '**/tests/navigation/**/*.test.ts', '**/tests/objectAction/**/*.test.ts', '**/tests/storage/**/*.test.ts', '**/tests/utils/**/*.test.ts',
+        '**/tests/audit/**/*.test.ts', '**/tests/auth/**', '**/tests/cache/cache.test.ts', '**/tests/collections/*.test.ts', '**/tests/db/**/*.test.ts', '**/tests/graphql/graphql.test.ts', '**/tests/metadata/*.test.ts', '**/tests/job/**/*.test.ts', '**/tests/navigation/**/*.test.ts', '**/tests/objectAction/**/*.test.ts', '**/tests/report/**/*.test.ts', '**/tests/storage/**/*.test.ts', '**/tests/utils/**/*.test.ts',
         // '**/tests/db/dbcreation.test.ts',
 
         // Larger test collections, left here to aid in quick, focused testing; these are the elements on the line above:

--- a/server/tests/report/ReportFormat.test.ts
+++ b/server/tests/report/ReportFormat.test.ts
@@ -1,0 +1,68 @@
+import * as COMMON from '@dpo-packrat/common';
+import { ReportFormat } from '../../report/impl/ReportFormat';
+
+// Pure-function coverage for the structured workflow-report format. No DB needed.
+describe('Report: format (de)serialization', () => {
+    test('parseEvents: empty body yields an empty array', () => {
+        expect(ReportFormat.parseEvents('')).toEqual([]);
+        expect(ReportFormat.parseEvents('[]')).toEqual([]);
+    });
+
+    test('parseEvents: round-trips a valid event array (unicode preserved)', () => {
+        const events: COMMON.IWorkflowReportEvent[] = [
+            { ts: '2026-08-16T13:45:26.000Z', phase: 'engine', code: COMMON.WorkflowReportCode.JobCreate, msg: 'Creating si-voyager-scene' },
+            { ts: '2026-08-16T13:45:27.000Z', phase: 'cook', code: COMMON.WorkflowReportCode.JobStart, msg: 'xCharacters—Unicode', data: { cookJobId: 'abc' } }
+        ];
+        const parsed = ReportFormat.parseEvents(JSON.stringify(events));
+        expect(parsed).toEqual(events);
+        expect(parsed[1].msg).toBe('xCharacters—Unicode');
+    });
+
+    test('parseEvents: a non-empty, non-array body is preserved as one legacy.text event (never throws)', () => {
+        const legacy = ReportFormat.parseEvents('some <b>old</b> html blob');
+        expect(legacy).toHaveLength(1);
+        expect(legacy[0].code).toBe(COMMON.WorkflowReportCode.LegacyText);
+        expect(legacy[0].msg).toBe('some <b>old</b> html blob');
+
+        const notArray = ReportFormat.parseEvents('{"a":1}');
+        expect(notArray).toHaveLength(1);
+        expect(notArray[0].code).toBe(COMMON.WorkflowReportCode.LegacyText);
+    });
+
+    test('serializeSummary: short summary is stored verbatim and re-parses', () => {
+        const summary: COMMON.IWorkflowReportSummary = {
+            subject: 'DPO Testing', idSubject: 1294, scene: 'xCharacters—Unicode', idScene: null as unknown as undefined,
+            idModel: 614, idSystemObject: 12178, mediaGroup: 'Cook 1 Test (B)',
+            cookServer: 'Cook Server: 1', cookJobId: '0d21006c', input: 'Model_Test.obj', recipe: 'si-voyager-scene'
+        };
+        const serialized = ReportFormat.serializeSummary(summary);
+        expect(serialized.length).toBeLessThanOrEqual(COMMON.WorkflowReportSummaryMaxLength);
+        expect(JSON.parse(serialized).idSystemObject).toBe(12178);
+    });
+
+    test('serializeSummary: over-length summary truncates NAMES, keeps ids, and stays valid JSON <= 512', () => {
+        const summary: COMMON.IWorkflowReportSummary = {
+            subject: 'S'.repeat(400), scene: 'C'.repeat(400), input: 'I'.repeat(400),
+            idSubject: 1294, idScene: 555, idModel: 614, idSystemObject: 12178
+        };
+        const serialized = ReportFormat.serializeSummary(summary);
+        expect(serialized.length).toBeLessThanOrEqual(COMMON.WorkflowReportSummaryMaxLength);
+        const parsed = JSON.parse(serialized); // must not throw
+        expect(parsed.idSystemObject).toBe(12178);
+        expect(parsed.idSubject).toBe(1294);
+        expect(parsed.idScene).toBe(555);
+        expect(parsed.idModel).toBe(614);
+    });
+
+    test('serializeSummary: pathological names collapse to ids-only, still valid JSON', () => {
+        const summary: COMMON.IWorkflowReportSummary = {
+            subject: 'S'.repeat(5000), scene: 'C'.repeat(5000), input: 'I'.repeat(5000),
+            idSystemObject: 12178, idScene: 555
+        };
+        const serialized = ReportFormat.serializeSummary(summary);
+        expect(serialized.length).toBeLessThanOrEqual(COMMON.WorkflowReportSummaryMaxLength);
+        const parsed = JSON.parse(serialized);
+        expect(parsed.idSystemObject).toBe(12178);
+        expect(parsed.idScene).toBe(555);
+    });
+});

--- a/server/tests/report/ReportFormat.test.ts
+++ b/server/tests/report/ReportFormat.test.ts
@@ -65,4 +65,35 @@ describe('Report: format (de)serialization', () => {
         expect(parsed.idSystemObject).toBe(12178);
         expect(parsed.idScene).toBe(555);
     });
+
+    test('mergeJSONReports: a single report emits its own body (not wrapped in an array)', () => {
+        const body = JSON.stringify([{ ts: '', phase: 'cook', code: 'x', msg: 'a' }]);
+        const merged = ReportFormat.mergeJSONReports([body]);
+        const parsed = JSON.parse(merged);
+        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0].code).toBe('x');
+    });
+
+    test('mergeJSONReports: a set emits an array of report bodies', () => {
+        const a = JSON.stringify([{ code: 'a' }]);
+        const b = JSON.stringify([{ code: 'b' }]);
+        const parsed = JSON.parse(ReportFormat.mergeJSONReports([a, b]));
+        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0][0].code).toBe('a');
+        expect(parsed[1][0].code).toBe('b');
+    });
+
+    test('mergeJSONReports: an unparseable body is preserved verbatim, not fatal', () => {
+        const good = JSON.stringify([{ code: 'ok' }]);
+        const parsed = JSON.parse(ReportFormat.mergeJSONReports([good, 'not json']));
+        expect(parsed).toHaveLength(2);
+        expect(parsed[1]).toBe('not json');
+    });
+
+    test('mergeJSONReports: empty body defaults to an empty array', () => {
+        const parsed = JSON.parse(ReportFormat.mergeJSONReports(['']));
+        expect(parsed).toEqual([]);
+    });
 });

--- a/server/tests/report/ReportQueue.test.ts
+++ b/server/tests/report/ReportQueue.test.ts
@@ -1,0 +1,103 @@
+import * as COMMON from '@dpo-packrat/common';
+import * as DBAPI from '../../db';
+import { ReportQueue } from '../../report/impl/ReportQueue';
+
+// A minimal stand-in for DBAPI.WorkflowReport: the queue only reads/writes Data/Name/MimeType and
+// calls update(). update() yields (setTimeout 0) so that, if writes were NOT serialized, concurrent
+// read-modify-write cycles would interleave and lose events — locking in the ordering guarantee.
+class FakeWorkflowReport {
+    idWorkflowReport: number;
+    Data: string;
+    Name: string = '';
+    MimeType: string;
+    updateCount: number = 0;
+
+    constructor(id: number, data: string = '[]', mimeType: string = 'text/html') {
+        this.idWorkflowReport = id;
+        this.Data = data;
+        this.MimeType = mimeType;
+    }
+
+    async update(): Promise<boolean> {
+        this.updateCount++;
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        return true;
+    }
+}
+
+function fake(id: number, data?: string, mimeType?: string): DBAPI.WorkflowReport {
+    return new FakeWorkflowReport(id, data, mimeType) as unknown as DBAPI.WorkflowReport;
+}
+
+function event(code: string): COMMON.IWorkflowReportEvent {
+    return { ts: '2026-08-16T00:00:00.000Z', phase: 'cook', code, msg: code };
+}
+
+describe('Report: write queue', () => {
+    test('appendEvent serializes concurrent writes in order with no lost events', async () => {
+        const wr = fake(1);
+        const codes = Array.from({ length: 25 }, (_v, i) => `evt-${i}`);
+        await Promise.all(codes.map((c) => ReportQueue.appendEvent(wr, event(c))));
+
+        const events = JSON.parse((wr as unknown as FakeWorkflowReport).Data) as COMMON.IWorkflowReportEvent[];
+        expect(events).toHaveLength(codes.length);
+        expect(events.map((e) => e.code)).toEqual(codes); // preserved call order, none dropped
+    });
+
+    test('appendEvent flips MimeType to application/json', async () => {
+        const wr = fake(2, '[]', 'text/html');
+        await ReportQueue.appendEvent(wr, event('a'));
+        expect((wr as unknown as FakeWorkflowReport).MimeType).toBe('application/json');
+    });
+
+    test('appendEvent recovers a malformed body as a legacy.text event, then appends', async () => {
+        const wr = fake(3, 'old <b>html</b> blob', 'text/html');
+        await ReportQueue.appendEvent(wr, event('after'));
+
+        const events = JSON.parse((wr as unknown as FakeWorkflowReport).Data) as COMMON.IWorkflowReportEvent[];
+        expect(events).toHaveLength(2);
+        expect(events[0].code).toBe(COMMON.WorkflowReportCode.LegacyText);
+        expect(events[0].msg).toBe('old <b>html</b> blob');
+        expect(events[1].code).toBe('after');
+    });
+
+    test('writes are isolated per idWorkflowReport (concurrent, different reports)', async () => {
+        const a = fake(10);
+        const b = fake(11);
+        await Promise.all([
+            ReportQueue.appendEvent(a, event('a1')),
+            ReportQueue.appendEvent(b, event('b1')),
+            ReportQueue.appendEvent(a, event('a2')),
+            ReportQueue.appendEvent(b, event('b2')),
+        ]);
+
+        const aEvents = JSON.parse((a as unknown as FakeWorkflowReport).Data) as COMMON.IWorkflowReportEvent[];
+        const bEvents = JSON.parse((b as unknown as FakeWorkflowReport).Data) as COMMON.IWorkflowReportEvent[];
+        expect(aEvents.map((e) => e.code)).toEqual(['a1', 'a2']);
+        expect(bEvents.map((e) => e.code)).toEqual(['b1', 'b2']);
+    });
+
+    test('appendEvent and setSummary on one report do not clobber each other', async () => {
+        const wr = fake(20);
+        await Promise.all([
+            ReportQueue.appendEvent(wr, event('e1')),
+            ReportQueue.setSummary(wr, { subject: 'DPO Testing', idSystemObject: 12178 }),
+            ReportQueue.appendEvent(wr, event('e2')),
+        ]);
+
+        const backing = wr as unknown as FakeWorkflowReport;
+        const events = JSON.parse(backing.Data) as COMMON.IWorkflowReportEvent[];
+        const summary = JSON.parse(backing.Name) as COMMON.IWorkflowReportSummary;
+        expect(events.map((e) => e.code)).toEqual(['e1', 'e2']); // Data intact
+        expect(summary.idSystemObject).toBe(12178);               // Name intact
+    });
+
+    test('waitForQueueToDrain resolves after in-flight writes complete', async () => {
+        const wr = fake(30);
+        void ReportQueue.appendEvent(wr, event('x'));
+        void ReportQueue.appendEvent(wr, event('y'));
+        const result = await ReportQueue.waitForQueueToDrain(5000);
+        expect(result.success).toBe(true);
+        expect(JSON.parse((wr as unknown as FakeWorkflowReport).Data)).toHaveLength(2);
+    });
+});

--- a/server/types/graphql.ts
+++ b/server/types/graphql.ts
@@ -2808,7 +2808,9 @@ export type WorkflowListResult = {
   JobRun?: Maybe<JobRun>;
   Owner?: Maybe<User>;
   ProjectName?: Maybe<Scalars['String']>;
+  ReportMimeType?: Maybe<Scalars['String']>;
   State?: Maybe<Scalars['String']>;
+  Summary?: Maybe<Scalars['String']>;
   Type?: Maybe<Scalars['String']>;
   UserInitiator?: Maybe<User>;
   Workflow?: Maybe<Workflow>;


### PR DESCRIPTION
* Add shared report event and summary types.
* Store report bodies as JSON event logs, not HTML.
* Serialize report writes to prevent conflicts.
* Finish queued report writes during shutdown.
* Cook jobs now show progressive report summaries.
* Show linked workflow objects with type labels.
* Add an in-app report viewer with clickable object links.
* Render legacy HTML reports in a sandboxed viewer.
* Add coded inspect and ingest events with object references.
* Add 21 tests for queues, merging, and summary parsing.
* Remove ObjectGraph dumps and broken object text.
* Strip HTML from ingest report events.
* Label report links clearly and remove duplicate lines.
* Show newest events first with a detail header.
* Make the scene basename tool review-only; no renaming.
