### PR TITLE
DPO3DPKRT-1027/Republish Scenes bulk op

### DIFF
--- a/server/http/routes/api/bulkOps/registry.ts
+++ b/server/http/routes/api/bulkOps/registry.ts
@@ -3,6 +3,7 @@ import { fixDisplayUnits } from './fixDisplayUnits';
 import { syncFromEDAN } from './syncFromEDAN';
 import { rebindSceneDerivatives } from './rebindSceneDerivatives';
 import { fixSceneBasenames } from './fixSceneBasenames';
+import { republishScenes } from './republishScenes';
 
 // Registered bulk operations. A new op = a new entry here; the route and client are generic across all.
 export const OPERATIONS: Record<string, BulkOperationDef> = {
@@ -10,6 +11,7 @@ export const OPERATIONS: Record<string, BulkOperationDef> = {
     [syncFromEDAN.key]: syncFromEDAN,
     [rebindSceneDerivatives.key]: rebindSceneDerivatives,
     [fixSceneBasenames.key]: fixSceneBasenames,
+    [republishScenes.key]: republishScenes,
 };
 
 export const OPERATION_LIST: { key: string; label: string }[] =

--- a/server/http/routes/api/bulkOps/republishScenes.ts
+++ b/server/http/routes/api/bulkOps/republishScenes.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as DBAPI from '../../../../db';
+import * as COL from '../../../../collections/interface';
+import * as COMMON from '@dpo-packrat/common';
+import { AuditFactory } from '../../../../audit/interface/AuditFactory';
+import { withAuditTransaction } from '../../../../audit/withAuditTransaction';
+import { RecordKeeper as RK } from '../../../../records/recordKeeper';
+import { BulkOperationDef, BulkOpRow, BulkOpGatherArgs, BulkOpReporter, BulkOpApplyResult } from './BulkOpTypes';
+
+const SRC = 'HTTP.Route.BulkOp.RepublishScenes';
+
+// The states a scene can be (re)published to. Leaving the per-row Select at the current state re-pushes
+// the scene to EDAN unchanged (the refresh use case); choosing another state changes it.
+const PUBLISH_TARGET_STATES: COMMON.ePublishedState[] = [
+    COMMON.ePublishedState.ePublished,
+    COMMON.ePublishedState.eAPIOnly,
+    COMMON.ePublishedState.eInternal,
+    COMMON.ePublishedState.eNotPublished,
+];
+
+// A published value is any state other than Not Published; only these can be reached without passing the
+// Approved-for-Publication / Posed-and-QC'd gate (unpublishing is always allowed).
+function isPublishedState(s: COMMON.ePublishedState): boolean {
+    return s === COMMON.ePublishedState.ePublished ||
+        s === COMMON.ePublishedState.eAPIOnly ||
+        s === COMMON.ePublishedState.eInternal;
+}
+
+// Read after.eState from a publish/unpublish audit payload (the shape publish.ts / RetireExecutorDeps.ts
+// emit) — the authoritative CURRENT Packrat state, matching what the details page derives.
+function parsePublicationState(data: string | null): COMMON.ePublishedState | null {
+    if (!data) return null;
+    try {
+        const parsed = JSON.parse(data);
+        const eState: unknown = parsed?.after?.eState;
+        if (typeof eState !== 'number' || COMMON.ePublishedState[eState] === undefined)
+            return null;
+        return eState as COMMON.ePublishedState;
+    } catch {
+        return null;
+    }
+}
+
+// Current Packrat published state: the latest publish/unpublish audit event, falling back to the latest
+// version's field for un-audited (legacy) objects — the same rule the details page uses.
+async function currentPackratState(idSystemObject: number): Promise<COMMON.ePublishedState> {
+    const ev = await DBAPI.Audit.fetchLatestPublicationEvent(idSystemObject);
+    const st = ev ? parsePublicationState(ev.Data) : null;
+    if (st !== null)
+        return st;
+    const sov = await DBAPI.SystemObjectVersion.fetchLatestFromSystemObject(idSystemObject);
+    return sov ? sov.publishedStateEnum() : COMMON.ePublishedState.eNotPublished;
+}
+
+// The full candidate universe when the client does not scope the sweep to a project's scenes.
+async function candidateSystemObjectIds(): Promise<number[]> {
+    const scenes = await DBAPI.Scene.fetchAll();
+    if (!scenes) return [];
+    const ids: number[] = [];
+    for (const scene of scenes) {
+        const so = await DBAPI.SystemObject.fetchFromSceneID(scene.idScene);
+        if (so) ids.push(so.idSystemObject);
+    }
+    return ids;
+}
+
+// Read-only per-scene evaluation. Only scenes that were ever published (carry an EdanUUID) are listed;
+// scenes that cannot be published because they are not Approved-for-Publication / Posed-and-QC'd are shown
+// report-only (isCandidate:false) with the reason, so the blocked set is visible but cannot be acted on.
+async function evaluateOne(idSystemObject: number): Promise<BulkOpRow | null> {
+    const so = await DBAPI.SystemObject.fetch(idSystemObject);
+    if (!so || !so.idScene)
+        return null;
+    const scene = await DBAPI.Scene.fetch(so.idScene);
+    if (!scene || !scene.EdanUUID)
+        return null; // never published to EDAN — nothing to republish
+
+    const current: COMMON.ePublishedState = await currentPackratState(idSystemObject);
+    const currentName: string = COMMON.PublishedStateEnumToString(current);
+    const qcOK: boolean = scene.ApprovedForPublication && scene.PosedAndQCd;
+    const note: string = qcOK ? '' : 'Not Approved / Not QC\'d — publish blocked';
+
+    return {
+        id: idSystemObject,
+        name: scene.Name,
+        isCandidate: qcOK,
+        rowData: { currentStatus: currentName, edanRecord: scene.EdanUUID, note },
+        defaultSettings: { targetState: String(current) },
+        current: { targetState: String(current) },
+    };
+}
+
+/**
+ * Republish scenes to EDAN. Gather lists every scene that was ever published (has an EdanUUID); each row's
+ * per-row Select defaults to the scene's current published state, so running a row unchanged re-pushes it
+ * to EDAN (refresh), while choosing another state changes it. Scenes that are not Approved-for-Publication
+ * / Posed-and-QC'd are shown report-only (not selectable); apply re-checks the gate and refuses them.
+ *
+ * apply performs the real EDAN publish via ICol.publish (staging + package upsert) OUTSIDE any transaction,
+ * then emits the eActionPublish / eActionUnpublish audit event that the details page reads for current
+ * state — mirroring the publish GraphQL mutation.
+ */
+export const republishScenes: BulkOperationDef = {
+    key: 'republishScenes',
+    label: 'Republish Scenes',
+    columns: [
+        { key: 'currentStatus', label: 'Current Status' },
+        { key: 'edanRecord', label: 'EDAN Record' },
+        { key: 'note', label: 'Note' },
+    ],
+    rowSettings: [
+        { key: 'targetState', label: 'Publish To', type: 'select',
+            options: PUBLISH_TARGET_STATES.map(s => ({ value: String(s), label: COMMON.PublishedStateEnumToString(s) })) },
+    ],
+    gather: async ({ scopedIds }: BulkOpGatherArgs, report: BulkOpReporter): Promise<BulkOpRow[]> => {
+        const ids: number[] = (scopedIds && scopedIds.length > 0) ? scopedIds : await candidateSystemObjectIds();
+        report(0, ids.length);
+        const rows: BulkOpRow[] = [];
+        let processed = 0;
+        for (const id of ids) {
+            const row = await evaluateOne(id);
+            if (row) rows.push(row);
+            report(++processed, ids.length);
+        }
+        return rows;
+    },
+    apply: async (idSystemObject: number, rowSettings: any, _idUser: number): Promise<BulkOpApplyResult> => {
+        const target: number = Number(rowSettings?.targetState);
+        if (!Number.isInteger(target) || COMMON.ePublishedState[target] === undefined)
+            return { success: false, message: `invalid target state '${rowSettings?.targetState}'` };
+
+        const so = await DBAPI.SystemObject.fetch(idSystemObject);
+        if (!so || !so.idScene)
+            return { success: false, message: 'not a scene' };
+        const scene = await DBAPI.Scene.fetch(so.idScene);
+        if (!scene)
+            return { success: false, message: `cannot fetch scene ${so.idScene}` };
+
+        // Re-check the publish gate (double-guards the report-only rows): publishing to a live state
+        // requires the scene be Approved-for-Publication and Posed-and-QC'd. Unpublishing is always allowed.
+        if (isPublishedState(target) && (!scene.ApprovedForPublication || !scene.PosedAndQCd))
+            return { success: false, message: 'refused: not Approved-for-Publication / Posed-and-QC\'d' };
+
+        const prior: COMMON.ePublishedState = await currentPackratState(idSystemObject);
+        const priorName: string = COMMON.PublishedStateEnumToString(prior);
+        const targetName: string = COMMON.PublishedStateEnumToString(target);
+
+        // ICol.publish stages the scene and upserts the EDAN 3D package; it does external HTTP + hot-folder
+        // I/O and MUST NOT run inside a Prisma transaction. It updates SystemObjectVersion.PublishedState
+        // internally; we emit the audit event (the authoritative current-state record) after it succeeds.
+        const ICol: COL.ICollection = COL.CollectionFactory.getInstance();
+        const publishRes = await ICol.publish(idSystemObject, target);
+        if (!publishRes.success)
+            return { success: false, message: publishRes.error ?? 'publish failed' };
+
+        const isUnpublish: boolean = target === COMMON.ePublishedState.eNotPublished;
+        await withAuditTransaction(async (): Promise<void> => {
+            await AuditFactory.emitSemantic({
+                action: isUnpublish ? DBAPI.eAuditType.eActionUnpublish : DBAPI.eAuditType.eActionPublish,
+                idSystemObject,
+                payload: {
+                    before: { eState: prior, eStateName: priorName },
+                    after: { eState: target, eStateName: targetName },
+                    via: 'bulkOperation',
+                },
+            });
+        });
+
+        RK.logInfo(RK.LogSection.eHTTP, 'republish scene', `${priorName} → ${targetName}`,
+            { idSystemObject, idScene: scene.idScene }, SRC);
+
+        const message: string = prior === target ? `re-pushed (${targetName})` : `${priorName} → ${targetName}`;
+        return { success: true, message, rowData: { currentStatus: targetName } };
+    },
+};

--- a/server/tests/collections/BulkOpRepublishScenes.test.ts
+++ b/server/tests/collections/BulkOpRepublishScenes.test.ts
@@ -1,0 +1,109 @@
+import * as DBAPI from '../../db';
+import * as COL from '../../collections/interface';
+import * as COMMON from '@dpo-packrat/common';
+import { AuditFactory } from '../../audit/interface/AuditFactory';
+import * as AUDITTX from '../../audit/withAuditTransaction';
+import { BulkOpJob } from '../../http/routes/api/bulkOps/BulkOpTypes';
+import { republishScenes } from '../../http/routes/api/bulkOps/republishScenes';
+
+type SceneStub = { idScene: number; Name: string; EdanUUID: string | null; ApprovedForPublication: boolean; PosedAndQCd: boolean };
+
+// Wire the DB reads gather/apply make: scene idScene N ↔ idSystemObject N*1000, each returning the stub.
+function stubScenes(scenes: SceneStub[], stateBySO: (idSystemObject: number) => COMMON.ePublishedState): void {
+    const byScene: Map<number, SceneStub> = new Map(scenes.map(s => [s.idScene, s]));
+    jest.spyOn(DBAPI.Scene, 'fetchAll').mockResolvedValue(scenes.map(s => ({ idScene: s.idScene })) as unknown as DBAPI.Scene[]);
+    jest.spyOn(DBAPI.SystemObject, 'fetchFromSceneID')
+        .mockImplementation(async (idScene: number) => ({ idSystemObject: idScene * 1000 } as DBAPI.SystemObject));
+    jest.spyOn(DBAPI.SystemObject, 'fetch')
+        .mockImplementation(async (idSystemObject: number) => ({ idScene: idSystemObject / 1000 } as DBAPI.SystemObject));
+    jest.spyOn(DBAPI.Scene, 'fetch')
+        .mockImplementation(async (idScene: number) => (byScene.get(idScene) as unknown as DBAPI.Scene) ?? null);
+    // No audit event: currentPackratState falls back to the latest version's field.
+    jest.spyOn(DBAPI.Audit, 'fetchLatestPublicationEvent').mockResolvedValue(null);
+    jest.spyOn(DBAPI.SystemObjectVersion, 'fetchLatestFromSystemObject')
+        .mockImplementation(async (idSystemObject: number) => ({ publishedStateEnum: () => stateBySO(idSystemObject) } as unknown as DBAPI.SystemObjectVersion));
+}
+
+describe('Bulk op: Republish Scenes', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test('gather lists ever-published scenes; QC-blocked is report-only; never-published omitted', async () => {
+        stubScenes([
+            { idScene: 1, Name: 'Scene 1', EdanUUID: 'uuid-1', ApprovedForPublication: true, PosedAndQCd: true },
+            { idScene: 2, Name: 'Scene 2', EdanUUID: 'uuid-2', ApprovedForPublication: false, PosedAndQCd: true },
+            { idScene: 3, Name: 'Scene 3', EdanUUID: null, ApprovedForPublication: true, PosedAndQCd: true },
+        ], () => COMMON.ePublishedState.ePublished);
+
+        await BulkOpJob.run(republishScenes, { params: {} });
+        const rows = BulkOpJob.rows;
+        expect(rows).toHaveLength(2); // scene 3 (no EdanUUID) omitted
+
+        const ok = rows.find(r => r.id === 1000);
+        expect(ok?.isCandidate).toBe(true);
+        expect(ok?.rowData.currentStatus).toBe(COMMON.PublishedStateEnumToString(COMMON.ePublishedState.ePublished));
+        expect(ok?.rowData.edanRecord).toBe('uuid-1');
+        expect(ok?.defaultSettings.targetState).toBe(String(COMMON.ePublishedState.ePublished));
+
+        const blocked = rows.find(r => r.id === 2000);
+        expect(blocked?.isCandidate).toBe(false); // not Approved → report-only
+        expect(blocked?.rowData.note).toMatch(/publish blocked/i);
+    });
+
+    test('apply republishes a QC-approved scene: calls ICol.publish + emits publish audit', async () => {
+        stubScenes([{ idScene: 1, Name: 'Scene 1', EdanUUID: 'uuid-1', ApprovedForPublication: true, PosedAndQCd: true }],
+            () => COMMON.ePublishedState.eNotPublished);
+        const publish = jest.fn().mockResolvedValue({ success: true });
+        jest.spyOn(COL.CollectionFactory, 'getInstance').mockReturnValue({ publish } as unknown as COL.ICollection);
+        const emit = jest.spyOn(AuditFactory, 'emitSemantic').mockResolvedValue(undefined as never);
+        jest.spyOn(AUDITTX, 'withAuditTransaction').mockImplementation(async (cb: () => Promise<unknown>) => cb());
+
+        const res = await republishScenes.apply(1000, { targetState: String(COMMON.ePublishedState.ePublished) }, 5, {});
+        expect(res.success).toBe(true);
+        expect(publish).toHaveBeenCalledWith(1000, COMMON.ePublishedState.ePublished);
+        expect(emit).toHaveBeenCalledWith(expect.objectContaining({ action: DBAPI.eAuditType.eActionPublish }));
+        expect(res.rowData.currentStatus).toBe(COMMON.PublishedStateEnumToString(COMMON.ePublishedState.ePublished));
+    });
+
+    test('apply refuses a publish target for a QC-blocked scene without touching EDAN', async () => {
+        stubScenes([{ idScene: 1, Name: 'Scene 1', EdanUUID: 'uuid-1', ApprovedForPublication: false, PosedAndQCd: true }],
+            () => COMMON.ePublishedState.eNotPublished);
+        const publish = jest.fn();
+        jest.spyOn(COL.CollectionFactory, 'getInstance').mockReturnValue({ publish } as unknown as COL.ICollection);
+
+        const res = await republishScenes.apply(1000, { targetState: String(COMMON.ePublishedState.ePublished) }, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toMatch(/refused/i);
+        expect(publish).not.toHaveBeenCalled();
+    });
+
+    test('apply allows unpublishing a QC-blocked scene', async () => {
+        stubScenes([{ idScene: 1, Name: 'Scene 1', EdanUUID: 'uuid-1', ApprovedForPublication: false, PosedAndQCd: false }],
+            () => COMMON.ePublishedState.ePublished);
+        const publish = jest.fn().mockResolvedValue({ success: true });
+        jest.spyOn(COL.CollectionFactory, 'getInstance').mockReturnValue({ publish } as unknown as COL.ICollection);
+        jest.spyOn(AuditFactory, 'emitSemantic').mockResolvedValue(undefined as never);
+        const tx = jest.spyOn(AUDITTX, 'withAuditTransaction').mockImplementation(async (cb: () => Promise<unknown>) => cb());
+
+        const res = await republishScenes.apply(1000, { targetState: String(COMMON.ePublishedState.eNotPublished) }, 5, {});
+        expect(res.success).toBe(true);
+        expect(publish).toHaveBeenCalledWith(1000, COMMON.ePublishedState.eNotPublished);
+        expect(tx).toHaveBeenCalled();
+    });
+
+    test('apply rejects an invalid target state', async () => {
+        const res = await republishScenes.apply(1000, { targetState: 'nonsense' }, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toMatch(/invalid target state/i);
+    });
+
+    test('apply surfaces an EDAN publish failure', async () => {
+        stubScenes([{ idScene: 1, Name: 'Scene 1', EdanUUID: 'uuid-1', ApprovedForPublication: true, PosedAndQCd: true }],
+            () => COMMON.ePublishedState.eNotPublished);
+        jest.spyOn(COL.CollectionFactory, 'getInstance')
+            .mockReturnValue({ publish: jest.fn().mockResolvedValue({ success: false, error: 'EDAN unreachable' }) } as unknown as COL.ICollection);
+
+        const res = await republishScenes.apply(1000, { targetState: String(COMMON.ePublishedState.ePublished) }, 5, {});
+        expect(res.success).toBe(false);
+        expect(res.message).toBe('EDAN unreachable');
+    });
+});


### PR DESCRIPTION
* Add a bulk tool to republish scenes to EDAN.
* List all scenes that have ever been published.
* Default each scene to its current publish status.
* Show QC-blocked scenes as review-only.
* Republish through the standard publishing path.
* Record publish and unpublish actions in the audit log.
* Add six tests for the republish workflow.
* Update the plan and roadmap for the local landing milestone.