### PR TITLE
DPO3DPKRT-1028/Cook Generalized Error Handling

### DIFF
--- a/common/report.ts
+++ b/common/report.ts
@@ -63,6 +63,8 @@ export const WorkflowReportCode = {
     JobLog: 'job.log',
     CookMatched: 'cook.matched',
     CookLog: 'cook.log',
+    CookError: 'cook.error',
+    CookWarning: 'cook.warning',
     InspectNote: 'inspect.note',
     InspectInvalid: 'inspect.invalid',
     SceneNote: 'scene.note',

--- a/server/db/api/Asset.ts
+++ b/server/db/api/Asset.ts
@@ -157,19 +157,21 @@ export class Asset extends DBC.DBObject<AssetBase> implements AssetBase, SystemO
         }
     }
 
-    /** Fetch assets that are connected to a specific Scene via the scene's id. **/
+    /** Fetch the live assets connected to a specific Scene via the scene's id. Assets are gathered
+     * both through the scene's SystemObjectXref-derived children (e.g. models) and through assets that
+     * link directly to the scene's own SystemObject. Retired assets are excluded and the result is
+     * ordered by FileName then idAsset, so callers that compare against this set — the download
+     * basename checks — receive a stable, current-only list on every execution. **/
     static async fetchFromScene(idScene: number): Promise<Asset[] | null> {
-
-        // when grabbing assets we need to grab those that are referenced by SystemObjectXref where
-        // our Packrat scene is the parent (e.g. models), but we also need to return those assets
-        // that don't use the xrefs and explicitly link to the Packrat Scene via it's idSystemObject field.
         return DBC.CopyArray<AssetBase, Asset>(
             await DBC.DBConnection.prisma.$queryRaw<Asset[]>`
                 SELECT DISTINCT a.* FROM Scene AS scn
-                JOIN SystemObject AS scnSO ON scn.idScene = scnSO.idScene 
+                JOIN SystemObject AS scnSO ON scn.idScene = scnSO.idScene
                 JOIN SystemObjectXref AS scnSOX ON scnSO.idSystemObject = scnSOX.idSystemObjectMaster
                 JOIN Asset AS a ON (a.idSystemObject = scnSOX.idSystemObjectDerived OR a.idSystemObject = scnSO.idSystemObject)
-                WHERE scn.idScene = ${idScene};
+                JOIN SystemObject AS aSO ON aSO.idAsset = a.idAsset
+                WHERE scn.idScene = ${idScene} AND aSO.Retired = 0
+                ORDER BY a.FileName, a.idAsset;
             `,Asset);
     }
 

--- a/server/job/impl/Cook/CookReportScan.ts
+++ b/server/job/impl/Cook/CookReportScan.ts
@@ -1,0 +1,98 @@
+import * as COMMON from '@dpo-packrat/common';
+
+// Turns a raw Cook job report into ranked, structured findings so a failure reason is surfaced as
+// coded report events for every recipe, instead of being left buried in the raw report body that a
+// user must read by eye. Every rule keys off signals Cook itself returns — the per-step logs and
+// error strings — so nothing here parses the source model, which may be very large or, like GLB,
+// opaque. Recipe-specific structured checks (e.g. the inspection-result material/geometry checks)
+// stay in their own job classes; this module handles the log/error signals common to all recipes.
+
+export interface CookScanFinding {
+    code: COMMON.WorkflowReportCodeType;
+    level: COMMON.WorkflowReportLevel;
+    message: string;
+}
+
+export interface CookScanResult {
+    errors: CookScanFinding[];
+    warnings: CookScanFinding[];
+}
+
+interface CookReportLike {
+    state?: string;
+    error?: string;
+    steps?: { [step: string]: { error?: string; log?: Array<{ message?: string }> } };
+}
+
+// Collect every log message across all steps, plus per-step and top-level error strings, into one
+// flat list the rules can scan for corroborating markers.
+function collectMessages(report: CookReportLike): string[] {
+    const messages: string[] = [];
+    if (typeof report.error === 'string' && report.error.length > 0)
+        messages.push(report.error);
+
+    const steps = report.steps;
+    if (steps && typeof steps === 'object') {
+        for (const key of Object.keys(steps)) {
+            const step = steps[key];
+            if (!step || typeof step !== 'object')
+                continue;
+            if (typeof step.error === 'string' && step.error.length > 0)
+                messages.push(step.error);
+            if (Array.isArray(step.log)) {
+                for (const entry of step.log)
+                    if (entry && typeof entry.message === 'string' && entry.message.length > 0)
+                        messages.push(entry.message);
+            }
+        }
+    }
+    return messages;
+}
+
+const contains = (messages: string[], needle: string): boolean =>
+    messages.some(m => m.includes(needle));
+
+// Translate a Cook tool-termination error into a friendly, actionable message using corroborating
+// log lines. Known tools get a specific reason; any other terminated tool gets a named generic so
+// the offending step is identified even when the exact cause is only in the raw report.
+function friendlyToolError(primary: string, messages: string[]): string {
+    if (primary.includes('Tool Blender: terminated with code'))
+        return contains(messages, 'Error: Unsupported file type: .zip')
+            ? 'Zip package is invalid or corrupt.'
+            : 'Blender step failed. See the Cook report.';
+
+    if (primary.includes('Tool MeshSmith: terminated with code'))
+        return contains(messages, 'Invalid vertex index')
+            ? 'Invalid mesh. Missing vertices or faces.'
+            : 'MeshSmith step failed. See the Cook report.';
+
+    const toolMatch: RegExpMatchArray | null = primary.match(/Tool ([A-Za-z0-9_]+): terminated with code/);
+    if (toolMatch)
+        return `Cook step "${toolMatch[1]}" failed. See the Cook report.`;
+
+    return primary;
+}
+
+// Produce ranked, coded findings from a Cook report. Errors are only emitted when Cook itself
+// reports the job as errored; the warning tier (non-blocking issues surfaced from an otherwise
+// successful run) is populated by recipe-specific callers and is intentionally empty here.
+export function scanCookReport(cookJobReport: unknown): CookScanResult {
+    const errors: CookScanFinding[] = [];
+    const warnings: CookScanFinding[] = [];
+    if (!cookJobReport || typeof cookJobReport !== 'object')
+        return { errors, warnings };
+
+    const report: CookReportLike = cookJobReport as CookReportLike;
+
+    if (report.state === 'error') {
+        const messages: string[] = collectMessages(report);
+        const primary: string = (typeof report.error === 'string' && report.error.length > 0)
+            ? report.error
+            : (messages.find(m => /terminated with code|not found|failed|invalid/i.test(m)) ?? 'Cook reported an error.');
+
+        const message: string = friendlyToolError(primary, messages);
+        errors.push({ code: COMMON.WorkflowReportCode.CookError, level: 'error', message });
+    }
+
+    return { errors, warnings };
+}

--- a/server/job/impl/Cook/CookReportScan.ts
+++ b/server/job/impl/Cook/CookReportScan.ts
@@ -96,3 +96,40 @@ export function scanCookReport(cookJobReport: unknown): CookScanResult {
 
     return { errors, warnings };
 }
+
+function pushWarning(warnings: CookScanFinding[], message: string): void {
+    if (warnings.some(w => w.message === message))
+        return;
+    warnings.push({ code: COMMON.WorkflowReportCode.CookWarning, level: 'warn', message });
+}
+
+// Non-blocking advisories derived from a successful inspection result: likely mistakes that do not
+// prevent ingest, so they are surfaced as CookWarning rather than failing the job. Kept pure and
+// separate from the verify path so it is unit-testable. Only the first mesh is examined, matching
+// the existing single-mesh convention in the inspector.
+export function collectInspectionWarnings(inspectionRoot: unknown): CookScanFinding[] {
+    const warnings: CookScanFinding[] = [];
+    if (!inspectionRoot || typeof inspectionRoot !== 'object')
+        return warnings;
+
+    const root = inspectionRoot as {
+        scene?: { materials?: Array<{ error?: string }> };
+        meshes?: Array<{ statistics?: { hasNormals?: boolean; materialIndex?: number[] } }>;
+    };
+    const firstMeshStats = Array.isArray(root.meshes) ? root.meshes[0]?.statistics : undefined;
+
+    // Missing normals are a likely oversight but are derivable downstream, so advise rather than block.
+    if (firstMeshStats?.hasNormals === false)
+        pushWarning(warnings, 'Model has no normals; they will be derived downstream.');
+
+    // A mesh that references a material slot Cook resolved to nothing (an empty or unmatched .mtl)
+    // usually signals a mistake, though the geometry still ingests — advise rather than block. Firing
+    // requires a positive material reference on the mesh, so a legitimately material-free model is not
+    // flagged. NOTE: confirm the exact fields against a captured xMtlEmpty/xMtlRef inspection report.
+    const materialCount: number = Array.isArray(root.scene?.materials) ? (root.scene as { materials: unknown[] }).materials.length : -1;
+    const referencesMaterial: boolean = Array.isArray(firstMeshStats?.materialIndex) && (firstMeshStats as { materialIndex: number[] }).materialIndex.length > 0;
+    if (referencesMaterial && materialCount === 0)
+        pushWarning(warnings, 'A material is referenced but none was resolved (empty or unmatched .mtl).');
+
+    return warnings;
+}

--- a/server/job/impl/Cook/CookReportScan.ts
+++ b/server/job/impl/Cook/CookReportScan.ts
@@ -107,14 +107,16 @@ function pushWarning(warnings: CookScanFinding[], message: string): void {
 // prevent ingest, so they are surfaced as CookWarning rather than failing the job. Kept pure and
 // separate from the verify path so it is unit-testable. Only the first mesh is examined, matching
 // the existing single-mesh convention in the inspector.
+interface InspectionMaterial { name?: string; channels?: Array<{ type?: string }> }
+
 export function collectInspectionWarnings(inspectionRoot: unknown): CookScanFinding[] {
     const warnings: CookScanFinding[] = [];
     if (!inspectionRoot || typeof inspectionRoot !== 'object')
         return warnings;
 
     const root = inspectionRoot as {
-        scene?: { materials?: Array<{ error?: string }> };
-        meshes?: Array<{ statistics?: { hasNormals?: boolean; materialIndex?: number[] } }>;
+        scene?: { materials?: InspectionMaterial[] };
+        meshes?: Array<{ statistics?: { hasNormals?: boolean } }>;
     };
     const firstMeshStats = Array.isArray(root.meshes) ? root.meshes[0]?.statistics : undefined;
 
@@ -122,14 +124,18 @@ export function collectInspectionWarnings(inspectionRoot: unknown): CookScanFind
     if (firstMeshStats?.hasNormals === false)
         pushWarning(warnings, 'Model has no normals; they will be derived downstream.');
 
-    // A mesh that references a material slot Cook resolved to nothing (an empty or unmatched .mtl)
-    // usually signals a mistake, though the geometry still ingests — advise rather than block. Firing
-    // requires a positive material reference on the mesh, so a legitimately material-free model is not
-    // flagged. NOTE: confirm the exact fields against a captured xMtlEmpty/xMtlRef inspection report.
-    const materialCount: number = Array.isArray(root.scene?.materials) ? (root.scene as { materials: unknown[] }).materials.length : -1;
-    const referencesMaterial: boolean = Array.isArray(firstMeshStats?.materialIndex) && (firstMeshStats as { materialIndex: number[] }).materialIndex.length > 0;
-    if (referencesMaterial && materialCount === 0)
-        pushWarning(warnings, 'A material is referenced but none was resolved (empty or unmatched .mtl).');
+    // A material Cook resolved with no diffuse channel is effectively empty: it comes from an empty
+    // .mtl or a usemtl name that matched no material definition, so Cook falls back to a default
+    // (roughness-only) material. The geometry still ingests, so advise rather than block. A material
+    // carrying a diffuse channel — a texture uri and/or a colour value — is a normal material and is
+    // not flagged, so a legitimately untextured, solid-colour model does not trip this.
+    const materials: InspectionMaterial[] = Array.isArray(root.scene?.materials) ? (root.scene as { materials: InspectionMaterial[] }).materials : [];
+    for (const material of materials) {
+        const hasDiffuse: boolean = Array.isArray(material?.channels)
+            && material.channels.some(c => typeof c?.type === 'string' && c.type.toLowerCase() === 'diffuse');
+        if (!hasDiffuse)
+            pushWarning(warnings, `Material "${material?.name ?? 'unnamed'}" has no diffuse channel (empty or unmatched .mtl).`);
+    }
 
     return warnings;
 }

--- a/server/job/impl/Cook/JobCook.ts
+++ b/server/job/impl/Cook/JobCook.ts
@@ -7,6 +7,7 @@ import * as REP from '../../../report/interface';
 import { Config } from '../../../config';
 import * as H from '../../../utils/helpers';
 import * as COOKRES from '../../../job/impl/Cook/CookResource';
+import { scanCookReport, CookScanResult, CookScanFinding } from './CookReportScan';
 import { RecordKeeper as RK } from '../../../records/recordKeeper';
 import * as COMMON from '@dpo-packrat/common';
 
@@ -522,9 +523,18 @@ export abstract class JobCook<T> extends JobPackrat {
     }
 
     protected async verifyResponse(cookJobReport: any): Promise<JobIOResults> {
-        // verify the response received from Cook, checking the report and job details
+        // Surface Cook's own failure signals as ranked, coded report events for every recipe, so the
+        // reason is highlighted rather than buried in the raw report body. Recipe subclasses layer
+        // their own structured checks on top of this shared pass.
+        const scan: CookScanResult = scanCookReport(cookJobReport);
+        for (const finding of scan.errors)
+            await this.appendToReportAndLog(finding.message, true, { code: finding.code, level: finding.level });
+
         if(cookJobReport['state']==='error') {
-            return { success: false, allowRetry: false, error: cookJobReport['error'] };
+            const error: string = scan.errors.length > 0
+                ? scan.errors.map((f: CookScanFinding) => f.message).join(' | ')
+                : (cookJobReport['error'] ?? 'Cook error');
+            return { success: false, allowRetry: false, error };
         }
 
         // we made it here so the job appears successful

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -931,27 +931,12 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
         }
         const logs = cookJobReport.steps['inspect-mesh'].log;
 
-        // make sure our base/super routine doesn't have anything to report
+        // The base pass scans the Cook report and emits a ranked CookError event with a friendly
+        // message for an errored job (including the Blender/MeshSmith tool-termination cases), so
+        // surface that result here without re-deriving the reason.
         const superResult: JobIOResults = await super.verifyResponse(cookJobReport);
-        if(superResult.success===false) {
-            // check for known issues and improve error message returned
-            if(superResult.error?.includes('Tool Blender: terminated with code: 1')===true) {
-                if(logContains(logs,'Error: Unsupported file type: .zip')===true)
-                    superResult.error = 'Zip package is invalid/corrupt.';
-                else
-                    superResult.error = 'Unknown Blender error. Check report.';
-            }
-            if(superResult.error?.includes('Tool MeshSmith: terminated with code: 1')===true) {
-                if(logContains(logs,'Invalid vertex index')===true)
-                    superResult.error = 'Invalid mesh. Missing vertices/faces.';
-                else
-                    superResult.error = 'Unknown MeshSmith error. Check report.';
-            }
-
-            RK.logError(RK.LogSection.eJOB,'verify response failed',`response is invalid: ${superResult.error}`,{ jobName: this.name(), idJobRun: this._dbJobRun.idJobRun },'Job.PackratInspect');
-            this.reportInspect(`[CookJob:Inspection] response is invalid. ${superResult.error}`, true);
+        if(superResult.success===false)
             return superResult;
-        }
 
         // check for ZIP processing errors
         if(logContains(logs,'Error: Unsupported file type: .zip')===true) {

--- a/server/job/impl/Cook/JobCookSIPackratInspect.ts
+++ b/server/job/impl/Cook/JobCookSIPackratInspect.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 import { JobCook } from './JobCook';
+import { collectInspectionWarnings, CookScanFinding } from './CookReportScan';
 import { CookRecipe } from './CookRecipe';
 import { Config } from '../../../config';
 
@@ -998,6 +999,12 @@ export class JobCookSIPackratInspect extends JobCook<JobCookSIPackratInspectPara
                 return { success: false, error: 'Invalid mesh. Missing UVs for included texture.', allowRetry: false };
             }
         }
+
+        // Non-blocking advisories: likely mistakes that still ingest, surfaced as CookWarning so a
+        // user sees them without the job failing.
+        const warnings: CookScanFinding[] = collectInspectionWarnings(inspectionRoot);
+        for (const warning of warnings)
+            await this.appendToReportAndLog(warning.message, undefined, { code: warning.code, level: warning.level });
 
         // we have success
         await this.recordSuccess(JSON.stringify(cookJobReport));

--- a/server/tests/job/cookReportScan.test.ts
+++ b/server/tests/job/cookReportScan.test.ts
@@ -1,5 +1,5 @@
 import * as COMMON from '@dpo-packrat/common';
-import { scanCookReport } from '../../job/impl/Cook/CookReportScan';
+import { scanCookReport, collectInspectionWarnings } from '../../job/impl/Cook/CookReportScan';
 
 describe('Cook: CookReportScan.scanCookReport', () => {
     test('a successful (done) report yields no findings', () => {
@@ -55,5 +55,45 @@ describe('Cook: CookReportScan.scanCookReport', () => {
     test('a non-object report is handled without throwing', () => {
         expect(scanCookReport(null).errors).toHaveLength(0);
         expect(scanCookReport('boom').errors).toHaveLength(0);
+    });
+});
+
+describe('Cook: CookReportScan.collectInspectionWarnings', () => {
+    const withMesh = (statistics: Record<string, unknown>, materials: Record<string, unknown>[] = [{ name: 'Material' }]) =>
+        ({ scene: { materials }, meshes: [{ statistics }] });
+
+    test('a clean textured model yields no warnings', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true, materialIndex: [0] }));
+        expect(warnings).toHaveLength(0);
+    });
+
+    test('a mesh without normals warns (non-blocking)', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: false, materialIndex: [0] }));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].code).toBe(COMMON.WorkflowReportCode.CookWarning);
+        expect(warnings[0].level).toBe('warn');
+        expect(warnings[0].message).toMatch(/no normals/i);
+    });
+
+    test('a referenced-but-unresolved material warns', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true, materialIndex: [0] }, []));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toMatch(/none was resolved/i);
+    });
+
+    test('a legitimately material-free model is not flagged', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true, materialIndex: [] }, []));
+        expect(warnings).toHaveLength(0);
+    });
+
+    test('both advisories can fire together', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: false, materialIndex: [0] }, []));
+        expect(warnings).toHaveLength(2);
+    });
+
+    test('a missing/garbage inspection root yields no warnings', () => {
+        expect(collectInspectionWarnings(null)).toHaveLength(0);
+        expect(collectInspectionWarnings({})).toHaveLength(0);
+        expect(collectInspectionWarnings('nope')).toHaveLength(0);
     });
 });

--- a/server/tests/job/cookReportScan.test.ts
+++ b/server/tests/job/cookReportScan.test.ts
@@ -59,35 +59,41 @@ describe('Cook: CookReportScan.scanCookReport', () => {
 });
 
 describe('Cook: CookReportScan.collectInspectionWarnings', () => {
-    const withMesh = (statistics: Record<string, unknown>, materials: Record<string, unknown>[] = [{ name: 'Material' }]) =>
+    // Material shapes mirror real Cook inspection output: an empty/unmatched .mtl resolves to a
+    // default material carrying only a roughness channel (idJobRun 611/616), a healthy material
+    // carries a diffuse channel (idJobRun 612/613).
+    const emptyMaterial = { name: 'Material', channels: [{ type: 'roughness', value: '1.0' }] };
+    const texturedMaterial = { name: 'Material', channels: [{ type: 'reflection' }, { type: 'diffuse', uri: 'Box_Test_Txr.png' }] };
+    const withMesh = (statistics: Record<string, unknown>, materials: Record<string, unknown>[] = [texturedMaterial]) =>
         ({ scene: { materials }, meshes: [{ statistics }] });
 
-    test('a clean textured model yields no warnings', () => {
-        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true, materialIndex: [0] }));
+    test('a healthy textured model yields no warnings', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true }));
         expect(warnings).toHaveLength(0);
     });
 
     test('a mesh without normals warns (non-blocking)', () => {
-        const warnings = collectInspectionWarnings(withMesh({ hasNormals: false, materialIndex: [0] }));
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: false }));
         expect(warnings).toHaveLength(1);
         expect(warnings[0].code).toBe(COMMON.WorkflowReportCode.CookWarning);
         expect(warnings[0].level).toBe('warn');
         expect(warnings[0].message).toMatch(/no normals/i);
     });
 
-    test('a referenced-but-unresolved material warns', () => {
-        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true, materialIndex: [0] }, []));
+    test('an empty/unmatched material (no diffuse channel) warns', () => {
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true }, [emptyMaterial]));
         expect(warnings).toHaveLength(1);
-        expect(warnings[0].message).toMatch(/none was resolved/i);
+        expect(warnings[0].message).toMatch(/no diffuse channel/i);
     });
 
-    test('a legitimately material-free model is not flagged', () => {
-        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true, materialIndex: [] }, []));
+    test('a solid-colour material with a diffuse value is not flagged', () => {
+        const solidColour = { name: 'Material', channels: [{ type: 'diffuse', value: '1.0, 1.0, 1.0, 1.0' }] };
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: true }, [solidColour]));
         expect(warnings).toHaveLength(0);
     });
 
     test('both advisories can fire together', () => {
-        const warnings = collectInspectionWarnings(withMesh({ hasNormals: false, materialIndex: [0] }, []));
+        const warnings = collectInspectionWarnings(withMesh({ hasNormals: false }, [emptyMaterial]));
         expect(warnings).toHaveLength(2);
     });
 

--- a/server/tests/job/cookReportScan.test.ts
+++ b/server/tests/job/cookReportScan.test.ts
@@ -1,0 +1,59 @@
+import * as COMMON from '@dpo-packrat/common';
+import { scanCookReport } from '../../job/impl/Cook/CookReportScan';
+
+describe('Cook: CookReportScan.scanCookReport', () => {
+    test('a successful (done) report yields no findings', () => {
+        const result = scanCookReport({ state: 'done', steps: { 'inspect-mesh': { log: [{ message: 'ok' }] } } });
+        expect(result.errors).toHaveLength(0);
+        expect(result.warnings).toHaveLength(0);
+    });
+
+    test('an unknown tool termination is surfaced as a named CookError', () => {
+        const result = scanCookReport({ state: 'error', error: 'Tool XNormal: terminated with code: 1' });
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].code).toBe(COMMON.WorkflowReportCode.CookError);
+        expect(result.errors[0].level).toBe('error');
+        expect(result.errors[0].message).toBe('Cook step "XNormal" failed. See the Cook report.');
+    });
+
+    test('Blender termination with an unsupported-zip log line reads as a corrupt zip', () => {
+        const result = scanCookReport({
+            state: 'error',
+            error: 'Tool Blender: terminated with code: 1',
+            steps: { 'inspect-mesh': { log: [{ message: 'Error: Unsupported file type: .zip' }] } }
+        });
+        expect(result.errors[0].message).toBe('Zip package is invalid or corrupt.');
+    });
+
+    test('Blender termination without the zip marker reads as a generic Blender failure', () => {
+        const result = scanCookReport({ state: 'error', error: 'Tool Blender: terminated with code: 1' });
+        expect(result.errors[0].message).toBe('Blender step failed. See the Cook report.');
+    });
+
+    test('MeshSmith termination with an invalid-vertex log line reads as a bad mesh', () => {
+        const result = scanCookReport({
+            state: 'error',
+            error: 'Tool MeshSmith: terminated with code: 1',
+            steps: { 'inspect-mesh': { log: [{ message: 'Invalid vertex index at 42' }] } }
+        });
+        expect(result.errors[0].message).toBe('Invalid mesh. Missing vertices or faces.');
+    });
+
+    test('an errored report with no top-level error falls back to a step error', () => {
+        const result = scanCookReport({
+            state: 'error',
+            steps: { convert: { error: 'Tool Draco: terminated with code: 2' } }
+        });
+        expect(result.errors[0].message).toBe('Cook step "Draco" failed. See the Cook report.');
+    });
+
+    test('an unrecognized error string is surfaced verbatim', () => {
+        const result = scanCookReport({ state: 'error', error: 'disk full while writing output' });
+        expect(result.errors[0].message).toBe('disk full while writing output');
+    });
+
+    test('a non-object report is handled without throwing', () => {
+        expect(scanCookReport(null).errors).toHaveLength(0);
+        expect(scanCookReport('boom').errors).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
- Added shared Cook report scanner for all recipes
- Added CookError/CookWarning report event codes
- Added inspection warning helper (non-blocking)
- Added CookWarning advisories at inspect time
- Added 14 unit tests for scanner + warnings
- All recipes now surface a friendly Cook error
- Made scene-asset fetch deterministic + retired-safe
- Dropped duplicate inspect error remap logic
- Inspect now warns, not blocks, on likely mistakes
- Empty-material warning keyed on missing diffuse