### PR TITLE
DPO3DPKRT-1031/Filter Retired Gen Downloads

### DIFF
--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -247,6 +247,10 @@ export const Config: ConfigType = {
             [eAuditType.eDBCreate]:                 AuditTier.STANDARD,
             [eAuditType.eDBUpdate]:                 AuditTier.STANDARD,
             [eAuditType.eDBDelete]:                 AuditTier.STANDARD,
+            // Object-graph relationship changes made from the UX — skeleton kept forever so the
+            // "who linked/unlinked what and when" fact survives even after payload pruning.
+            [eAuditType.eActionRelationshipCreate]: AuditTier.STANDARD,
+            [eAuditType.eActionRelationshipDelete]: AuditTier.STANDARD,
             // TIER_TRANSIENT - ownership-relevant but not forensic
             [eAuditType.eSolrRebuild]:              AuditTier.TRANSIENT,
             [eAuditType.eGenDownloads]:             AuditTier.TRANSIENT,

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -251,6 +251,7 @@ export const Config: ConfigType = {
             // "who linked/unlinked what and when" fact survives even after payload pruning.
             [eAuditType.eActionRelationshipCreate]: AuditTier.STANDARD,
             [eAuditType.eActionRelationshipDelete]: AuditTier.STANDARD,
+            [eAuditType.eActionDownloadTagBackfill]: AuditTier.STANDARD,
             // TIER_TRANSIENT - ownership-relevant but not forensic
             [eAuditType.eSolrRebuild]:              AuditTier.TRANSIENT,
             [eAuditType.eGenDownloads]:             AuditTier.TRANSIENT,

--- a/server/db/api/ObjectType.ts
+++ b/server/db/api/ObjectType.ts
@@ -332,6 +332,7 @@ export enum eAuditType {
     eActionSVXUnitsFixed = 120,
     eActionRelationshipCreate = 121,
     eActionRelationshipDelete = 122,
+    eActionDownloadTagBackfill = 123,
 }
 
 export function LicenseRestrictLevelToPublishedStateEnum(restrictLevel: number): COMMON.ePublishedState {

--- a/server/db/api/ObjectType.ts
+++ b/server/db/api/ObjectType.ts
@@ -330,6 +330,8 @@ export enum eAuditType {
     eActionApproveARModels = 118,
     eActionApproveDownloadModels = 119,
     eActionSVXUnitsFixed = 120,
+    eActionRelationshipCreate = 121,
+    eActionRelationshipDelete = 122,
 }
 
 export function LicenseRestrictLevelToPublishedStateEnum(restrictLevel: number): COMMON.ePublishedState {

--- a/server/graphql/schema/systemobject/resolvers/mutations/deleteObjectConnection.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/deleteObjectConnection.ts
@@ -7,6 +7,8 @@ import { RelatedObjectType } from '../../../../../types/graphql';
 import * as COMMON from '@dpo-packrat/common';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
+import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
+import { eAuditType } from '../../../../../db/api/ObjectType';
 
 export default async function deleteObjectConnection(_: Parent, args: MutationDeleteObjectConnectionArgs): Promise<DeleteObjectConnectionResult> {
     const { input: { idSystemObjectMaster, objectTypeMaster, idSystemObjectDerived, objectTypeDerived } } = args;
@@ -40,6 +42,12 @@ export default async function deleteObjectConnection(_: Parent, args: MutationDe
                 const { success, error } = await DBAPI.SystemObjectXref.deleteIfAllowed(xref.idSystemObjectXref);
                 if (success) {
                     RK.logInfo(RK.LogSection.eGQL,'delete object connection success',undefined,{ xref },'GraphQL.SystemObject.ObjectConnection');
+                    // Record the removed parent->child relationship (keyed to the parent/master object).
+                    await AuditFactory.emitSemantic({
+                        action: eAuditType.eActionRelationshipDelete,
+                        idSystemObject: idSystemObjectMaster,
+                        payload: { master: idSystemObjectMaster, masterType: objectTypeMaster, derived: idSystemObjectDerived, derivedType: objectTypeDerived },
+                    });
                 } else {
                     RK.logError(RK.LogSection.eGQL,'delete object connection failed',`unable to delete SystemObjectXref: ${error}`,{ xref },'GraphQL.SystemObject.ObjectConnection');
                     result = { success: false, details: `unable to delete SystemObjectXref: ${error}`  };

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateDerivedObjects.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateDerivedObjects.ts
@@ -6,6 +6,8 @@ import { getRelatedObjects } from '../queries/getSystemObjectDetails';
 import { isValidParentChildRelationship } from '../../../ingestion/resolvers/mutations/ingestData';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
+import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
+import { eAuditType } from '../../../../../db/api/ObjectType';
 
 export default async function updateDerivedObjects(_: Parent, args: MutationUpdateDerivedObjectsArgs): Promise<UpdateDerivedObjectsResult> {
     const { input } = args;
@@ -45,6 +47,13 @@ export default async function updateDerivedObjects(_: Parent, args: MutationUpda
                         RK.logError(RK.LogSection.eGQL,'update dervied objects failed','failed to wire SystemObjectXref',{ wireSourceToDerived },'GraphQL.SystemObject.DerivedObjects');
                         continue;
                     }
+
+                    // Record the new parent->child relationship (keyed to the parent object being edited).
+                    await AuditFactory.emitSemantic({
+                        action: eAuditType.eActionRelationshipCreate,
+                        idSystemObject: SO.idSystemObject,
+                        payload: { via: 'derivedObjects', master: SO.idSystemObject, masterType: ParentObjectType, derived: newlySelected.idSystemObject, derivedType: newlySelected.objectType },
+                    });
                 }
             } else {
                 RK.logError(RK.LogSection.eGQL,'update dervied objects failed',`failed to fetch system object ${idSystemObject}`,{},'GraphQL.SystemObject.DerivedObjects');

--- a/server/graphql/schema/systemobject/resolvers/mutations/updateSourceObjects.ts
+++ b/server/graphql/schema/systemobject/resolvers/mutations/updateSourceObjects.ts
@@ -5,6 +5,8 @@ import { RecordKeeper as RK } from '../../../../../records/recordKeeper';
 import { isValidParentChildRelationship } from '../../../ingestion/resolvers/mutations/ingestData';
 import { Authorization, AUTH_ERROR } from '../../../../../auth/Authorization';
 import { withAuditTransaction } from '../../../../../audit/withAuditTransaction';
+import { AuditFactory } from '../../../../../audit/interface/AuditFactory';
+import { eAuditType } from '../../../../../db/api/ObjectType';
 
 export default async function updateSourceObjects(_: Parent, args: MutationUpdateSourceObjectsArgs): Promise<UpdateSourceObjectsResult> {
     const { input } = args;
@@ -43,6 +45,13 @@ export default async function updateSourceObjects(_: Parent, args: MutationUpdat
                         RK.logError(RK.LogSection.eGQL,'update source objects failed','failed to wire SystemObjectXref',{ wireSourceToDerived },'GraphQL.SystemObject.SourceObject');
                         continue;
                     }
+
+                    // Record the new parent->child relationship (keyed to the object being edited).
+                    await AuditFactory.emitSemantic({
+                        action: eAuditType.eActionRelationshipCreate,
+                        idSystemObject: SO.idSystemObject,
+                        payload: { via: 'sourceObjects', master: newlySelected.idSystemObject, masterType: newlySelected.objectType, derived: SO.idSystemObject, derivedType: ChildObjectType },
+                    });
                 }
             } else {
                 RK.logError(RK.LogSection.eGQL,'update source objects failed',`failed to fetch system object ${idSystemObject}`,{},'GraphQL.SystemObject.SourceObject');

--- a/server/http/routes/api/bulkOps/backfillDownloadTags.ts
+++ b/server/http/routes/api/bulkOps/backfillDownloadTags.ts
@@ -1,0 +1,184 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as DBAPI from '../../../../db';
+import * as CACHE from '../../../../cache';
+import * as COMMON from '@dpo-packrat/common';
+import { AuditFactory } from '../../../../audit/interface/AuditFactory';
+import { RecordKeeper as RK } from '../../../../records/recordKeeper';
+import { cookDownloadTypeKeyFromFilename, cookDownloadTagForTypeKey, cookModelAutomationTagForTypeKey, DownloadTag } from '../../../../job/impl/Cook/CookOutputContract';
+import { BulkOperationDef, BulkOpRow, BulkOpGatherArgs, BulkOpReporter, BulkOpApplyResult } from './BulkOpTypes';
+
+// Backfill the deterministic Cook-download tag (ModelSceneXref.Usage/Quality/UVResolution +
+// Model.idVPurpose=Download + Model.AutomationTag) onto legacy scene-derivative models so a repaired
+// row is IDENTICAL to one produced by si-generate-downloads / si-voyager-scene. The tag is derived
+// purely from the model's filename suffix via the shared CookOutputContract mapping — no guessing.
+//
+// Deliberate boundaries (safety):
+//   - Only the deterministic identity is written. Content-derived fields (FileSize, bounding box,
+//     inspection stats) are NEVER fabricated. A row whose deterministic tag is already correct but
+//     whose content is incomplete is reported as 'needs-manual' (run inspection/regeneration), not fixed.
+//   - A filename matching zero or more-than-one Cook suffix is 'ambiguous' (report-only).
+//   - A ModelSceneXref whose Model record is missing is 'needs-manual' (report-only).
+//   Only 'fixable' rows are apply-eligible; everything else is surfaced with a reason for manual handling.
+
+type TagStatus = 'fixable' | 'ambiguous' | 'needs-manual';
+
+interface TagState {
+    status: TagStatus;
+    typeKey: string | null;
+    current: string;         // current usage/quality/uv (+ purpose/automationTag) summary
+    proposed: string;        // proposed summary (empty for non-fixable)
+    reason: string;
+}
+
+const tagSummary = (usage: string | null | undefined, quality: string | null | undefined, uv: number | null | undefined): string =>
+    `${usage ?? '∅'} / ${quality ?? '∅'} / ${uv ?? '∅'}`;
+
+async function downloadPurposeId(): Promise<number | undefined> {
+    const v = await CACHE.VocabularyCache.vocabularyByEnum(COMMON.eVocabularyID.eModelPurposeDownload);
+    return v?.idVocabulary;
+}
+
+// Classify one ModelSceneXref (a model-in-scene) that looks like a Cook download derivative.
+async function classifyMSX(msx: DBAPI.ModelSceneXref, downloadVPurpose: number | undefined): Promise<TagState | null> {
+    const typeKey = cookDownloadTypeKeyFromFilename(msx.Name ?? '');
+    if (typeKey === null)
+        return null;                                    // not a recognized download derivative — skip silently
+    if (typeKey === 'ambiguous')
+        return { status: 'ambiguous', typeKey: null, current: tagSummary(msx.Usage, msx.Quality, msx.UVResolution), proposed: '',
+            reason: `filename '${msx.Name}' matches more than one Cook suffix — not auto-assigned` };
+
+    const model: DBAPI.Model | null = await DBAPI.Model.fetch(msx.idModel);
+    if (!model)
+        return { status: 'needs-manual', typeKey, current: tagSummary(msx.Usage, msx.Quality, msx.UVResolution), proposed: '',
+            reason: `Model ${msx.idModel} record missing — re-ingest/regenerate` };
+
+    const tag: DownloadTag | null = cookDownloadTagForTypeKey(typeKey);
+    const autoTag: string | null = cookModelAutomationTagForTypeKey(typeKey);
+    if (!tag || !autoTag)
+        return { status: 'needs-manual', typeKey, current: tagSummary(msx.Usage, msx.Quality, msx.UVResolution), proposed: '',
+            reason: `no deterministic tag for '${typeKey}'` };
+
+    const tagsMatch: boolean = msx.Usage === tag.usage && msx.Quality === tag.quality && msx.UVResolution === tag.uvResolution
+        && model.idVPurpose === (downloadVPurpose ?? model.idVPurpose) && model.AutomationTag === autoTag;
+    const contentComplete: boolean = msx.FileSize !== null && msx.BoundingBoxP1X !== null;
+    const current: string = tagSummary(msx.Usage, msx.Quality, msx.UVResolution);
+    const proposed: string = tagSummary(tag.usage, tag.quality, tag.uvResolution);
+
+    if (tagsMatch) {
+        if (contentComplete)
+            return null;                                // fully correct — nothing to show
+        return { status: 'needs-manual', typeKey, current, proposed,
+            reason: 'tag correct but FileSize/bounding-box missing — run inspection to fully match a generated row' };
+    }
+    const contentNote: string = contentComplete ? '' : ' (note: FileSize/bbox missing — inspection recommended after the tag fix)';
+    return { status: 'fixable', typeKey, current, proposed, reason: `${current} → ${proposed}${contentNote}` };
+}
+
+async function sceneSystemObjectIds(scopedIds?: number[]): Promise<number[]> {
+    if (scopedIds && scopedIds.length > 0)
+        return scopedIds;
+    const scenes = await DBAPI.Scene.fetchAll();
+    const ids: number[] = [];
+    for (const scene of scenes ?? []) {
+        const so = await DBAPI.SystemObject.fetchFromSceneID(scene.idScene);
+        if (so) ids.push(so.idSystemObject);
+    }
+    return ids;
+}
+
+export const backfillDownloadTags: BulkOperationDef = {
+    key: 'backfillDownloadTags',
+    label: 'Backfill Download Tags',
+    columns: [
+        { key: 'status', label: 'Status' },
+        { key: 'modelName', label: 'Model / Download' },
+        { key: 'matchedType', label: 'Cook Type' },
+        { key: 'currentTag', label: 'Current (Usage/Quality/UV)' },
+        { key: 'proposedTag', label: 'Proposed (Usage/Quality/UV)' },
+        { key: 'details', label: 'Details' },
+    ],
+    rowSettings: [],
+    gather: async ({ scopedIds }: BulkOpGatherArgs, report: BulkOpReporter): Promise<BulkOpRow[]> => {
+        const downloadVPurpose: number | undefined = await downloadPurposeId();
+        const ids: number[] = await sceneSystemObjectIds(scopedIds);
+        report(0, ids.length);
+        const rows: BulkOpRow[] = [];
+        let processed = 0;
+        for (const idSceneSO of ids) {
+            const sceneSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSceneSO);
+            if (sceneSO && sceneSO.idScene) {
+                const msxList: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromScene(sceneSO.idScene);
+                for (const msx of msxList ?? []) {
+                    const state = await classifyMSX(msx, downloadVPurpose);
+                    if (!state)
+                        continue;
+                    const modelSO: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetchFromModelID(msx.idModel);
+                    if (!modelSO)
+                        continue;                       // no SystemObject for the model — cannot target it
+                    rows.push({
+                        id: modelSO.idSystemObject,
+                        name: msx.Name ?? `Model ${msx.idModel}`,
+                        isCandidate: state.status === 'fixable',
+                        rowData: {
+                            status: state.status,
+                            modelName: msx.Name ?? `Model ${msx.idModel}`,
+                            matchedType: state.typeKey ?? '—',
+                            currentTag: state.current,
+                            proposedTag: state.proposed || '—',
+                            details: state.reason,
+                        },
+                    });
+                }
+            }
+            report(++processed, ids.length);
+        }
+        return rows;
+    },
+    apply: async (idSystemObject: number, _rowSettings: any, _idUser: number): Promise<BulkOpApplyResult> => {
+        const so: DBAPI.SystemObject | null = await DBAPI.SystemObject.fetch(idSystemObject);
+        if (!so || !so.idModel)
+            return { success: false, message: 'not a model' };
+        const model: DBAPI.Model | null = await DBAPI.Model.fetch(so.idModel);
+        if (!model)
+            return { success: false, message: `cannot fetch model ${so.idModel}` };
+        const downloadVPurpose: number | undefined = await downloadPurposeId();
+
+        const msxList: DBAPI.ModelSceneXref[] | null = await DBAPI.ModelSceneXref.fetchFromModel(model.idModel);
+        let applied = 0;
+        let lastProposed = '';
+        for (const msx of msxList ?? []) {
+            // Re-derive at apply time so a stale gathered row can never drive a wrong write.
+            const typeKey = cookDownloadTypeKeyFromFilename(msx.Name ?? '');
+            if (typeKey === null || typeKey === 'ambiguous')
+                continue;
+            const tag = cookDownloadTagForTypeKey(typeKey);
+            const autoTag = cookModelAutomationTagForTypeKey(typeKey);
+            if (!tag || !autoTag)
+                continue;
+
+            const before = { usage: msx.Usage, quality: msx.Quality, uv: msx.UVResolution, idVPurpose: model.idVPurpose, automationTag: model.AutomationTag };
+            msx.Usage = tag.usage;
+            msx.Quality = tag.quality;
+            msx.UVResolution = tag.uvResolution;
+            if (!await msx.update())
+                return { success: false, message: `failed to update ModelSceneXref ${msx.idModelSceneXref}` };
+            if (downloadVPurpose)
+                model.idVPurpose = downloadVPurpose;
+            model.AutomationTag = autoTag;
+            if (!await model.update())
+                return { success: false, message: `failed to update Model ${model.idModel}` };
+
+            await AuditFactory.emitSemantic({
+                action: DBAPI.eAuditType.eActionDownloadTagBackfill,
+                idSystemObject,
+                payload: { typeKey, before, after: { usage: tag.usage, quality: tag.quality, uv: tag.uvResolution, idVPurpose: model.idVPurpose, automationTag: autoTag }, idScene: msx.idScene, via: 'bulkOperation' },
+            });
+            RK.logInfo(RK.LogSection.eHTTP,'backfill download tags','applied',{ idSystemObject, idModel: model.idModel, typeKey },'HTTP.Route.BulkOp.BackfillDownloadTags');
+            lastProposed = `${tag.usage} / ${tag.quality} / ${tag.uvResolution}`;
+            applied++;
+        }
+        if (applied === 0)
+            return { success: false, message: 'no recognized download tag to apply for this model' };
+        return { success: true, message: lastProposed, rowData: { status: 'fixable', currentTag: lastProposed, proposedTag: lastProposed, details: 'tag applied' } };
+    },
+};

--- a/server/http/routes/api/bulkOps/registry.ts
+++ b/server/http/routes/api/bulkOps/registry.ts
@@ -4,6 +4,7 @@ import { syncFromEDAN } from './syncFromEDAN';
 import { rebindSceneDerivatives } from './rebindSceneDerivatives';
 import { fixSceneBasenames } from './fixSceneBasenames';
 import { republishScenes } from './republishScenes';
+import { backfillDownloadTags } from './backfillDownloadTags';
 
 // Registered bulk operations. A new op = a new entry here; the route and client are generic across all.
 export const OPERATIONS: Record<string, BulkOperationDef> = {
@@ -12,6 +13,7 @@ export const OPERATIONS: Record<string, BulkOperationDef> = {
     [rebindSceneDerivatives.key]: rebindSceneDerivatives,
     [fixSceneBasenames.key]: fixSceneBasenames,
     [republishScenes.key]: republishScenes,
+    [backfillDownloadTags.key]: backfillDownloadTags,
 };
 
 export const OPERATION_LIST: { key: string; label: string }[] =

--- a/server/job/impl/Cook/CookOutputContract.ts
+++ b/server/job/impl/Cook/CookOutputContract.ts
@@ -68,3 +68,47 @@ export function findBasenameOffenders(recipe: CookRecipeKey, candidateFilenames:
     }
     return offenders;
 }
+
+// The deterministic ModelSceneXref tag (Usage/Quality/UVResolution) a Cook download-type key maps to.
+// This is the single source of truth shared by si-generate-downloads generation and the backfill op, so
+// a repaired legacy row carries values identical to a freshly generated one. Returns null for a type key
+// that is not a recognized download output.
+export interface DownloadTag { usage: string; quality: string; uvResolution: number; }
+export function cookDownloadTagForTypeKey(typeKey: string): DownloadTag | null {
+    switch (typeKey) {
+        case 'objZipFull':                 return { usage: `Download:${typeKey}`, quality: 'Highest', uvResolution: 0 };
+        case 'objZipLow':
+        case 'gltfZipLow':
+        case 'webAssetGlbLowUncompressed': return { usage: `Download:${typeKey}`, quality: 'Low', uvResolution: 4096 };
+        case 'webAssetGlbARCompressed':    return { usage: 'App3D',    quality: 'AR', uvResolution: 2048 };
+        case 'usdz':                       return { usage: 'iOSApp3D', quality: 'AR', uvResolution: 2048 };
+    }
+    return null;
+}
+
+// The Model.AutomationTag a download-type key maps to (same values si-generate-downloads writes).
+export function cookModelAutomationTagForTypeKey(typeKey: string): string | null {
+    const tag: DownloadTag | null = cookDownloadTagForTypeKey(typeKey);
+    if (!tag)
+        return null;
+    switch (typeKey) {
+        case 'objZipFull':
+        case 'objZipLow':
+        case 'gltfZipLow':
+        case 'webAssetGlbLowUncompressed': return `download-${typeKey}-${tag.quality}-${tag.uvResolution}`;
+        case 'webAssetGlbARCompressed':
+        case 'usdz':                       return `scene-${tag.usage}-${tag.quality}-${tag.uvResolution}`;
+    }
+    return null;
+}
+
+// The Cook download typeKey a filename maps to, by endsWith over the canonical suffix table. Returns
+// null for no match and 'ambiguous' when more than one suffix matches, so callers (backfill) never guess.
+export function cookDownloadTypeKeyFromFilename(fileName: string): string | null | 'ambiguous' {
+    const matches = COMMON.CookDownloadDescriptors.filter(d => fileName.endsWith(d.suffixFull));
+    if (matches.length === 0)
+        return null;
+    if (matches.length > 1)
+        return 'ambiguous';
+    return matches[0].typeKey;
+}

--- a/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
+++ b/server/job/impl/Cook/JobCookSIGenerateDownloads.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 import { JobCook } from './JobCook';
 import { CookRecipe } from './CookRecipe';
-import { findBasenameOffenders, BasenameOffender } from './CookOutputContract';
+import { findBasenameOffenders, BasenameOffender, cookDownloadTagForTypeKey, cookModelAutomationTagForTypeKey } from './CookOutputContract';
 import { Config } from '../../../config';
 
 import * as JOB from '../../interface';
@@ -735,55 +735,25 @@ export class JobCookSIGenerateDownloads extends JobCook<JobCookSIGenerateDownloa
 
     public static computeModelPropertiesFromDownloadType(downloadType: string): { usage: string|undefined, quality: string|undefined, uvResolution: number|undefined } {
 
-        // NOTE: caution if return types from Cook change
-        switch(downloadType) {
-
-            case 'objZipFull':
-                return { usage: 'Download:'+downloadType, quality: 'Highest', uvResolution: 0 };
-
-            case 'objZipLow':
-            case 'gltfZipLow':
-            case 'webAssetGlbLowUncompressed':
-                return { usage: 'Download:'+downloadType, quality: 'Low', uvResolution: 4096 };
-
-            // refers to: <baseName>-100k-2048_std_draco.glb
-            case 'webAssetGlbARCompressed':
-                return { usage: 'App3D', quality: 'AR', uvResolution: 2048 };
-
-            case 'usdz':
-                return { usage: 'iOSApp3D', quality: 'AR', uvResolution: 2048 };
+        // Delegates to the shared CookOutputContract mapping (single source of truth also used by the
+        // download-tag backfill), so generation and backfill can never drift apart.
+        const tag = cookDownloadTagForTypeKey(downloadType);
+        if (!tag) {
+            RK.logError(RK.LogSection.eJOB,'compute model properties failed','unsupported downloadType',{ downloadType },'Job.GenerateDownloads');
+            return { usage: undefined, quality: undefined, uvResolution: undefined };
         }
-
-        RK.logError(RK.LogSection.eJOB,'compute model properties failed','unsupported downloadType',{ downloadType },'Job.GenerateDownloads');
-        return { usage: undefined, quality: undefined, uvResolution: undefined };
+        return { usage: tag.usage, quality: tag.quality, uvResolution: tag.uvResolution };
     }
 
     public static computeModelAutomationTagFromDownloadType(downloadType: string): string {
 
-        const { usage, quality, uvResolution } = JobCookSIGenerateDownloads.computeModelPropertiesFromDownloadType(downloadType);
-        if(usage==undefined || quality==undefined || uvResolution==undefined) {
-            // LOG.error(`JobCookSIGenerateDownloads.computeModelAutomationTag unsupported downloadType: '${downloadType}' (${usage} | ${quality} | ${uvResolution})`,LOG.LS.eDEBUG);
-            return `error-${downloadType}-null-null`;
-        }
-
-        switch(downloadType) {
-            // HACK: need to hardcode these because the model is created outside ModelScreneXref context
-            // and doesn't have the needed Usage, Quality, and UVResolution details. skipping 'Usage'.
-            case 'objZipFull':
-            case 'objZipLow':
-            case 'gltfZipLow':
-            case 'webAssetGlbLowUncompressed':
-                return `download-${downloadType}-${quality}-${uvResolution}`;
-
-            // HACK: hardcoding these as well expecting them to be reassigned/overwritten by ModelSceneXref
-            // MSX format is: `scene-${this.Usage}-${this.Quality}-${this.UVResolution}`
-            case 'webAssetGlbARCompressed':
-            case 'usdz':
-                return `scene-${usage}-${quality}-${uvResolution}`;
-        }
-
+        // Delegates to the shared CookOutputContract mapping (single source of truth also used by the
+        // download-tag backfill). Preserves the legacy fallback string for an unsupported type.
+        const auto = cookModelAutomationTagForTypeKey(downloadType);
+        if (auto)
+            return auto;
         RK.logError(RK.LogSection.eJOB,'compute model automation tag failed','unsupported downloadType',{ downloadType },'Job.GenerateDownloads');
-        return `unknown-${downloadType}`;
+        return `error-${downloadType}-null-null`;
     }
 
     private async computeVocabModelGeometryFile(): Promise<DBAPI.Vocabulary | undefined> {

--- a/server/workflow/impl/Packrat/WorkflowEngine.ts
+++ b/server/workflow/impl/Packrat/WorkflowEngine.ts
@@ -185,10 +185,18 @@ export class WorkflowEngine implements WF.IWorkflowEngine {
             return { success: false, message: 'Scene is retired — reinstate it before generating downloads.', data: { isValid: false } };
         }
 
-        // check for multiple master models (not yet supported for download generation)
-        const masterModels: DBAPI.Model[] | null = await DBAPI.Model.fetchMasterFromScene(scene.idScene);
-        if(masterModels && masterModels.length > 1) {
-            RK.logError(RK.LogSection.eWF,'generate downloads blocked','download generation is not yet supported for scenes with multiple master models',{ idScene, numModels: masterModels.length },'Workflow.Engine');
+        // check for multiple master models (not yet supported for download generation). Retired master
+        // models (superseded/failed runs) are ignored — never counted toward the multi-model refusal —
+        // mirroring the active-scene filter in JobCookSIVoyagerScene.
+        const allMasterModels: DBAPI.Model[] | null = await DBAPI.Model.fetchMasterFromScene(scene.idScene);
+        const activeMasterModels: DBAPI.Model[] = [];
+        for(const m of allMasterModels ?? []) {
+            const mSO: DBAPI.SystemObject | null = await m.fetchSystemObject();
+            if(mSO && !mSO.Retired)
+                activeMasterModels.push(m);
+        }
+        if(activeMasterModels.length > 1) {
+            RK.logError(RK.LogSection.eWF,'generate downloads blocked','download generation is not yet supported for scenes with multiple master models',{ idScene, numModels: activeMasterModels.length },'Workflow.Engine');
             return { success: false, message: 'download generation is not yet supported for scenes with multiple master models', data: { isValid: false } };
         }
 


### PR DESCRIPTION
- Backfill Download Tags bulk op (review + apply)
- Shared Cook download-tag mappers in CookOutputContract
- Relationship create/delete audit types + tier mapping
- Audit emitted on add/remove relationship in the UX
- Download-tag backfill audit type + STANDARD tier
- Gen downloads ignores retired master models
- Download tag mapping now uses shared source