### PR TITLE
DPO3DPKRT-1032/Preservation Metrics Endpoint & Admin Page

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -130,6 +130,16 @@ export default class API {
         return this.request('api/scene/published', { method: 'GET' });
     }
 
+    // preservation metrics for an inclusive date range; pass series=true for per-period plot data
+    static async getMetrics(start: string, end: string, series: boolean = false, granularity: 'day' | 'week' | 'month' | 'year' = 'month'): Promise<RequestResponse> {
+        const params = new URLSearchParams({ start, end });
+        if (series) {
+            params.set('series', '1');
+            params.set('granularity', granularity);
+        }
+        return this.request(`api/metrics?${params.toString()}`, { method: 'GET' });
+    }
+
     // volumetric inspection results — returns the JSON produced by JobVolumeInspect
     // for the given asset version. data is null when no completed inspection exists.
     static async getVolumetricInspectionResults(idAssetVersion: number): Promise<RequestResponse> {

--- a/client/src/constants/routes.ts
+++ b/client/src/constants/routes.ts
@@ -72,6 +72,7 @@ export const ADMIN_ROUTES_TYPE = {
     CREATESUBJECT: 'subjects/create',
     TOOLS: 'tools',
     CONTACTS: 'contacts',
+    METRICS: 'metrics',
 };
 
 export const ADMIN_ROUTE = {

--- a/client/src/pages/Admin/components/AdminSidebarMenu.tsx
+++ b/client/src/pages/Admin/components/AdminSidebarMenu.tsx
@@ -75,6 +75,7 @@ function AdminSidebarMenu(): React.ReactElement {
                 <AdminSidebarMenuRow path={'subjects'} selected={path.includes('subjects')} />
                 <Box className={classes.divider} />
                 <AdminSidebarMenuRow path={'tools'} selected={path.includes('tools')} />
+                <AdminSidebarMenuRow path={'metrics'} selected={path.includes('metrics')} />
             </MenuList>
         </Box>
     );

--- a/client/src/pages/Admin/components/Metrics/AdminMetricsView.tsx
+++ b/client/src/pages/Admin/components/Metrics/AdminMetricsView.tsx
@@ -1,0 +1,348 @@
+/* eslint-disable react/jsx-max-props-per-line */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Button, MenuItem, Select, TextField, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { useLocation } from 'react-router';
+import { Helmet } from 'react-helmet';
+import { toast } from 'react-toastify';
+import API, { RequestResponse } from '../../../../api';
+import { useUserStore } from '../../../../store';
+import GenericBreadcrumbsView from '../../../../components/shared/GenericBreadcrumbsView';
+
+type Granularity = 'day' | 'week' | 'month' | 'year';
+
+type Totals = {
+    objectsPreserved: { assetVersions: number; repositoryObjects: number };
+    storage: { bytes: number; terabytes: number; bytesNonDPO: number; terabytesNonDPO: number };
+    activeNonDPOUsers: number;
+    scenes: { publishEvents: number; distinctScenes: number };
+};
+
+type SeriesPoint = {
+    period: string;
+    assetVersions: number;
+    repositoryObjects: number;
+    storageBytes: number;
+    storageTerabytes: number;
+    storageBytesNonDPO: number;
+    storageTerabytesNonDPO: number;
+    activeNonDPOUsers: number;
+    scenePublishEvents: number;
+    scenesPublished: number;
+};
+
+type MetricsData = {
+    range: { start: string; end: string; granularity: Granularity };
+    dpo: { userIDs: number[]; count: number };
+    summary: Totals;
+    cumulative: Totals;
+    series?: SeriesPoint[];
+};
+
+const useStyles = makeStyles(({ palette }) => ({
+    container: {
+        display: 'flex',
+        flex: 1,
+        flexDirection: 'column',
+        overflow: 'auto',
+        paddingBottom: '15px',
+        paddingLeft: '15px',
+        paddingRight: '15px',
+        margin: '0 auto',
+        width: '100%',
+        maxWidth: 1100,
+    },
+    breadcrumbs: {
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: '46px',
+        paddingLeft: '20px',
+        paddingRight: '20px',
+        background: '#ECF5FD',
+        color: '#3F536E',
+        marginBottom: '15px',
+        width: 'fit-content',
+    },
+    controls: {
+        display: 'flex',
+        alignItems: 'flex-end',
+        flexWrap: 'wrap',
+        gap: '12px',
+        marginBottom: '18px',
+    },
+    presets: {
+        display: 'flex',
+        gap: '6px',
+        flexWrap: 'wrap',
+        marginBottom: '14px',
+    },
+    field: { display: 'flex', flexDirection: 'column' },
+    fieldLabel: { fontSize: '0.72rem', color: '#3F536E', marginBottom: 2 },
+    sectionTitle: {
+        fontSize: '1.05rem',
+        fontWeight: 600,
+        color: palette.primary.main,
+        margin: '18px 0 10px',
+    },
+    tileRow: { display: 'flex', flexWrap: 'wrap', gap: '12px' },
+    tile: {
+        flex: '1 1 190px',
+        minWidth: 190,
+        border: '1px solid #C5D9E8',
+        borderRadius: 6,
+        padding: '12px 14px',
+        background: '#FAFCFF',
+    },
+    tileLabel: { fontSize: '0.75rem', color: '#5B6B7F', marginBottom: 6 },
+    tileValue: { fontSize: '1.5rem', fontWeight: 600, color: '#25384F', lineHeight: 1.1 },
+    tileSub: { fontSize: '0.72rem', color: '#7A8Aa0', marginTop: 4 },
+    chartCard: {
+        border: '1px solid #C5D9E8',
+        borderRadius: 6,
+        padding: '12px 14px',
+        marginTop: '12px',
+        background: '#fff',
+    },
+    chartTitle: { fontSize: '0.85rem', fontWeight: 600, color: '#3F536E', marginBottom: 8 },
+    notAuthorized: { padding: '20px', color: '#8B0000' },
+    dpoNote: { fontSize: '0.72rem', color: '#7A8Aa0', margin: '4px 0 14px' },
+}));
+
+// --- date helpers (local time) ---
+function fmtDate(d: Date): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+function quarterStart(d: Date): Date {
+    return new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
+}
+
+const NUM = (n: number): string => n.toLocaleString();
+
+// Auto-scaling byte formatter (decimal units, matching the 10^12 TB used for reporting).
+function formatBytes(bytes: number): string {
+    if (!bytes || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1000)));
+    const val = bytes / Math.pow(1000, i);
+    return `${val.toLocaleString(undefined, { maximumFractionDigits: i >= 3 ? 2 : 1 })} ${units[i]}`;
+}
+
+// --- minimal dependency-free bar chart ---
+function BarChart({ points, getValue, color, format }: { points: SeriesPoint[]; getValue: (p: SeriesPoint) => number; color: string; format?: (n: number) => string }): React.ReactElement {
+    const fmt = format ?? NUM;
+    const width = 640, height = 160, padL = 8, padR = 8, padB = 22, padT = 20;
+    const vals = points.map(getValue);
+    const realMax = points.length ? Math.max(...vals) : 0;
+    if (points.length === 0 || realMax === 0)
+        return <Typography style={{ fontSize: '0.8rem', color: '#7A8Aa0' }}>No data in range.</Typography>;
+    const plotW = width - padL - padR;
+    const plotH = height - padT - padB;
+    const bw = plotW / points.length;
+    const showBarLabels = points.length <= 24;
+    const labelEvery = Math.ceil(points.length / 12);
+    return (
+        <svg viewBox={`0 0 ${width} ${height}`} width='100%' role='img'>
+            <text x={padL} y={11} fontSize='9' fill='#7A8Aa0'>peak {fmt(realMax)}</text>
+            {points.map((p, i) => {
+                const v = vals[i];
+                const h = (v / realMax) * plotH;
+                const x = padL + i * bw;
+                const y = padT + (plotH - h);
+                const cx = x + bw / 2;
+                return (
+                    <g key={p.period}>
+                        <rect x={x + bw * 0.12} y={y} width={bw * 0.76} height={h} fill={color} rx={1}>
+                            <title>{`${p.period}: ${fmt(v)}`}</title>
+                        </rect>
+                        {showBarLabels && v > 0 && (
+                            <text x={cx} y={y - 3} textAnchor='middle' fontSize='8' fill='#25384F'>{fmt(v)}</text>
+                        )}
+                        {i % labelEvery === 0 && (
+                            <text x={cx} y={height - 7} textAnchor='middle' fontSize='8' fill='#7A8Aa0'>{p.period}</text>
+                        )}
+                    </g>
+                );
+            })}
+            <line x1={padL} y1={padT + plotH} x2={width - padR} y2={padT + plotH} stroke='#C5D9E8' strokeWidth='1' />
+        </svg>
+    );
+}
+
+function Tile({ label, value, sub }: { label: string; value: string; sub?: string }): React.ReactElement {
+    const classes = useStyles();
+    return (
+        <Box className={classes.tile}>
+            <div className={classes.tileLabel}>{label}</div>
+            <div className={classes.tileValue}>{value}</div>
+            {sub && <div className={classes.tileSub}>{sub}</div>}
+        </Box>
+    );
+}
+
+function AdminMetricsView(): React.ReactElement {
+    const classes = useStyles();
+    const location = useLocation();
+    const { user } = useUserStore();
+    const isAuthorized = (user?.canAccessTools ?? false) || (user?.isAdmin ?? false);
+
+    const today = new Date();
+    const [start, setStart] = useState<string>(fmtDate(quarterStart(today)));
+    const [end, setEnd] = useState<string>(fmtDate(today));
+    const [granularity, setGranularity] = useState<Granularity>('month');
+    const [data, setData] = useState<MetricsData | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+
+    const fetchData = useCallback(async () => {
+        try {
+            setLoading(true);
+            const result: RequestResponse = await API.getMetrics(start, end, true, granularity);
+            if (!result?.success) {
+                toast.error(result?.message ?? 'Failed to load metrics');
+                return;
+            }
+            setData(result.data as MetricsData);
+        } catch (error) {
+            toast.error('Failed to load metrics');
+        } finally {
+            setLoading(false);
+        }
+    }, [start, end, granularity]);
+
+    useEffect(() => { if (isAuthorized) fetchData(); /* initial load */ }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const applyPreset = (kind: 'thisQ' | 'lastQ' | 'ytd' | 'last12'): void => {
+        const now = new Date();
+        if (kind === 'thisQ') { setStart(fmtDate(quarterStart(now))); setEnd(fmtDate(now)); } else if (kind === 'lastQ') {
+            const qs = quarterStart(now);
+            const lastQEnd = new Date(qs.getTime() - 86400000);
+            setStart(fmtDate(quarterStart(lastQEnd))); setEnd(fmtDate(lastQEnd));
+        } else if (kind === 'ytd') { setStart(`${now.getFullYear()}-01-01`); setEnd(fmtDate(now)); } else if (kind === 'last12') {
+            const from = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+            setStart(fmtDate(from)); setEnd(fmtDate(now));
+        }
+    };
+
+    const downloadJSON = (): void => {
+        if (!data) return;
+        // Omit the DPO user-ID list from the exported report; keep only the aggregate count.
+        const exportData = { ...data, dpo: { count: data.dpo.count } };
+        triggerDownload(JSON.stringify(exportData, null, 2), `packrat-metrics_${start}_${end}.json`, 'application/json');
+    };
+    const downloadCSV = (): void => {
+        if (!data?.series) return;
+        const header = ['period', 'assetVersions', 'repositoryObjects', 'storageBytes', 'storageBytesNonDPO', 'storageTerabytes', 'storageTerabytesNonDPO', 'activeNonDPOUsers', 'scenePublishEvents', 'scenesPublished'];
+        const lines = data.series.map(p => [p.period, p.assetVersions, p.repositoryObjects, p.storageBytes, p.storageBytesNonDPO, p.storageTerabytes, p.storageTerabytesNonDPO, p.activeNonDPOUsers, p.scenePublishEvents, p.scenesPublished].join(','));
+        triggerDownload([header.join(','), ...lines].join('\n'), `packrat-metrics_${start}_${end}.csv`, 'text/csv');
+    };
+
+    if (!isAuthorized)
+        return (
+            <Box className={classes.container}>
+                <p className={classes.notAuthorized}>You are <b>Not Authorized</b> to view metrics.</p>
+            </Box>
+        );
+
+    const series: SeriesPoint[] = data?.series ?? [];
+
+    return (
+        <React.Fragment>
+            <Helmet><title>Admin: Metrics</title></Helmet>
+            <Box className={classes.container}>
+                <Box className={classes.breadcrumbs}>
+                    <GenericBreadcrumbsView items={location.pathname.slice(1)} />
+                </Box>
+
+                <div className={classes.presets}>
+                    <Button size='small' variant='outlined' onClick={() => applyPreset('thisQ')}>This Quarter</Button>
+                    <Button size='small' variant='outlined' onClick={() => applyPreset('lastQ')}>Last Quarter</Button>
+                    <Button size='small' variant='outlined' onClick={() => applyPreset('ytd')}>Year to Date</Button>
+                    <Button size='small' variant='outlined' onClick={() => applyPreset('last12')}>Last 12 Months</Button>
+                </div>
+
+                <Box className={classes.controls}>
+                    <div className={classes.field}>
+                        <span className={classes.fieldLabel}>Start</span>
+                        <TextField type='date' size='small' variant='outlined' value={start} onChange={e => setStart(e.target.value)} />
+                    </div>
+                    <div className={classes.field}>
+                        <span className={classes.fieldLabel}>End</span>
+                        <TextField type='date' size='small' variant='outlined' value={end} onChange={e => setEnd(e.target.value)} />
+                    </div>
+                    <div className={classes.field}>
+                        <span className={classes.fieldLabel}>Granularity</span>
+                        <Select value={granularity} onChange={e => setGranularity(e.target.value as Granularity)} variant='outlined' style={{ height: 40, minWidth: 110 }}>
+                            <MenuItem value='day'>Day</MenuItem>
+                            <MenuItem value='week'>Week</MenuItem>
+                            <MenuItem value='month'>Month</MenuItem>
+                            <MenuItem value='year'>Year</MenuItem>
+                        </Select>
+                    </div>
+                    <Button variant='contained' color='primary' onClick={fetchData} disabled={loading}>{loading ? 'Loading…' : 'Run'}</Button>
+                    <Button variant='outlined' onClick={downloadCSV} disabled={!data?.series}>CSV</Button>
+                    <Button variant='outlined' onClick={downloadJSON} disabled={!data}>JSON</Button>
+                </Box>
+
+                {data && (
+                    <>
+                        <div className={classes.dpoNote}>
+                            Range {new Date(data.range.start).toLocaleDateString()} – {new Date(data.range.end).toLocaleDateString()} ·
+                            {' '}Non-DPO = users outside the DPO set ({data.dpo.count} DPO user{data.dpo.count === 1 ? '' : 's'}).
+                        </div>
+
+                        <div className={classes.sectionTitle}>Selected Range</div>
+                        <Box className={classes.tileRow}>
+                            <Tile label='Objects Preserved' value={NUM(data.summary.objectsPreserved.repositoryObjects)} sub={`${NUM(data.summary.objectsPreserved.assetVersions)} asset versions`} />
+                            <Tile label='Data Preserved' value={formatBytes(data.summary.storage.bytes)} />
+                            <Tile label='Data Preserved (non-DPO)' value={formatBytes(data.summary.storage.bytesNonDPO)} />
+                            <Tile label='Active non-DPO Users' value={NUM(data.summary.activeNonDPOUsers)} />
+                            <Tile label='Scenes Published/Updated' value={NUM(data.summary.scenes.distinctScenes)} sub={`${NUM(data.summary.scenes.publishEvents)} publish events`} />
+                        </Box>
+
+                        <div className={classes.sectionTitle}>Cumulative (through end date)</div>
+                        <Box className={classes.tileRow}>
+                            <Tile label='Objects Preserved' value={NUM(data.cumulative.objectsPreserved.repositoryObjects)} sub={`${NUM(data.cumulative.objectsPreserved.assetVersions)} asset versions`} />
+                            <Tile label='Data Preserved' value={formatBytes(data.cumulative.storage.bytes)} />
+                            <Tile label='Data Preserved (non-DPO)' value={formatBytes(data.cumulative.storage.bytesNonDPO)} />
+                            <Tile label='Scenes Published (total)' value={NUM(data.cumulative.scenes.distinctScenes)} />
+                        </Box>
+
+                        <div className={classes.sectionTitle}>Over Time</div>
+                        <Box className={classes.chartCard}>
+                            <div className={classes.chartTitle}>Data preserved per period</div>
+                            <BarChart points={series} getValue={p => p.storageBytes} color='#2B7DE9' format={formatBytes} />
+                        </Box>
+                        <Box className={classes.chartCard}>
+                            <div className={classes.chartTitle}>Objects preserved per period</div>
+                            <BarChart points={series} getValue={p => p.repositoryObjects} color='#37A66B' />
+                        </Box>
+                        <Box className={classes.chartCard}>
+                            <div className={classes.chartTitle}>Scenes published/updated per period</div>
+                            <BarChart points={series} getValue={p => p.scenesPublished} color='#B07CE0' />
+                        </Box>
+                        <Box className={classes.chartCard}>
+                            <div className={classes.chartTitle}>Active non-DPO users per period</div>
+                            <BarChart points={series} getValue={p => p.activeNonDPOUsers} color='#E0913C' />
+                        </Box>
+                    </>
+                )}
+            </Box>
+        </React.Fragment>
+    );
+}
+
+function triggerDownload(content: string, filename: string, mime: string): void {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+export default AdminMetricsView;

--- a/client/src/pages/Admin/index.tsx
+++ b/client/src/pages/Admin/index.tsx
@@ -26,6 +26,7 @@ import AdminUserForm from './components/User/AdminUserForm';
 import AdminProjectsView from './components/AdminProjectsView';
 import AdminUnitsView from './components/AdminUnitsView';
 import AdminToolsView from './components/AdminToolsView';
+import AdminMetricsView from './components/Metrics/AdminMetricsView';
 import AdminContactView from './components/Contact/AdminContactView';
 import AddUnitForm from './components/AddUnitForm';
 import AddProjectForm from './components/AddProjectForm';
@@ -52,6 +53,7 @@ function Admin(): React.ReactElement {
             <Route path={resolveRoute(ADMIN_ROUTE.ROUTES.CREATESUBJECT)} element={<SubjectForm />} />
             <Route path={resolveRoute(ADMIN_ROUTE.ROUTES.SUBJECTS)} element={<SubjectView />} />
             <Route path={resolveRoute(ADMIN_ROUTE.ROUTES.TOOLS)} element={<AdminToolsView />} />
+            <Route path={resolveRoute(ADMIN_ROUTE.ROUTES.METRICS)} element={<AdminMetricsView />} />
             <Route path='/' element={<Navigate to={resolveSubRoute(ADMIN_ROUTE.TYPE, ADMIN_ROUTE.ROUTES.LICENSES)} />} />
         </Routes>
     );

--- a/conf/scripts/deploy.sh
+++ b/conf/scripts/deploy.sh
@@ -53,5 +53,14 @@ export ENV=$ENV
 
 echo "Deploying docker images for env $ENV with tag: $IMAGE_TAG"
 
+# Docker containers need IPv4 forwarding for build-time egress (apk/npm reach package mirrors) and for
+# runtime networking. A hardened sysctl baseline (e.g. CIS/STIG) can pin net.ipv4.ip_forward=0, which
+# severs container egress and fails the build at 'apk update'. Assert it here so a deploy never fails on
+# it. The host should persist this as 1 (a container host requires it); this is a build-time safety net.
+if [ "$(sysctl -n net.ipv4.ip_forward 2>/dev/null)" != "1" ]; then
+  echo "WARN: net.ipv4.ip_forward=0 — enabling for Docker container egress (host should persist this as 1)"
+  sudo sysctl -w net.ipv4.ip_forward=1 || echo "WARN: could not set net.ipv4.ip_forward (need passwordless sudo); build may fail to reach package mirrors"
+fi
+
 # Build packrat-server and client dynamically for environment's requested
 docker compose --env-file .env.$ENV -f ./conf/docker/docker-compose.deploy.yml up --build -d packrat-server-$ENV packrat-client-$ENV packrat-solr-$ENV

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -394,6 +394,22 @@ export const Config: ConfigType = {
     }
 };
 
+/**
+ * Resolves the set of user IDs treated as DPO staff for reporting. Reads a comma-separated
+ * override from PACKRAT_DPO_USER_IDS; when unset or empty, defaults to the union of the
+ * admin and tools user lists (representative of DPO staff at this time). Everyone else is
+ * treated as non-DPO by the metrics endpoints.
+ */
+export function getDPOUserIDs(): number[] {
+    const raw: string | undefined = process.env.PACKRAT_DPO_USER_IDS;
+    if (raw && raw.trim().length > 0) {
+        const ids: number[] = raw.split(',').map(s => parseInt(s.trim(), 10)).filter(n => Number.isInteger(n) && n > 0);
+        if (ids.length > 0)
+            return [...new Set(ids)];
+    }
+    return [...new Set([...Config.auth.users.admin, ...Config.auth.users.tools])];
+}
+
 function parseEnvDays(raw: string | undefined, fallback: number): number {
     if (raw === undefined) return fallback;
     const n = parseInt(raw, 10);

--- a/server/db/api/Metrics.ts
+++ b/server/db/api/Metrics.ts
@@ -1,0 +1,243 @@
+/* eslint-disable camelcase */
+import { Prisma } from '@prisma/client';
+import * as DBC from '../connection';
+import * as H from '../../utils/helpers';
+import { RecordKeeper as RK } from '../../records/recordKeeper';
+
+/** Period bucket size for time-series output. Values map to MySQL DATE_FORMAT masks. */
+export type MetricsGranularity = 'day' | 'week' | 'month' | 'year';
+
+const GRANULARITY_FORMAT: Record<MetricsGranularity, string> = {
+    day:   '%Y-%m-%d',
+    week:  '%x-W%v',
+    month: '%Y-%m',
+    year:  '%Y',
+};
+
+/** ISO-8601 week key (year-Www) matching MySQL DATE_FORMAT('%x-W%v'): weeks start Monday, week 1 holds the year's first Thursday. */
+function isoWeekKey(d: Date): string {
+    const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    const day = (date.getUTCDay() + 6) % 7;                  // Mon=0 .. Sun=6
+    date.setUTCDate(date.getUTCDate() - day + 3);            // Thursday of this week
+    const isoYear = date.getUTCFullYear();
+    const firstThursday = new Date(Date.UTC(isoYear, 0, 4)); // Jan 4 is always in week 1
+    const firstDay = (firstThursday.getUTCDay() + 6) % 7;
+    firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDay + 3);
+    const week = 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * 86400000));
+    return `${isoYear}-W${String(week).padStart(2, '0')}`;
+}
+
+/** Period bucket key for a date, matching the MySQL DATE_FORMAT mask for the granularity. */
+function periodKey(d: Date, granularity: MetricsGranularity): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    switch (granularity) {
+        case 'day':   return `${y}-${m}-${day}`;
+        case 'week':  return isoWeekKey(d);
+        case 'month': return `${y}-${m}`;
+        case 'year':  return `${y}`;
+    }
+}
+
+/** Every period bucket from lo to hi (inclusive), in chronological order — used to zero-fill gaps in the series. */
+function enumeratePeriods(lo: Date, hi: Date, granularity: MetricsGranularity): string[] {
+    const keys: string[] = [];
+    const seen: Set<string> = new Set();
+    const cur = new Date(lo.getFullYear(), lo.getMonth(), lo.getDate());
+    const end = new Date(hi.getFullYear(), hi.getMonth(), hi.getDate());
+    while (cur.getTime() <= end.getTime()) {
+        const k: string = periodKey(cur, granularity);
+        if (!seen.has(k)) { seen.add(k); keys.push(k); }
+        cur.setDate(cur.getDate() + 1);
+    }
+    return keys;
+}
+
+export type MetricsTotals = {
+    /** Ingested asset-version rows (every preserved file/version) in the window. */
+    assetVersions: number;
+    /** Distinct repository objects (SystemObjects) that received an ingested asset version. */
+    repositoryObjects: number;
+    /** Total bytes of ingested asset versions (full OCFL footprint, all versions). */
+    storageBytes: number;
+    /** Subset of storageBytes contributed by non-DPO users. */
+    storageBytesNonDPO: number;
+    /** Distinct non-DPO users with any audited activity in the window. */
+    activeNonDPOUsers: number;
+    /** Scene publish/update events (published SystemObjectVersions) in the window. */
+    scenePublishEvents: number;
+    /** Distinct scenes touched by those publish/update events. */
+    scenesPublished: number;
+};
+
+export type MetricsSeriesPoint = MetricsTotals & { period: string };
+
+type WindowRow = {
+    assetVersions: number | bigint;
+    repositoryObjects: number | bigint;
+    storageBytes: number | bigint;
+    storageBytesNonDPO: number | bigint;
+};
+type SceneRow = { events: number | bigint; distinctScenes: number | bigint };
+type UsersRow = { activeUsers: number | bigint };
+
+const PUBLISHED_STATE_MIN = 0; // PublishedState > 0 => API Only | Published | Internal (i.e. any EDAN-published state)
+
+/**
+ * Metrics — aggregate reporting queries for on-demand / quarterly preservation stats.
+ * All windows are inclusive of [lo, hi]; cumulative-to-date is expressed by passing lo = epoch.
+ * "non-DPO" is any user whose idUser is not in dpoUserIDs (resolved from config by the caller).
+ */
+export class Metrics {
+    /** Asset-version counts, distinct repository objects, and storage bytes (total + non-DPO) for a window. */
+    static async fetchStorageTotals(lo: Date, hi: Date, dpoUserIDs: number[]): Promise<Pick<MetricsTotals, 'assetVersions' | 'repositoryObjects' | 'storageBytes' | 'storageBytesNonDPO'>> {
+        const zero = { assetVersions: 0, repositoryObjects: 0, storageBytes: 0, storageBytesNonDPO: 0 };
+        try {
+            const nonDPOSum: Prisma.Sql = dpoUserIDs.length
+                ? Prisma.sql`COALESCE(SUM(CASE WHEN AV.idUserCreator NOT IN (${Prisma.join(dpoUserIDs)}) THEN AV.StorageSize ELSE 0 END), 0)`
+                : Prisma.sql`COALESCE(SUM(AV.StorageSize), 0)`;
+            const rows: WindowRow[] = await DBC.DBConnection.prisma.$queryRaw<WindowRow[]>(Prisma.sql`
+                SELECT COUNT(*) AS assetVersions,
+                       COUNT(DISTINCT A.idSystemObject) AS repositoryObjects,
+                       COALESCE(SUM(AV.StorageSize), 0) AS storageBytes,
+                       ${nonDPOSum} AS storageBytesNonDPO
+                FROM AssetVersion AS AV
+                JOIN Asset AS A ON (AV.idAsset = A.idAsset)
+                WHERE AV.Ingested = 1
+                  AND AV.DateCreated BETWEEN ${lo} AND ${hi}`);
+            const r: WindowRow | undefined = rows[0];
+            if (!r)
+                return zero;
+            return {
+                assetVersions: Number(r.assetVersions),
+                repositoryObjects: Number(r.repositoryObjects),
+                storageBytes: Number(r.storageBytes),
+                storageBytesNonDPO: Number(r.storageBytesNonDPO),
+            };
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB, 'metrics storage totals failed', H.Helpers.getErrorString(error), { lo, hi }, 'DB.Metrics');
+            return zero;
+        }
+    }
+
+    /** Distinct non-DPO users with any audited activity in a window. */
+    static async fetchActiveNonDPOUsers(lo: Date, hi: Date, dpoUserIDs: number[]): Promise<number> {
+        try {
+            const notDPO: Prisma.Sql = dpoUserIDs.length ? Prisma.sql`AND AU.idUser NOT IN (${Prisma.join(dpoUserIDs)})` : Prisma.empty;
+            const rows: UsersRow[] = await DBC.DBConnection.prisma.$queryRaw<UsersRow[]>(Prisma.sql`
+                SELECT COUNT(DISTINCT AU.idUser) AS activeUsers
+                FROM Audit AS AU
+                WHERE AU.idUser IS NOT NULL
+                  ${notDPO}
+                  AND AU.AuditDate BETWEEN ${lo} AND ${hi}`);
+            return rows[0] ? Number(rows[0].activeUsers) : 0;
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB, 'metrics active users failed', H.Helpers.getErrorString(error), { lo, hi }, 'DB.Metrics');
+            return 0;
+        }
+    }
+
+    /** Scene publish/update events and distinct scenes touched (any EDAN-published state) in a window. */
+    static async fetchScenesPublished(lo: Date, hi: Date): Promise<{ events: number; distinctScenes: number }> {
+        try {
+            const rows: SceneRow[] = await DBC.DBConnection.prisma.$queryRaw<SceneRow[]>(Prisma.sql`
+                SELECT COUNT(*) AS events, COUNT(DISTINCT SO.idScene) AS distinctScenes
+                FROM SystemObjectVersion AS SOV
+                JOIN SystemObject AS SO ON (SOV.idSystemObject = SO.idSystemObject)
+                WHERE SO.idScene IS NOT NULL
+                  AND SOV.PublishedState > ${PUBLISHED_STATE_MIN}
+                  AND SOV.DateCreated BETWEEN ${lo} AND ${hi}`);
+            const r: SceneRow | undefined = rows[0];
+            return { events: r ? Number(r.events) : 0, distinctScenes: r ? Number(r.distinctScenes) : 0 };
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB, 'metrics scenes published failed', H.Helpers.getErrorString(error), { lo, hi }, 'DB.Metrics');
+            return { events: 0, distinctScenes: 0 };
+        }
+    }
+
+    /** All summary totals for a window, assembled from the individual aggregate queries. */
+    static async fetchTotals(lo: Date, hi: Date, dpoUserIDs: number[]): Promise<MetricsTotals> {
+        const [storage, activeNonDPOUsers, scenes] = await Promise.all([
+            Metrics.fetchStorageTotals(lo, hi, dpoUserIDs),
+            Metrics.fetchActiveNonDPOUsers(lo, hi, dpoUserIDs),
+            Metrics.fetchScenesPublished(lo, hi),
+        ]);
+        return {
+            ...storage,
+            activeNonDPOUsers,
+            scenePublishEvents: scenes.events,
+            scenesPublished: scenes.distinctScenes,
+        };
+    }
+
+    /** Per-period time series for the same metrics, bucketed by granularity. Periods with no data are omitted. */
+    static async fetchSeries(lo: Date, hi: Date, dpoUserIDs: number[], granularity: MetricsGranularity): Promise<MetricsSeriesPoint[]> {
+        const fmt: string = GRANULARITY_FORMAT[granularity];
+        const points: Map<string, MetricsSeriesPoint> = new Map();
+        const point = (period: string): MetricsSeriesPoint => {
+            let p: MetricsSeriesPoint | undefined = points.get(period);
+            if (!p) {
+                p = { period, assetVersions: 0, repositoryObjects: 0, storageBytes: 0, storageBytesNonDPO: 0, activeNonDPOUsers: 0, scenePublishEvents: 0, scenesPublished: 0 };
+                points.set(period, p);
+            }
+            return p;
+        };
+
+        try {
+            const nonDPOSum: Prisma.Sql = dpoUserIDs.length
+                ? Prisma.sql`COALESCE(SUM(CASE WHEN AV.idUserCreator NOT IN (${Prisma.join(dpoUserIDs)}) THEN AV.StorageSize ELSE 0 END), 0)`
+                : Prisma.sql`COALESCE(SUM(AV.StorageSize), 0)`;
+            const storageRows = await DBC.DBConnection.prisma.$queryRaw<(WindowRow & { period: string })[]>(Prisma.sql`
+                SELECT DATE_FORMAT(AV.DateCreated, ${fmt}) AS period,
+                       COUNT(*) AS assetVersions,
+                       COUNT(DISTINCT A.idSystemObject) AS repositoryObjects,
+                       COALESCE(SUM(AV.StorageSize), 0) AS storageBytes,
+                       ${nonDPOSum} AS storageBytesNonDPO
+                FROM AssetVersion AS AV
+                JOIN Asset AS A ON (AV.idAsset = A.idAsset)
+                WHERE AV.Ingested = 1
+                  AND AV.DateCreated BETWEEN ${lo} AND ${hi}
+                GROUP BY period`);
+            for (const r of storageRows) {
+                const p = point(r.period);
+                p.assetVersions = Number(r.assetVersions);
+                p.repositoryObjects = Number(r.repositoryObjects);
+                p.storageBytes = Number(r.storageBytes);
+                p.storageBytesNonDPO = Number(r.storageBytesNonDPO);
+            }
+
+            const sceneRows = await DBC.DBConnection.prisma.$queryRaw<(SceneRow & { period: string })[]>(Prisma.sql`
+                SELECT DATE_FORMAT(SOV.DateCreated, ${fmt}) AS period,
+                       COUNT(*) AS events, COUNT(DISTINCT SO.idScene) AS distinctScenes
+                FROM SystemObjectVersion AS SOV
+                JOIN SystemObject AS SO ON (SOV.idSystemObject = SO.idSystemObject)
+                WHERE SO.idScene IS NOT NULL
+                  AND SOV.PublishedState > ${PUBLISHED_STATE_MIN}
+                  AND SOV.DateCreated BETWEEN ${lo} AND ${hi}
+                GROUP BY period`);
+            for (const r of sceneRows) {
+                const p = point(r.period);
+                p.scenePublishEvents = Number(r.events);
+                p.scenesPublished = Number(r.distinctScenes);
+            }
+
+            const notDPO: Prisma.Sql = dpoUserIDs.length ? Prisma.sql`AND AU.idUser NOT IN (${Prisma.join(dpoUserIDs)})` : Prisma.empty;
+            const userRows = await DBC.DBConnection.prisma.$queryRaw<{ period: string; activeUsers: number | bigint }[]>(Prisma.sql`
+                SELECT DATE_FORMAT(AU.AuditDate, ${fmt}) AS period, COUNT(DISTINCT AU.idUser) AS activeUsers
+                FROM Audit AS AU
+                WHERE AU.idUser IS NOT NULL
+                  ${notDPO}
+                  AND AU.AuditDate BETWEEN ${lo} AND ${hi}
+                GROUP BY period`);
+            for (const r of userRows)
+                point(r.period).activeNonDPOUsers = Number(r.activeUsers);
+
+            // Zero-fill gaps so the series is a continuous timeline across the whole range.
+            return enumeratePeriods(lo, hi, granularity).map(period => point(period));
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB, 'metrics series failed', H.Helpers.getErrorString(error), { lo, hi, granularity }, 'DB.Metrics');
+            return [];
+        }
+    }
+}

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -32,6 +32,7 @@ export * from './api/JobRun';
 export * from './api/License';
 export * from './api/LicenseAssignment';
 export * from './api/Metadata';
+export * from './api/Metrics';
 export * from './api/Model';
 export * from './api/ModelMaterial';
 export * from './api/ModelMaterialChannel';

--- a/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
+++ b/server/graphql/schema/systemobject/resolvers/queries/getSystemObjectDetails.ts
@@ -331,8 +331,8 @@ async function getPublishedState(idSystemObject: number, oID: DBAPI.ObjectIDAndT
 
                 // Warn an admin editing a Subject in a Unit they are not directly assigned to.
                 // Admin context units are zeroed, so read the raw assignments.
-                if (isAdmin && subjectDB) {
-                    const ownUnits: number[] = await DBAPI.UserAuthorization.fetchUnitsForUser(ctx!.idUser);
+                if (isAdmin && subjectDB && ctx) {
+                    const ownUnits: number[] = await DBAPI.UserAuthorization.fetchUnitsForUser(ctx.idUser);
                     subjectUnitMismatch = !ownUnits.includes(subjectDB.idUnit);
                 }
             } break;

--- a/server/http/index.ts
+++ b/server/http/index.ts
@@ -36,6 +36,7 @@ import { getUnit } from './routes/api/object';
 import { getExternalSources, createExternalSource, updateExternalSource } from './routes/api/object';
 import { getUserUnits, setUserUnits, getUnitAuth, setUnitAuth, getProjectAuth, setProjectAuth, getAuthUsers, getAuthUnits, getAuthProjects, getAuthSummary, getAuthDenials } from './routes/api/authorization';
 import { getServiceStatus } from './routes/api/status';
+import { getMetrics } from './routes/api/metrics';
 import { createWebDAVToken } from './routes/api/scene';
 import { sceneByUUID } from './routes/api/sceneByUUID';
 import { getAuditLifeline } from './routes/api/auditLifeline';
@@ -285,6 +286,8 @@ export class HttpServer {
         this.app.get('/api/auth/denials', getAuthDenials);
 
         this.app.get('/api/status', getServiceStatus);
+
+        this.app.get('/api/metrics', getMetrics);                   // admin/tools: preservation metrics for a date range (+ optional series)
 
         this.app.get('/api/sandbox/play',play);
 

--- a/server/http/routes/api/metrics.ts
+++ b/server/http/routes/api/metrics.ts
@@ -1,0 +1,136 @@
+import * as DBAPI from '../../../db';
+import { ASL, LocalStore } from '../../../utils/localStore';
+import { isAuthenticated } from '../../auth';
+import { Config, getDPOUserIDs } from '../../../config';
+import { RecordKeeper as RK } from '../../../records/recordKeeper';
+import { MetricsGranularity, MetricsTotals, MetricsSeriesPoint } from '../../../db/api/Metrics';
+import { Request, Response } from 'express';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function respond(res: Response, success: boolean, message: string | undefined, data?: any): void {
+    res.status(200).send(JSON.stringify({ success, message, data }));
+}
+
+const BYTES_PER_TB = 1_000_000_000_000; // decimal TB (10^12), matches storage-vendor / management reporting
+const GRANULARITIES: MetricsGranularity[] = ['day', 'week', 'month', 'year'];
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parses a start/end param. Date-only values are widened to the day's start or end in server-local time. */
+function parseDate(raw: string, endOfDay: boolean): Date | null {
+    if (DATE_ONLY_RE.test(raw)) {
+        const [y, m, d] = raw.split('-').map(n => parseInt(n, 10));
+        return endOfDay ? new Date(y, m - 1, d, 23, 59, 59, 999) : new Date(y, m - 1, d, 0, 0, 0, 0);
+    }
+    const parsed: Date = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toTB(bytes: number): number {
+    return Math.round((bytes / BYTES_PER_TB) * 10000) / 10000;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function shapeTotals(t: MetricsTotals): any {
+    return {
+        objectsPreserved: { assetVersions: t.assetVersions, repositoryObjects: t.repositoryObjects },
+        storage: {
+            bytes: t.storageBytes,
+            terabytes: toTB(t.storageBytes),
+            bytesNonDPO: t.storageBytesNonDPO,
+            terabytesNonDPO: toTB(t.storageBytesNonDPO),
+        },
+        activeNonDPOUsers: t.activeNonDPOUsers,
+        scenes: { publishEvents: t.scenePublishEvents, distinctScenes: t.scenesPublished },
+    };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function shapeSeriesPoint(p: MetricsSeriesPoint): any {
+    return {
+        period: p.period,
+        assetVersions: p.assetVersions,
+        repositoryObjects: p.repositoryObjects,
+        storageBytes: p.storageBytes,
+        storageTerabytes: toTB(p.storageBytes),
+        storageBytesNonDPO: p.storageBytesNonDPO,
+        storageTerabytesNonDPO: toTB(p.storageBytesNonDPO),
+        activeNonDPOUsers: p.activeNonDPOUsers,
+        scenePublishEvents: p.scenePublishEvents,
+        scenesPublished: p.scenesPublished,
+    };
+}
+
+/**
+ * GET /api/metrics?start=YYYY-MM-DD&end=YYYY-MM-DD[&series=1][&granularity=month]
+ *
+ * Preservation reporting for the given inclusive date range (server-local time):
+ *   - objects preserved (ingested asset versions + distinct repository objects)
+ *   - TB of data preserved (total, and the non-DPO-contributed subset)
+ *   - active non-DPO users (distinct users with audited activity)
+ *   - scene content published/updated (publish events + distinct scenes)
+ *
+ * Returns `summary` (delta within the range) and `cumulative` (all-time through `end`).
+ * With `series=1`, also returns a per-period array (granularity: day|week|month|year, default month)
+ * suitable for plotting. Admin/tools only.
+ */
+export async function getMetrics(req: Request, res: Response): Promise<void> {
+    if (!isAuthenticated(req)) {
+        respond(res, false, 'getMetrics: not authenticated');
+        return;
+    }
+    const LS: LocalStore | undefined = ASL.getStore();
+    if (!LS || !LS.idUser) {
+        respond(res, false, 'getMetrics: missing local store/user');
+        return;
+    }
+    const authorized: number[] = [...new Set([...Config.auth.users.admin, ...Config.auth.users.tools])];
+    if (!authorized.includes(LS.idUser)) {
+        respond(res, false, 'getMetrics: not authorized');
+        return;
+    }
+
+    const startRaw: string = String(req.query.start ?? '');
+    const endRaw: string = String(req.query.end ?? '');
+    if (!startRaw || !endRaw) {
+        respond(res, false, 'getMetrics: start and end query params are required (YYYY-MM-DD)');
+        return;
+    }
+    const start: Date | null = parseDate(startRaw, false);
+    const end: Date | null = parseDate(endRaw, true);
+    if (!start || !end) {
+        respond(res, false, 'getMetrics: start/end must be valid dates (YYYY-MM-DD or ISO)');
+        return;
+    }
+    if (start.getTime() > end.getTime()) {
+        respond(res, false, 'getMetrics: start must be on or before end');
+        return;
+    }
+
+    const wantSeries: boolean = req.query.series === '1' || req.query.series === 'true';
+    const granularityRaw: string = String(req.query.granularity ?? 'month').toLowerCase();
+    const granularity: MetricsGranularity = (GRANULARITIES as string[]).includes(granularityRaw)
+        ? granularityRaw as MetricsGranularity : 'month';
+
+    try {
+        const dpoUserIDs: number[] = getDPOUserIDs();
+        const epoch = new Date(0);
+
+        const [rangeTotals, cumulativeTotals, series] = await Promise.all([
+            DBAPI.Metrics.fetchTotals(start, end, dpoUserIDs),
+            DBAPI.Metrics.fetchTotals(epoch, end, dpoUserIDs),
+            wantSeries ? DBAPI.Metrics.fetchSeries(start, end, dpoUserIDs, granularity) : Promise.resolve(null),
+        ]);
+
+        respond(res, true, undefined, {
+            range: { start: start.toISOString(), end: end.toISOString(), granularity },
+            dpo: { userIDs: dpoUserIDs, count: dpoUserIDs.length },
+            summary: shapeTotals(rangeTotals),
+            cumulative: shapeTotals(cumulativeTotals),
+            series: series ? series.map(shapeSeriesPoint) : undefined,
+        });
+    } catch (error) {
+        RK.logError(RK.LogSection.eHTTP, 'getMetrics failed',
+            error instanceof Error ? error.message : String(error), { startRaw, endRaw }, 'HTTP.Route.Metrics');
+        respond(res, false, `getMetrics: ${error instanceof Error ? error.message : 'unexpected error'}`);
+    }
+}


### PR DESCRIPTION
* Add a REST endpoint for date-range preservation metrics.
* Return summary, cumulative, and time-series metrics.
* Fill missing dates with zero values for continuous charts.
* Add metrics for storage, users, and scene publishing.
* Add an admin page with filters, charts, tiles, and export.
* Configure DPO users through an environment variable.
* Export metrics as CSV or JSON for external analysis.
* Show chart values and peaks without requiring hover.
* Auto-scale byte charts so small values remain visible.
* Exclude DPO user IDs from JSON exports.
* Remove an unsafe assertion from subject publish checks.
