### PR TITLE
(0.9.43) Hotfix: Voyager 0.65 Support and Metrics Update

### DIFF
--- a/client/src/pages/Admin/components/Metrics/AdminMetricsView.tsx
+++ b/client/src/pages/Admin/components/Metrics/AdminMetricsView.tsx
@@ -12,7 +12,7 @@ import GenericBreadcrumbsView from '../../../../components/shared/GenericBreadcr
 type Granularity = 'day' | 'week' | 'month' | 'year';
 
 type Totals = {
-    objectsPreserved: { assetVersions: number; repositoryObjects: number };
+    objectsPreserved: { assetVersions: number; repositoryObjects: number; created: number; updated: number };
     storage: { bytes: number; terabytes: number; bytesNonDPO: number; terabytesNonDPO: number };
     activeNonDPOUsers: number;
     scenes: { publishEvents: number; distinctScenes: number; currentlyPublished: number };
@@ -22,6 +22,8 @@ type SeriesPoint = {
     period: string;
     assetVersions: number;
     repositoryObjects: number;
+    objectsCreated: number;
+    objectsUpdated: number;
     storageBytes: number;
     storageTerabytes: number;
     storageBytesNonDPO: number;
@@ -125,6 +127,10 @@ const NUM = (n: number): string => n.toLocaleString();
 
 // Plain-English explanations shown on hover so the metric titles make sense to end users.
 const TT = {
+    objectsCreated: 'New repository objects whose first-ever ingested version falls in this range — a growth view of net-new entities entering the repository.',
+    objectsUpdated: 'Pre-existing repository objects (created before this range) that received a new ingested version in the range. Add to Objects Created for the total distinct objects touched.',
+    objectsTouched: 'Distinct repository objects (models, scenes, capture data, etc.) that received ingested content in the range, whether newly created or updated. Counts each object once.',
+    events: 'Preservation events: every ingested file version in the range, counting re-ingests and regenerated derivatives. A work-volume view — one object can contribute many events.',
     objects: 'Distinct repository objects (models, scenes, capture data, etc.) that received ingested content. Many file versions can roll up into one object.',
     assetVersions: 'Every preserved file version ingested. Each re-ingest of a file adds another version.',
     data: 'Total size of ingested file versions (full storage footprint across all versions).',
@@ -263,8 +269,8 @@ function AdminMetricsView(): React.ReactElement {
     };
     const downloadCSV = (): void => {
         if (!data?.series) return;
-        const header = ['period', 'assetVersions', 'repositoryObjects', 'storageBytes', 'storageBytesNonDPO', 'storageTerabytes', 'storageTerabytesNonDPO', 'activeNonDPOUsers', 'scenePublishEvents', 'scenesPublished', 'scenesPublishedCurrent'];
-        const lines = data.series.map(p => [p.period, p.assetVersions, p.repositoryObjects, p.storageBytes, p.storageBytesNonDPO, p.storageTerabytes, p.storageTerabytesNonDPO, p.activeNonDPOUsers, p.scenePublishEvents, p.scenesPublished, p.scenesPublishedCurrent].join(','));
+        const header = ['period', 'assetVersions', 'repositoryObjects', 'objectsCreated', 'objectsUpdated', 'storageBytes', 'storageBytesNonDPO', 'storageTerabytes', 'storageTerabytesNonDPO', 'activeNonDPOUsers', 'scenePublishEvents', 'scenesPublished', 'scenesPublishedCurrent'];
+        const lines = data.series.map(p => [p.period, p.assetVersions, p.repositoryObjects, p.objectsCreated, p.objectsUpdated, p.storageBytes, p.storageBytesNonDPO, p.storageTerabytes, p.storageTerabytesNonDPO, p.activeNonDPOUsers, p.scenePublishEvents, p.scenesPublished, p.scenesPublishedCurrent].join(','));
         triggerDownload([header.join(','), ...lines].join('\n'), `packrat-metrics_${start}_${end}.csv`, 'text/csv');
     };
 
@@ -324,7 +330,9 @@ function AdminMetricsView(): React.ReactElement {
 
                         <div className={classes.sectionTitle}>Selected Range</div>
                         <Box className={classes.tileRow}>
-                            <Tile label='Objects Preserved' value={NUM(data.summary.objectsPreserved.repositoryObjects)} sub={`${NUM(data.summary.objectsPreserved.assetVersions)} asset versions`} info={TT.objects} />
+                            <Tile label='Objects Created' value={NUM(data.summary.objectsPreserved.created)} sub='net-new entities' info={TT.objectsCreated} />
+                            <Tile label='Objects Updated' value={NUM(data.summary.objectsPreserved.updated)} sub='existing objects revised' info={TT.objectsUpdated} />
+                            <Tile label='Preservation Events' value={NUM(data.summary.objectsPreserved.assetVersions)} sub='file versions ingested' info={TT.events} />
                             <Tile label='Data Preserved' value={formatBytes(data.summary.storage.bytes)} info={TT.data} />
                             <Tile label='Data Preserved (non-DPO)' value={formatBytes(data.summary.storage.bytesNonDPO)} info={TT.dataNonDPO} />
                             <Tile label='Active non-DPO Users' value={NUM(data.summary.activeNonDPOUsers)} info={TT.activeUsers} />
@@ -333,7 +341,8 @@ function AdminMetricsView(): React.ReactElement {
 
                         <div className={classes.sectionTitle}>Cumulative (through end date)</div>
                         <Box className={classes.tileRow}>
-                            <Tile label='Objects Preserved' value={NUM(data.cumulative.objectsPreserved.repositoryObjects)} sub={`${NUM(data.cumulative.objectsPreserved.assetVersions)} asset versions`} info={TT.objects} />
+                            <Tile label='Objects (total)' value={NUM(data.cumulative.objectsPreserved.repositoryObjects)} info={TT.objectsTouched} />
+                            <Tile label='Preservation Events (total)' value={NUM(data.cumulative.objectsPreserved.assetVersions)} sub='file versions ingested' info={TT.events} />
                             <Tile label='Data Preserved' value={formatBytes(data.cumulative.storage.bytes)} info={TT.data} />
                             <Tile label='Data Preserved (non-DPO)' value={formatBytes(data.cumulative.storage.bytesNonDPO)} info={TT.dataNonDPO} />
                             <Tile label='Scenes Published (total)' value={NUM(data.cumulative.scenes.currentlyPublished)} info={TT.scenesCurrent} />
@@ -345,8 +354,16 @@ function AdminMetricsView(): React.ReactElement {
                             <BarChart points={series} getValue={p => p.storageBytes} color='#2B7DE9' format={formatBytes} />
                         </Box>
                         <Box className={classes.chartCard}>
-                            <ChartTitle title='Objects preserved per period' info={TT.objects} />
-                            <BarChart points={series} getValue={p => p.repositoryObjects} color='#37A66B' />
+                            <ChartTitle title='Objects created per period' info={TT.objectsCreated} />
+                            <BarChart points={series} getValue={p => p.objectsCreated} color='#37A66B' />
+                        </Box>
+                        <Box className={classes.chartCard}>
+                            <ChartTitle title='Objects updated per period' info={TT.objectsUpdated} />
+                            <BarChart points={series} getValue={p => p.objectsUpdated} color='#2FA0A0' />
+                        </Box>
+                        <Box className={classes.chartCard}>
+                            <ChartTitle title='Preservation events per period' info={TT.events} />
+                            <BarChart points={series} getValue={p => p.assetVersions} color='#C58A2E' />
                         </Box>
                         <Box className={classes.chartCard}>
                             <ChartTitle title='Scenes published/updated per period' info={TT.scenesRange} />

--- a/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
+++ b/client/src/pages/Repository/components/DetailsView/DetailsThumbnail.tsx
@@ -309,12 +309,21 @@ function DetailsThumbnail(props: DetailsThumbnailProps): React.ReactElement {
             {(objectType === eSystemObjectType.eScene || objectType === eSystemObjectType.eModel) && rootExplorerLink.length > 0 && documentLink.length > 0 && (
                 <React.Fragment>
                     { showVoyagerExplorer && (
-                        <voyager-explorer
-                            id='Voyager-Explorer'
-                            root={rootExplorerLink}
-                            document={encodeURIComponent(documentLink)}
-                            style={{ width: '100%', height: '500px', display: 'block', position: 'relative' }}
-                        />
+                        // Fixed-height, clipped wrapper: Voyager's globally-injected CSS inflates the
+                        // <voyager-explorer> host past its inline height, leaving an unrendered gap below
+                        // the canvas and trapping page scroll. The wrapper pins the layout height so the
+                        // page stays scrollable and no deadzone appears below the viewer.
+                        <Box
+                            id='Voyager-Explorer-Container'
+                            style={{ width: '100%', height: '500px', overflow: 'hidden', position: 'relative' }}
+                        >
+                            <voyager-explorer
+                                id='Voyager-Explorer'
+                                root={rootExplorerLink}
+                                document={encodeURIComponent(documentLink)}
+                                style={{ width: '100%', height: '100%', display: 'block', position: 'relative' }}
+                            />
+                        </Box>
                     )}
                     <Button
                         className={classes.editButton}

--- a/client/src/pages/Repository/components/DetailsView/index.tsx
+++ b/client/src/pages/Repository/components/DetailsView/index.tsx
@@ -1030,7 +1030,7 @@ function DetailsView(): React.ReactElement {
         || nameChanged || retiredChanged || licenseChanged || subtitleChanged;
 
     return (
-        <Box className={classes.container}>
+        <Box id='DetailsScrollContainer' className={classes.container}>
             <Box className={classes.content}>
                 {notice?.show && (
                     <NoticeBanner
@@ -1126,7 +1126,19 @@ function DetailsView(): React.ReactElement {
                     {(objectType === eSystemObjectType.eScene || objectType === eSystemObjectType.eModel) &&
                         <LoadingButton className={classes.updateButton}
                             loading={false}
-                            onClick={() => document.getElementById('Voyager-Explorer')?.scrollIntoView()}
+                            onClick={() => {
+                                // Scroll only the details container to the viewer. scrollIntoView() walks every
+                                // scrollable ancestor including the window/body, which normally doesn't scroll —
+                                // forcing it exposes an empty deadzone below the page. Scrolling the container
+                                // directly clamps to its own content, so no gap appears.
+                                const el = document.getElementById('Voyager-Explorer-Container') ?? document.getElementById('Voyager-Explorer');
+                                const scroller = document.getElementById('DetailsScrollContainer');
+                                if (el && scroller) {
+                                    const top = el.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop;
+                                    scroller.scrollTo({ top, behavior: 'smooth' });
+                                } else
+                                    el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                            }}
                             style={{ marginLeft: 5 }}
                         >View</LoadingButton>}
 

--- a/server/db/api/Metrics.ts
+++ b/server/db/api/Metrics.ts
@@ -62,10 +62,12 @@ function enumeratePeriodsWithEnds(lo: Date, hi: Date, granularity: MetricsGranul
 }
 
 export type MetricsTotals = {
-    /** Ingested asset-version rows (every preserved file/version) in the window. */
+    /** Ingested asset-version rows (every preserved file/version) in the window — preservation-event / work volume. */
     assetVersions: number;
-    /** Distinct repository objects (SystemObjects) that received an ingested asset version. */
+    /** Distinct repository objects (SystemObjects) that received an ingested asset version (created or updated). */
     repositoryObjects: number;
+    /** Distinct repository objects whose earliest ingested asset version falls in the window (newly created). */
+    objectsCreated: number;
     /** Total bytes of ingested asset versions (full OCFL footprint, all versions). */
     storageBytes: number;
     /** Subset of storageBytes contributed by non-DPO users. */
@@ -126,6 +128,30 @@ export class Metrics {
         } catch (error) /* istanbul ignore next */ {
             RK.logError(RK.LogSection.eDB, 'metrics storage totals failed', H.Helpers.getErrorString(error), { lo, hi }, 'DB.Metrics');
             return zero;
+        }
+    }
+
+    /**
+     * Distinct repository objects newly created in a window: those whose earliest ingested asset version
+     * (across all time) falls within [lo, hi]. Objects with any ingested version before `lo` are treated as
+     * pre-existing (an update, not a creation). objectsUpdated is derived by the caller as repositoryObjects - objectsCreated.
+     */
+    static async fetchObjectsCreated(lo: Date, hi: Date): Promise<number> {
+        try {
+            const rows: { objectsCreated: number | bigint }[] = await DBC.DBConnection.prisma.$queryRaw<{ objectsCreated: number | bigint }[]>(Prisma.sql`
+                SELECT COUNT(*) AS objectsCreated
+                FROM (
+                    SELECT A.idSystemObject
+                    FROM AssetVersion AS AV
+                    JOIN Asset AS A ON (AV.idAsset = A.idAsset)
+                    WHERE AV.Ingested = 1 AND A.idSystemObject IS NOT NULL
+                    GROUP BY A.idSystemObject
+                    HAVING MIN(AV.DateCreated) BETWEEN ${lo} AND ${hi}
+                ) AS t`);
+            return rows[0] ? Number(rows[0].objectsCreated) : 0;
+        } catch (error) /* istanbul ignore next */ {
+            RK.logError(RK.LogSection.eDB, 'metrics objects created failed', H.Helpers.getErrorString(error), { lo, hi }, 'DB.Metrics');
+            return 0;
         }
     }
 
@@ -202,14 +228,16 @@ export class Metrics {
 
     /** All summary totals for a window, assembled from the individual aggregate queries. */
     static async fetchTotals(lo: Date, hi: Date, dpoUserIDs: number[]): Promise<MetricsTotals> {
-        const [storage, activeNonDPOUsers, scenes, scenesPublishedCurrent] = await Promise.all([
+        const [storage, objectsCreated, activeNonDPOUsers, scenes, scenesPublishedCurrent] = await Promise.all([
             Metrics.fetchStorageTotals(lo, hi, dpoUserIDs),
+            Metrics.fetchObjectsCreated(lo, hi),
             Metrics.fetchActiveNonDPOUsers(lo, hi, dpoUserIDs),
             Metrics.fetchScenesPublished(lo, hi),
             Metrics.fetchScenesCurrentlyPublished(hi),
         ]);
         return {
             ...storage,
+            objectsCreated,
             activeNonDPOUsers,
             scenePublishEvents: scenes.events,
             scenesPublished: scenes.distinctScenes,
@@ -224,7 +252,7 @@ export class Metrics {
         const point = (period: string): MetricsSeriesPoint => {
             let p: MetricsSeriesPoint | undefined = points.get(period);
             if (!p) {
-                p = { period, assetVersions: 0, repositoryObjects: 0, storageBytes: 0, storageBytesNonDPO: 0, activeNonDPOUsers: 0, scenePublishEvents: 0, scenesPublished: 0, scenesPublishedCurrent: 0 };
+                p = { period, assetVersions: 0, repositoryObjects: 0, objectsCreated: 0, storageBytes: 0, storageBytesNonDPO: 0, activeNonDPOUsers: 0, scenePublishEvents: 0, scenesPublished: 0, scenesPublishedCurrent: 0 };
                 points.set(period, p);
             }
             return p;
@@ -252,6 +280,23 @@ export class Metrics {
                 p.storageBytes = Number(r.storageBytes);
                 p.storageBytesNonDPO = Number(r.storageBytesNonDPO);
             }
+
+            // Objects created per period: bucket each object by its earliest-ever ingested version, keeping only
+            // those whose first version lands in the window. Objects touched but created earlier fall out here
+            // (they remain in repositoryObjects), so repositoryObjects - objectsCreated is the per-period updated count.
+            const createdRows = await DBC.DBConnection.prisma.$queryRaw<{ period: string; objectsCreated: number | bigint }[]>(Prisma.sql`
+                SELECT DATE_FORMAT(t.firstDate, ${fmt}) AS period, COUNT(*) AS objectsCreated
+                FROM (
+                    SELECT A.idSystemObject AS idSystemObject, MIN(AV.DateCreated) AS firstDate
+                    FROM AssetVersion AS AV
+                    JOIN Asset AS A ON (AV.idAsset = A.idAsset)
+                    WHERE AV.Ingested = 1 AND A.idSystemObject IS NOT NULL
+                    GROUP BY A.idSystemObject
+                    HAVING MIN(AV.DateCreated) BETWEEN ${lo} AND ${hi}
+                ) AS t
+                GROUP BY period`);
+            for (const r of createdRows)
+                point(r.period).objectsCreated = Number(r.objectsCreated);
 
             const eventRows = await DBC.DBConnection.prisma.$queryRaw<{ period: string; events: number | bigint }[]>(Prisma.sql`
                 SELECT DATE_FORMAT(SOV.DateCreated, ${fmt}) AS period, COUNT(*) AS events

--- a/server/http/routes/api/metrics.ts
+++ b/server/http/routes/api/metrics.ts
@@ -32,7 +32,12 @@ function toTB(bytes: number): number {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function shapeTotals(t: MetricsTotals): any {
     return {
-        objectsPreserved: { assetVersions: t.assetVersions, repositoryObjects: t.repositoryObjects },
+        objectsPreserved: {
+            assetVersions: t.assetVersions,                                         // preservation events (work volume, counts re-ingests)
+            repositoryObjects: t.repositoryObjects,                                 // distinct objects touched (created or updated)
+            created: t.objectsCreated,                                              // newly created objects (first version in window)
+            updated: Math.max(0, t.repositoryObjects - t.objectsCreated),           // pre-existing objects revised in window
+        },
         storage: {
             bytes: t.storageBytes,
             terabytes: toTB(t.storageBytes),
@@ -50,6 +55,8 @@ function shapeSeriesPoint(p: MetricsSeriesPoint): any {
         period: p.period,
         assetVersions: p.assetVersions,
         repositoryObjects: p.repositoryObjects,
+        objectsCreated: p.objectsCreated,
+        objectsUpdated: Math.max(0, p.repositoryObjects - p.objectsCreated),
         storageBytes: p.storageBytes,
         storageTerabytes: toTB(p.storageBytes),
         storageBytesNonDPO: p.storageBytesNonDPO,

--- a/server/types/voyager/common.ts
+++ b/server/types/voyager/common.ts
@@ -29,12 +29,15 @@ export type Vector3 = number[];
 export type Vector4 = number[];
 export type Matrix4 = number[];
 export type Quaternion = Vector4;
+// Packrat-local: upstream document.ts/model.ts import QuaternionTuple from "three", which is not
+// available server-side, so it is defined here and imported from "./common". Preserve this line when
+// replacing common.ts with a newer upstream copy.
 export type QuaternionTuple = [ x: number, y: number, z: number, w: number ];
 export type ColorRGB = Vector3;
 export type ColorRGBA = Vector4;
 
-export type TLanguageType = "EN" | "ES" | "DE" | "NL" | "JA" | "FR" | "IT" | "HAW";
-export enum ELanguageType { EN, ES, DE, NL, JA, FR, IT, HAW }
+export type TLanguageType = "EN" | "ES" | "DE" | "NL" | "JA" | "FR" | "IT" | "HAW" | "AR" | "TA";
+export enum ELanguageType { EN, ES, DE, NL, JA, FR, IT, HAW, AR, TA }
 export enum ELanguageStringType {
     EN = 'English',
     ES = 'Spanish (Español)',
@@ -45,5 +48,6 @@ export enum ELanguageStringType {
     IT = 'Italian (Italiano)',
     HAW = 'Hawaiian (ʻŌlelo Hawaiʻi)',
     AR = 'Arabic (العربية)',
+    TA = 'Tamil (தமிழ்)'
 }
 export const DEFAULT_LANGUAGE = "EN";

--- a/server/types/voyager/json/meta.schema.json
+++ b/server/types/voyager/json/meta.schema.json
@@ -154,7 +154,7 @@
                 "type": {
                     "description": "Type of action.",
                     "type": "string",
-                    "enum": [ "PlayAnimation", "PlayAudio", "ShowAnnotation", "HideAnnotation", "ToggleAnnotation" ]
+                    "enum": [ "PlayAnimation", "PlayAudio", "ShowAnnotation", "HideAnnotation", "ToggleAnnotation", "EnableAction", "DisableAction" ]
                 },
                 "trigger": {
                     "description": "Method by which this action is triggered.",
@@ -199,7 +199,7 @@
                 "clamp": {
                     "description": "Flag to clamp an animation on the last frame",
                     "type": "boolean",
-                    "default": 1
+                    "default": false
                 },
                 "syncWith": {
                     "description": "Name of an animation to sync audio with",

--- a/server/types/voyager/json/setup.schema.json
+++ b/server/types/voyager/json/setup.schema.json
@@ -177,6 +177,12 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "markerStyle": {
+                    "type": "string",
+                    "enum": [
+                        "Pin", "Ring"
+                    ]
+                },
                 "startPosition": {
                     "$ref": "./common.schema.json#/definitions/vector3"
                 },

--- a/server/types/voyager/meta.ts
+++ b/server/types/voyager/meta.ts
@@ -112,15 +112,17 @@ export interface IAction
     audioId?: string;
     annotationId?: string;
     actionAnnoId?: string;
+    actionTargetId?: string;
     animation?: string;
     style?: TActionPlayStyle;
     speed?: number;
     clamp?: boolean;
     syncWith?: string;
+    enabled?: boolean;
 }
 
-export type TActionType = "PlayAnimation" | "PlayAudio" | "ShowAnnotation" | "HideAnnotation" | "ToggleAnnotation";
-export enum EActionType { PlayAnimation, PlayAudio, ShowAnnotation, HideAnnotation, ToggleAnnotation }
+export type TActionType = "PlayAnimation" | "PlayAudio" | "ShowAnnotation" | "HideAnnotation" | "ToggleAnnotation" | "EnableAction" | "DisableAction";
+export enum EActionType { PlayAnimation, PlayAudio, ShowAnnotation, HideAnnotation, ToggleAnnotation, EnableAction, DisableAction }
 
 export type TActionTrigger = "OnClick" | "OnLoad" | "OnAnnotation" | "OnTourStep" | "OnActionEnd" | "OnActionBegin";
 export enum EActionTrigger { OnClick, OnLoad, OnAnnotation, OnTourStep, OnActionEnd, OnActionBegin }

--- a/server/types/voyager/setup.ts
+++ b/server/types/voyager/setup.ts
@@ -25,7 +25,6 @@ import { ELanguageType, TLanguageType } from "./common";
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 export type TShaderMode = "Default" | "Clay" | "XRay" | "Normals" | "Wireframe";
 export enum EShaderMode { Default, Clay, XRay, Normals, Wireframe }
 
@@ -40,6 +39,9 @@ export enum EReaderPosition { Overlay, Left, Right }
 
 export type TSliceAxis = "X" | "Y" | "Z";
 export enum ESliceAxis { X, Y, Z }
+
+export type TMarkerStyle = "Pin" | "Ring";
+export enum EMarkerStyle { Pin, Ring }
 
 export interface ISetup
 {
@@ -161,6 +163,7 @@ export interface IAudio
 export interface ITape
 {
     enabled: boolean;
+    markerStyle?: TMarkerStyle;
     startPosition?: number[];
     startDirection?: number[];
     endPosition?: number[];


### PR DESCRIPTION
- Split preservation metrics into Created and Updated.
- Add Created and Updated charts by reporting period.
- Add SQL query for objects by earliest version.
- Add Created and Updated columns to CSV exports.
- Support Voyager 0.65
- Fix the Voyager viewer scroll deadzone.
- Keep View-button scrolling inside the details panel.